### PR TITLE
Template title should be empty

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issues.md
+++ b/.github/ISSUE_TEMPLATE/bug-issues.md
@@ -1,7 +1,7 @@
 ---
 name: Bug
 about: Reporting bugs and problems in Codewind
-title: Complete the bug template to report problems found in Codewind.
+title: ''
 labels: kind/bug
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/enhancement-issues.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-issues.md
@@ -1,7 +1,7 @@
 ---
 name: Enhancement
 about: Suggesting enhancements for Codewind
-title: Complete the enhancement template to suggest improvements to Codewind.
+title: ''
 labels: kind/enhancement
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/question-issues.md
+++ b/.github/ISSUE_TEMPLATE/question-issues.md
@@ -1,7 +1,7 @@
 ---
 name: Question
 about: Asking questions about Codewind
-title: Complete the question template to ask a question about Codewind.
+title: ''
 labels: kind/question
 assignees: ''
 


### PR DESCRIPTION
Related to issue #83

Change template title to empty strings to make it more convenient when opening issues.

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>