### PR TITLE
Fix dead buildah link and error if curl 404s

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -15,10 +15,10 @@ LABEL org.label-schema.name="Codewind PFE" org.label-schema.description="Codewin
       org.label-schema.url="https://codewind.dev/" \
       org.label-schema.vcs-url="https://github.com/eclipse/codewind" org.label-schema.vendor="IBM"
 
-ARG BUILDAH_RPM=http://download-ib01.fedoraproject.org/pub/fedora/linux/updates/30/Everything/x86_64/Packages/b/buildah-1.9.0-1.git00eb895.fc30.x86_64.rpm
+ARG BUILDAH_RPM=https://download-ib01.fedoraproject.org/pub/fedora/linux/updates/30/Everything/x86_64/Packages/b/buildah-1.9.2-2.fc30.x86_64.rpm
 
 # Download the buildah RPM
-RUN curl -o buildah.rpm $BUILDAH_RPM
+RUN curl -f -o buildah.rpm $BUILDAH_RPM
 
 # Download and set up Node 10.x RPM
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

Fixes a dead link in the Dockerfile that was used to retrieve the buildah RPM. Also updates the curl command so that it fails if the link 404s, since it appears it doesn't do that automatically

Also opened https://github.com/eclipse/codewind/issues/92 to look at using dnf in PFE for the future