### PR TITLE
Fix Environment API when Tekton is not installed

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -51,9 +51,7 @@ paths:
                   tekton_dashboard_url:
                     type: string
                     example: '9.20.195.90.nip.io'
-                    description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string.\
-                      If there is an error determining the URL, it is 'error'.\
-                      This is usually caused by Tekton not being set up, eg the Tekton namespace is missing or RBAC has not been set up."
+                    description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string. May also be 'error' or 'not-installed'."
         500:
           description: Internal error occurred
   /api/v1/projects:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -30,7 +30,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  running_on_icp:
+                  running_on_k8s:
                     type: boolean
                     example: false
                   user_string:
@@ -48,6 +48,12 @@ paths:
                   os_platform:
                     type: string
                     example: 'Linux'
+                  tekton_dashboard_url:
+                    type: string
+                    example: '9.20.195.90.nip.io'
+                    description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string.\
+                      If there is an error determining the URL, it is 'error'.\
+                      This is usually caused by Tekton not being set up, eg the Tekton namespace is missing or RBAC has not been set up."
         500:
           description: Internal error occurred
   /api/v1/projects:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -30,7 +30,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  running_on_k8s:
+                  running_in_k8s:
                     type: boolean
                     example: false
                   user_string:

--- a/src/pfe/portal/routes/environment.route.js
+++ b/src/pfe/portal/routes/environment.route.js
@@ -60,14 +60,16 @@ router.get('/api/v1/environment', async (req, res) => {
     // just await on this promise if it exists so we only call getTektonDashboardUrl once
     if (!tektonDashboardUrlPromise) {
       tektonDashboardUrlPromise = getTektonDashboardUrl()
-        .then((tektonUrl) => log.info(`Initialized Tekton dashboard url as "${tektonUrl}"`));
+        .then((tektonUrl) => {
+          log.info(`Initialized Tekton dashboard url as "${tektonUrl}"`)
+          return tektonUrl;
+        });
     }
     tektonDashboardUrl = await tektonDashboardUrlPromise;
   }
 
   try {
-    let body = {};
-    body = {
+    const envData = {
       running_on_k8s: global.codewind.RUNNING_IN_K8S,
       user_string: req.cw_user.userString,
       socket_namespace: req.cw_user.uiSocketNamespace,
@@ -76,7 +78,7 @@ router.get('/api/v1/environment', async (req, res) => {
       os_platform: process.env.HOST_OS || 'Linux',
       tekton_dashboard_url: tektonDashboardUrl,
     }
-    res.status(200).send(body);
+    res.status(200).send(envData);
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/src/pfe/portal/routes/environment.route.js
+++ b/src/pfe/portal/routes/environment.route.js
@@ -70,7 +70,7 @@ router.get('/api/v1/environment', async (req, res) => {
 
   try {
     const envData = {
-      running_on_k8s: global.codewind.RUNNING_IN_K8S,
+      running_in_k8s: global.codewind.RUNNING_IN_K8S,
       user_string: req.cw_user.userString,
       socket_namespace: req.cw_user.uiSocketNamespace,
       codewind_version: process.env.CODEWIND_VERSION,

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -141,11 +141,13 @@ async function main() {
       log.info('starting codewind on Kubernetes');
       global.codewind.RUNNING_IN_K8S = true;
 
-      // get current ingress path running on
-      const k8sIngressPath = process.env.CHE_INGRESS_HOST;
-      log.info("Ingress path is " + k8sIngressPath);
+      // get current ingress path - it is passed in an env var
+      // https://github.com/eclipse/codewind-che-plugin/blob/master/codewind-che-sidecar/scripts/kube/codewind_template.yaml#L135
+      const INGRESS_HOST_ENVVAR = 'CHE_INGRESS_HOST';
+      const k8sIngressPath = process.env[INGRESS_HOST_ENVVAR];
+      log.info(`Ingress path is "${k8sIngressPath}"`);
       if (!k8sIngressPath) {
-        throw new Error("Ingress host env var was not set");
+        throw new Error(`${INGRESS_HOST_ENVVAR} was not set in the environment`);
       }
       const protocol = process.env.PORTAL_HTTPS == 'true' ? 'https://' : 'http://'
       originsWhitelist.push(protocol + k8sIngressPath);

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -134,11 +134,19 @@ async function main() {
   };
 
   // find if running in kubernetes and build up a whitelist of allowed origins
-  const originsWhitelist = []
+
   try {
     k8Client = new K8Client({ config: k8config.getInCluster(), version: '1.9' });
+  }
+  catch (err) {
+    log.info('Codewind does not appear to be running in k8s')
+    global.codewind.RUNNING_IN_K8S = false;
+  }
+
+  const originsWhitelist = []
+  try {
     if (k8Client) {
-      log.info('starting codewind on Kubernetes');
+      log.info('Codewind is running in k8s');
       global.codewind.RUNNING_IN_K8S = true;
 
       // get current ingress path - it is passed in an env var
@@ -157,6 +165,7 @@ async function main() {
   }
 
   if (!global.codewind.RUNNING_IN_K8S) {
+    log.info('Codewind is running locally');
     originsWhitelist.push('http://localhost:*');
   }
 

--- a/test/src/environment.test.js
+++ b/test/src/environment.test.js
@@ -26,7 +26,7 @@ describe('Environment API tests', function() {
 
         res.should.have.status(200);
         res.should.have.ownProperty('body');
-        res.body.should.have.ownProperty('running_on_k8s', USING_K8S);
+        res.body.should.have.ownProperty('running_in_k8s', USING_K8S);
         res.body.should.have.ownProperty('user_string');
         res.body.should.have.ownProperty('socket_namespace', SOCKET_NAMESPACE);
         res.body.should.have.ownProperty('codewind_version');

--- a/test/src/environment.test.js
+++ b/test/src/environment.test.js
@@ -26,10 +26,11 @@ describe('Environment API tests', function() {
 
         res.should.have.status(200);
         res.should.have.ownProperty('body');
-        res.body.should.have.ownProperty('running_on_icp', USING_K8S);
+        res.body.should.have.ownProperty('running_on_k8s', USING_K8S);
         res.body.should.have.ownProperty('user_string');
         res.body.should.have.ownProperty('socket_namespace', SOCKET_NAMESPACE);
         res.body.should.have.ownProperty('codewind_version');
+        res.body.should.have.ownProperty('tekton_dashboard_url');
         res.body.should.have.ownProperty('os_platform');
         if (!USING_K8S) res.body.should.have.ownProperty('workspace_location');
     });


### PR DESCRIPTION
- Fix TypeError if tekton is not installed
- Have different statuses for success (url) vs not installed vs local (ie, n/a) vs error, so client can display better feedback
- Only look up dashboard url once instead of on every api call
- Update tests and API doc
- Rename running_on_icp field to running_on_k8s

- Fix ingress logic which errored on Openshift

Underlying tekton-getting logic is not changed. I still can't get the success case working; likely because I am not installing tekton as expected (#106 ? I did run those steps but this code still cannot find the tekton ingress).