### PR TITLE
Get repositories instead of templates from extensions

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -55,14 +55,6 @@ module.exports = class Templates {
 
     let newProjectTemplates = [];
 
-    // reduce function, want to take repository list and index
-    // them by url, and use that to avoid processing duplicate entries
-    const reducer = (repos, repo) => {
-      if (repo.url && !repos[repo.url])
-        repos[repo.url] = repo;
-      return repos;
-    };
-
     // apply reduce function to create a copy of the repository list index by url
     const repos = this.repositoryList.reduce(reducer, {});
 
@@ -187,4 +179,12 @@ module.exports = class Templates {
 function getTemplateStyle(template) {
   // if a project's style isn't specified, it defaults to 'Codewind'
   return template.projectStyle || 'Codewind';
+}
+
+// reduce function, want to take repository list and index
+// them by url, and use that to avoid processing duplicate entries
+function reducer(repos, repo) {
+  if (repo.url && !repos[repo.url])
+    repos[repo.url] = repo;
+  return repos;
 }

--- a/src/pfe/portal/modules/utils/acclimatise.js
+++ b/src/pfe/portal/modules/utils/acclimatise.js
@@ -11,8 +11,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 const NODEMON_JSON_LOCATION = './scripts/nodemon.json';
-const Logger = require('../utils/Logger');
-const log = new Logger('acclimatise.js');
 
 /**
  * Function to add "acclimatise" a project by:

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -147,14 +147,14 @@ describe('Templates.js', function() {
         it('getTemplateList should ignore invalid or duplicate repository entries from template provider', async function() {
 
             // add a template provider that returns the wrong type
-            templates.addProvider('invalid_provider', {
+            templates.addProvider('invalid_provider1', {
                 getRepositories: async function() {
                     return 'wrong type';
                 }
             });
 
             // add a template provider that contains invalid or duplicate entries
-            templates.addProvider('invalid_provider', {
+            templates.addProvider('invalid_provider2', {
                 getRepositories: async function() {
                     return [
                         'wrong type',

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -10,7 +10,7 @@
 *******************************************************************************/
 const chai = require('chai');
 
-global.codewind = { RUNNING_IN_K8S: false };
+global.codewind = {};
 const Templates = require('../../../src/pfe/portal/modules/Templates');
 
 chai.should();

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -10,7 +10,6 @@
 *******************************************************************************/
 const chai = require('chai');
 
-global.codewind = {};
 const Templates = require('../../../src/pfe/portal/modules/Templates');
 
 chai.should();


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Based on recent discussion with @tobespc, extensions will now return additional template repositories to Codewind (and let Codewind read the templates from it), rather than extensions doing the parsing and returning template objects to Codewind

This PR is to handle that scenario and is required by kabanero-io/appsodyExtension#18