### PR TITLE
Enable 'container' type log streams.

### DIFF
--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -13,6 +13,8 @@ const docker = new dockerApi();
 const Logger = require('../utils/Logger');
 const log = new Logger('dockerFunctions.js');
 
+const { spawn } = require('child_process');
+
 /**
  * Exported function to stream the Docker container log for a given project
  * @param project, the project to get the container log for
@@ -69,6 +71,13 @@ module.exports.exec = async function exec(project, command) {
   // .then(stream => {
   //   container.modem.demuxStream(stream.output, process.stdout, process.stderr);
   // });
+}
+
+// Use spawn to run a given command inside the container and return the resulting
+// child process.
+module.exports.spawnContainerProcess = function spawnContainerProcess(project, commandArray) {
+  const cmdArray = ['exec', '-i', project.containerId].concat(commandArray);
+  return spawn('/usr/bin/docker', cmdArray);
 }
 
 module.exports.run = async function(containerName, command, volumes) {

--- a/src/pfe/portal/routes/projects/logStream.route.js
+++ b/src/pfe/portal/routes/projects/logStream.route.js
@@ -49,6 +49,8 @@ async function startStreamingAll(req, res, startStreams) {
           let logObject = {logName: logName}
           if (logs[logType].origin == 'workspace') {
             logObject.workspaceLogPath = path.dirname(file);
+          } else if (logs[logType].origin == 'container') {
+            logObject.containerLogPath = path.dirname(file);
           }
           logTypes[logType].push(logObject);
           let logFile = file;
@@ -64,7 +66,7 @@ async function startStreamingAll(req, res, startStreams) {
           logTypes[CONTAINER_LOG_TYPE] = [];
         }
         // Use '-' for stdout (ie the container log).
-        logTypes[CONTAINER_LOG_TYPE].push({logName: '-'});
+        logTypes[CONTAINER_LOG_TYPE].push({origin: 'container', logName: '-'});
         if (startStreams) {
           project.startStreamingLog(user.uiSocket, CONTAINER_LOG_TYPE, 'container', CONTAINER_LOG_NAME, CONTAINER_LOG_NAME);
         }


### PR DESCRIPTION
This PR enables container log streams for issue #7 
Container log streams are followed by logging into the container and running tail. Docker exec doesn't kill processes it started in the container when it is terminated so when streams are stopped and restarted we exec in again and kill the last tail process for that log.
(Our tail command is quite specific so there isn't much risk of killing the wrong command.)