### PR TITLE
Change template descriptions to html comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issues.md
+++ b/.github/ISSUE_TEMPLATE/bug-issues.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please fill out the following form to report a bug. If some fields do not apply to your situation, feel free to skip them.
+<!-- Please fill out the following form to report a bug. If some fields do not apply to your situation, feel free to skip them.-->
 
 **Codewind version:**
 **OS:**
@@ -17,5 +17,9 @@ Please fill out the following form to report a bug. If some fields do not apply 
 **IDE version:**
 **Kubernetes cluster:**
 
-**Description of the bug:** Please describe the bug with enough detail so that it can be reproduced by others.
-**Workaround:** Did you find a way to work around the bug? If so, please describe how you worked around it.
+**Description of the bug:**
+<!-- Please describe the bug with enough detail so that it can be reproduced by others.-->
+
+**Workaround:** 
+<!-- Did you find a way to work around the bug? If so, please describe how you worked around it.-->
+

--- a/.github/ISSUE_TEMPLATE/enhancement-issues.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-issues.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please fill out the following form to suggest an enhancement. If some fields do not apply to your situation, feel free to skip them.
+<!-- Please fill out the following form to suggest an enhancement. If some fields do not apply to your situation, feel free to skip them.-->
 
 **Codewind version:**
 **OS:**
@@ -17,5 +17,7 @@ Please fill out the following form to suggest an enhancement. If some fields do 
 **IDE version:**
 **Kubernetes cluster:**
 
-**Description of the enhancement:** How would you like to see Codewind improved?
-**Proposed solution:** Do you have ideas about how your idea could be implemented?
+**Description of the enhancement:**
+<!-- How would you like to see Codewind improved?-->
+**Proposed solution:** 
+<!-- Do you have ideas about how your idea could be implemented?-->

--- a/.github/ISSUE_TEMPLATE/question-issues.md
+++ b/.github/ISSUE_TEMPLATE/question-issues.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Please fill out the following form to ask a quesstion. If some fields do not apply to your situation, feel free to skip them.
+<!-- Please fill out the following form to ask a quesstion. If some fields do not apply to your situation, feel free to skip them.-->
 
 **Codewind version:**
 **OS:**
@@ -17,4 +17,5 @@ Please fill out the following form to ask a quesstion. If some fields do not app
 **IDE version:**
 **Kubernetes cluster:**
 
-**Question synopsis:** What question can we help you with?
+**Question synopsis:**
+<!-- What question can we help you with?-->


### PR DESCRIPTION
Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>

Related to issue #83 

Change template descriptions to html comments so that the issue is less cluttered once it's created.