### PR TITLE
Add a root route to PFE

### DIFF
--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -177,6 +177,7 @@ async function main() {
 
   let userList = new UserList();
 
+  app.get('/', (req, res) => { res.sendStatus(200); });
   app.get('/health', (req, res) => { res.sendStatus(200); });
   app.use(securityMiddleware);
 

--- a/test/src/root.test.js
+++ b/test/src/root.test.js
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const chai = require('chai');
+const reqService = require('../modules/request.service');
+
+chai.should();
+
+describe('Root endpoint test', function() {
+
+    it('should return status 200', async function() {
+        const res = await reqService.chai
+            .get('/');
+        res.should.have.status(200);
+    });
+});


### PR DESCRIPTION
Adds a / route to PFE and return HTTP code 200. Required so ensure that when K8s ingress is created it can bind to the live PFE service. 

Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>