### PR TITLE
add unittest for projectStatusController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ codewind-workspace/
 .DS_Store
 .vscode/tasks.json
 .project
+.logs
 node_modules/
 package-lock.json
 src/performance/webclient/build/

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -112,56 +112,6 @@ setInterval(pingApplications, pingInterval);
 setInterval(pingInTransitApplications, inTransitPingInterval);
 
 /**
- * @function
- * @description Provide the latest status for a project and status type.
- *
- * @param type <Required | String> - The status type. Supported types include: 'appState' and 'buildState'.
- * @param projectID <Required | String> - An alphanumeric identifier for a project.
- *
- * @returns Promise<{data: {}}>
- */
-export async function getProjectStatus(type: string, projectID: string): Promise<{data: {}}> {
-
-    const response: any = {};
-
-    if (type == STATE_TYPES.appState) {
-        const appState: ProjectState = appStateMap.get(projectID);
-        const data: any = {
-            appStatus: appState.state
-        };
-        if (appState.hasMsg()) {
-           data.appErrorStatus = await locale.getTranslation(appState.msg);
-        }
-        if (appState.detailedAppStatus) {
-           data.detailedAppStatus = appState.detailedAppStatus;
-        }
-        response.data = data;
-        return response;
-    } else if (type == STATE_TYPES.buildState) {
-        const buildState: ProjectState = buildStateMap.get(projectID);
-        let buildRequired = false;
-        if (buildRequiredMap.get(projectID)) {
-            buildRequired = buildRequiredMap.get(projectID);
-        }
-        const data: any = {
-            buildStatus: buildState.state,
-            buildRequired: buildRequired
-        };
-        if (buildState.hasMsg()) {
-            data.detailedBuildStatus = await locale.getTranslation(buildState.msg);
-        }
-        if (buildState.lastbuild) {
-            data.lastbuild = buildState.lastbuild;
-        }
-        response.data = data;
-        return response;
-    } else {
-        logger.logProjectError("Unrecognized status type: " + type, projectID);
-        throw new Error("Unrecognized type: " + type);
-    }
-}
-
-/**
  * @see [[Filewatcher.updateStatus]]
  */
 export async function updateStatus(req: IUpdateStatusParams): Promise<IUpdateStatusSuccess | IUpdateStatusFailure> {

--- a/src/pfe/file-watcher/server/test/unit-test/configs/module.configs.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/configs/module.configs.ts
@@ -14,6 +14,7 @@ import { utilsTestModule } from "../tests/utils.module.test";
 import { localeTestModule } from "../tests/locale.module.test";
 import { workspaceSettingsTestModule } from "../tests/workspaceSettings.module.test";
 import { projectSettingsTestModule } from "../tests/projectSettings.module.test";
+import { projectStatusControllerTestModule } from "../tests/projectStatusController.test";
 import * as mocha from "mocha";
 
 interface ModuleExtension {
@@ -46,8 +47,14 @@ const projectSettingsModule: ModuleExtension = {
     moduleFunc: projectSettingsTestModule
 };
 
-export const moduleLists: Array<ModuleExtension> = [logHelperModule, 
-                                                    utilsModule, 
+const projectStatusControllerModule: ModuleExtension = {
+    moduleName: "projectStatusController",
+    moduleFunc: projectStatusControllerTestModule
+};
+
+export const moduleLists: Array<ModuleExtension> = [logHelperModule,
+                                                    utilsModule,
                                                     localeModule,
                                                     workspaceSettingsModule,
-                                                    projectSettingsModule];
+                                                    projectSettingsModule,
+                                                    projectStatusControllerModule];

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectStatusController.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectStatusController.test.ts
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+import { expect } from "chai";
+
+import * as projectStatusController from "../../../../server/src/controllers/projectStatusController";
+import * as socket from "../../../src/utils/socket";
+
+
+export function projectStatusControllerTestModule(): void {
+    const projectID = "testProject";
+    it("getAppState of a non-exist project", async() => {
+        const actualResult = await projectStatusController.getAppState(projectID);
+        expect(actualResult).to.equal(projectStatusController.AppState.unknown);
+    });
+
+    it("getBuildState of a non-exist project", async() => {
+        const actualResult = await projectStatusController.getBuildState(projectID);
+        expect(actualResult).to.equal(projectStatusController.BuildState.unknown);
+    });
+
+    it("isBuildRequired of a non-exist project", async() => {
+        const actualResult = await projectStatusController.isBuildRequired(projectID);
+        expect(actualResult).to.equal(false);
+    });
+
+
+
+    it("getAppState of a non-exist project", async() => {
+        const actualResult = await projectStatusController.getAppState(projectID);
+        expect(actualResult).to.equal(projectStatusController.AppState.unknown);
+    });
+
+    it("getBuildState of a non-exist project", async() => {
+        const actualResult = await projectStatusController.getBuildState(projectID);
+        expect(actualResult).to.equal(projectStatusController.BuildState.unknown);
+    });
+
+    it("isBuildRequired of a non-exist project", async() => {
+        const actualResult = await projectStatusController.isBuildRequired(projectID);
+        expect(actualResult).to.equal(false);
+    });
+
+    describe("combinational testing of updateProjectStatus function", () => {
+        before("create workspace settings directory with config file", async () => {
+            await projectStatusController.addProject(projectID);
+        });
+
+        after("remove the test directory", async () => {
+            projectStatusController.deleteProject(projectID);
+            const appStateResult = await projectStatusController.getAppState(projectID);
+            expect(appStateResult).to.equal(projectStatusController.AppState.unknown);
+            const buildStateResult = await projectStatusController.getBuildState(projectID);
+            expect(buildStateResult).to.equal(projectStatusController.BuildState.unknown);
+            const actualResult = await projectStatusController.isBuildRequired(projectID);
+            expect(actualResult).to.equal(false);
+        });
+
+        const combinations: any = {
+            "combo1": {
+                data: {
+                    projectID: projectID,
+                    type: undefined
+                },
+                "result": { "statusCode": 400, "error": { "msg": "Missing required status type parameter"}}
+            },
+            "combo2": {
+                data: {
+                    projectID: projectID,
+                    type: "invalidType"
+                },
+                "result": { "statusCode": 400, "error": { "msg": "Unrecognized status type: invalidType"}}
+            },
+            "combo3": {
+                data: {
+                    projectID: undefined,
+                    type: projectStatusController.STATE_TYPES.buildState
+                },
+                "result": { "statusCode": 400, "error": { "msg": "Missing request parameters projectID or status for build state update"}}
+            },
+            "combo4": {
+                data: {
+                    projectID: projectID,
+                    type: projectStatusController.STATE_TYPES.appState
+                },
+                "result": { "statusCode": 400, "error": { "msg": "Missing request parameters projectID or status for application state update"}}
+            },
+            "combo5": {
+                data: {
+                    projectID: projectID,
+                    type: projectStatusController.STATE_TYPES.buildState,
+                    buildStatus: "invalidState"
+                },
+                "result": { "statusCode": 400, "error": { "msg": "Invalid build state: invalidState"}}
+            },
+            "combo6": {
+                data: {
+                    projectID: projectID,
+                    type: projectStatusController.STATE_TYPES.appState,
+                    status: "invalidState"
+                },
+                "result": { "statusCode": 400, "error": { "msg": "Invalid application state: invalidState"}}
+            },
+            "combo7": {
+                data: {
+                    projectID: projectID,
+                    type: projectStatusController.STATE_TYPES.appState,
+                    status: projectStatusController.AppState.started,
+                    error: "testMessage"
+                },
+                "result": { "statusCode": 200}
+            },
+            "combo8": {
+                data: {
+                    projectID: projectID,
+                    type: projectStatusController.STATE_TYPES.buildState,
+                    buildStatus: projectStatusController.BuildState.inProgress,
+                    detailedBuildStatus: "testDetailedStatus",
+                    appImageLastBuild: "123456789",
+                    buildImageLastBuild: "123456789"
+                },
+                "result": { "statusCode": 200}
+            },
+
+        };
+        for (const combo of Object.keys(combinations)) {
+
+            const data = combinations[combo]["data"];
+            const expectedResult = combinations[combo]["result"];
+
+            it(combo + " => data: " + JSON.stringify(data), async() => {
+                const actualResult = await projectStatusController.updateStatus(data);
+                expect(actualResult).to.deep.equal(expectedResult);
+                if (actualResult.statusCode === 200) {
+                    if (data.type === projectStatusController.STATE_TYPES.appState) {
+                        const appStateResult = await projectStatusController.getAppState(projectID);
+                        expect(appStateResult).to.equal(data.status);
+                    } else if (data.type === projectStatusController.STATE_TYPES.buildState) {
+                        const buildStateResult = await projectStatusController.getBuildState(projectID);
+                        expect(buildStateResult).to.equal(data.buildStatus);
+                        const isBuildInProgress = await projectStatusController.isBuildInProgress(projectID);
+                        expect(isBuildInProgress).to.equal(true);
+                    }
+                }
+            });
+        }
+    });
+
+
+    describe("combinational testing of buildRequired function", () => {
+        before("create workspace settings directory with config file", async () => {
+            await projectStatusController.addProject(projectID);
+        });
+
+        after("remove the test directory", async () => {
+            projectStatusController.deleteProject(projectID);
+            const appStateResult = await projectStatusController.getAppState(projectID);
+            expect(appStateResult).to.equal(projectStatusController.AppState.unknown);
+            const buildStateResult = await projectStatusController.getBuildState(projectID);
+            expect(buildStateResult).to.equal(projectStatusController.BuildState.unknown);
+            const actualResult = await projectStatusController.isBuildRequired(projectID);
+            expect(actualResult).to.equal(false);
+        });
+
+        let buildRequired = "";
+
+        socket.registerListener({
+            name: "codewindunittest",
+            handleEvent: (event, data) => {
+                if (event === "projectStatusChanged") {
+                    if (data.buildRequired) {
+                        buildRequired = data.buildRequired;
+                    }
+                }
+            }
+        });
+
+        it("set buildRequired to true ", async() => {
+                await projectStatusController.buildRequired(projectID, true);
+                expect(buildRequired).to.equal(true);
+                const getBuildRequired = await projectStatusController.isBuildRequired(projectID);
+                expect(getBuildRequired).to.equal(true);
+                const getIsBuildInProgress = await projectStatusController.isBuildInProgress(projectID);
+                expect(getIsBuildInProgress).to.equal(false);
+            });
+    });
+}

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectStatusController.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectStatusController.test.ts
@@ -31,29 +31,12 @@ export function projectStatusControllerTestModule(): void {
         expect(actualResult).to.equal(false);
     });
 
-
-
-    it("getAppState of a non-exist project", async() => {
-        const actualResult = await projectStatusController.getAppState(projectID);
-        expect(actualResult).to.equal(projectStatusController.AppState.unknown);
-    });
-
-    it("getBuildState of a non-exist project", async() => {
-        const actualResult = await projectStatusController.getBuildState(projectID);
-        expect(actualResult).to.equal(projectStatusController.BuildState.unknown);
-    });
-
-    it("isBuildRequired of a non-exist project", async() => {
-        const actualResult = await projectStatusController.isBuildRequired(projectID);
-        expect(actualResult).to.equal(false);
-    });
-
     describe("combinational testing of updateProjectStatus function", () => {
-        before("create workspace settings directory with config file", async () => {
+        before("add project to buildStateMap and appStateMap", async () => {
             await projectStatusController.addProject(projectID);
         });
 
-        after("remove the test directory", async () => {
+        after("remove the test project", async () => {
             projectStatusController.deleteProject(projectID);
             const appStateResult = await projectStatusController.getAppState(projectID);
             expect(appStateResult).to.equal(projectStatusController.AppState.unknown);
@@ -155,11 +138,11 @@ export function projectStatusControllerTestModule(): void {
 
 
     describe("combinational testing of buildRequired function", () => {
-        before("create workspace settings directory with config file", async () => {
+        before("add project to buildStateMap and appStateMap", async () => {
             await projectStatusController.addProject(projectID);
         });
 
-        after("remove the test directory", async () => {
+        after("remove the test project", async () => {
             projectStatusController.deleteProject(projectID);
             const appStateResult = await projectStatusController.getAppState(projectID);
             expect(appStateResult).to.equal(projectStatusController.AppState.unknown);


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for #47 
This PR added unit tests for projectStatusController.ts. 
The code coverage has increased from 15.36 to 55.16.
Could not test all functions, since some of them require an app container up and running, such as `pingApplication`, and `pingInTransiteApplication`

In addition, function `getProjectStatus` is removed in this PR, since that function is never called/used by any other modules. 