### PR TITLE
Add unittests for Turbine ProjectUtil

### DIFF
--- a/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
+++ b/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
@@ -23,6 +23,7 @@ import * as nodeProject from "../projects/nodejsProject";
 import { DockerProject } from "../projects/DockerProject";
 import { ShellExtensionProject } from "../projects/ShellExtensionProject";
 import { ProjectInfo, ProjectCapabilities, defaultProjectCapabilities } from "../projects/Project";
+import * as constants from "../projects/constants";
 
 export const DOCKER_TYPE = "docker";
 
@@ -163,7 +164,7 @@ async function getExtensionProjectHandler(projectInfo: ProjectInfo): Promise<any
         // try to load extension handler if ID was provided
         if (extensionID) {
             try {
-                const files = await utils.asyncReadDir(`/codewind-workspace/.extensions/${extensionID}`);
+                const files = await utils.asyncReadDir(`${constants.projectConstants.projectsExtensionDir}${extensionID}`);
                 if (files) {
                     if (files.includes(".sh-extension")) {
                         handler = new ShellExtensionProject(projectInfo.projectType);
@@ -174,6 +175,7 @@ async function getExtensionProjectHandler(projectInfo: ProjectInfo): Promise<any
             }
             catch (err) {
                 logger.logError(`Failed to get extension project handler ${extensionID} for ${projectInfo.location}`);
+                logger.logError(err);
                 return undefined;
             }
         }

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -21,6 +21,7 @@ import * as projectEventsController from "../controllers/projectEventsController
 import { IExtensionProject } from "../extensions/IExtensionProject";
 import * as processManager from "../utils/processManager";
 import * as logger from "../utils/logger";
+import * as constants from "../projects/constants";
 
 /**
  * @interface
@@ -90,7 +91,7 @@ export class ShellExtensionProject implements IExtensionProject {
         try {
             const result = await processManager.spawnDetachedAsync(
                 projectInfo.projectID,
-                `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`,
+                `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`,
                 args,
                 {});
 
@@ -116,7 +117,7 @@ export class ShellExtensionProject implements IExtensionProject {
      */
     init = async (projectInfo: ProjectInfo): Promise<void> => {
         this.id = projectInfo.extensionID;
-        this.config = await fs.readJson(`/codewind-workspace/.extensions/${this.id}/.sh-extension`);
+        this.config = await fs.readJson(`${constants.projectConstants.projectsExtensionDir}${this.id}/.sh-extension`);
         await this.setLanguage(projectInfo);
     }
 
@@ -127,7 +128,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param operation <Required | Operation> - The create operation.
      */
     create = (operation: Operation): void => {
-        projectUtil.containerCreate(operation, `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`, "create");
+        projectUtil.containerCreate(operation, `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`, "create");
     }
 
     /**
@@ -138,7 +139,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
      */
     update = (operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void => {
-        projectUtil.containerUpdate(operation, `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`, "update");
+        projectUtil.containerUpdate(operation, `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`, "update");
     }
 
     /**
@@ -148,7 +149,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     start = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.runScript(projectInfo, `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`, "start");
+        await projectUtil.runScript(projectInfo, `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`, "start");
     }
 
     /**
@@ -158,7 +159,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     stop = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.runScript(projectInfo, `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`, "stop");
+        await projectUtil.runScript(projectInfo, `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`, "stop");
     }
 
     /**
@@ -168,7 +169,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     rebuild = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.runScript(projectInfo, `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`, "rebuild");
+        await projectUtil.runScript(projectInfo, `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`, "rebuild");
     }
 
     /**
@@ -178,7 +179,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     deleteContainer = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.containerDelete(projectInfo, `/codewind-workspace/.extensions/${this.id}/entrypoint.sh`);
+        await projectUtil.containerDelete(projectInfo, `${constants.projectConstants.projectsExtensionDir}${this.id}/entrypoint.sh`);
     }
 
     /**

--- a/src/pfe/file-watcher/server/src/projects/constants.ts
+++ b/src/pfe/file-watcher/server/src/projects/constants.ts
@@ -10,12 +10,13 @@
  *******************************************************************************/
 "use strict";
 import * as path from "path";
-const workspaceDir = process.env.CW_WORKSPACE ||  path.join(path.sep, "codewind-workspace", path.sep);
+export const workspaceDir = process.env.CW_WORKSPACE ||  path.join(path.sep, "codewind-workspace", path.sep);
 // project constants
 export const projectConstants = {
     projectsDataDir: process.env.CW_PROJECTDATA_DIR || path.join(path.sep, "file-watcher", "fwdata", "projects", path.sep),
     projectsLogDir: process.env.CW_LOGS_DIR || path.join(workspaceDir, ".logs", path.sep),
     projectsInfoDir: path.join(workspaceDir, ".projects", path.sep),
+    projectsExtensionDir: path.join(workspaceDir, ".extensions", path.sep),
     containerPrefix: "cw-"
 };
 

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -721,12 +721,13 @@ export function getDefaultContainerName(projectID: string, projectLocation: stri
  *
  * @returns string
  */
-async function getContainerName(projectInfo: ProjectInfo): Promise<string> {
+export async function getContainerName(projectInfo: ProjectInfo): Promise<string> {
 
     const projectID: string = projectInfo.projectID;
     const projectLocation: string = projectInfo.location;
 
     const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
+    logger.logInfo("typeof projectHandler.getContainerName is " + typeof projectHandler.getContainerName);
     if (projectHandler && projectHandler.hasOwnProperty("getContainerName") && typeof projectHandler.getContainerName === "function") {
         return projectHandler.getContainerName(projectID, projectLocation);
     }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -501,34 +501,26 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
  *
  * @returns string
  */
-async function getProjectMavenSettings(projectInfo: ProjectInfo): Promise<string> {
+export async function getProjectMavenSettings(projectInfo: ProjectInfo): Promise<string> {
 
     logger.logProjectInfo("mavenProfiles: " + projectInfo.mavenProfiles, projectInfo.projectID);
     logger.logProjectInfo("mavenProperties: " + projectInfo.mavenProperties, projectInfo.projectID);
 
-    const profiles = projectInfo.mavenProfiles;
+    const profilesArr = projectInfo.mavenProfiles;
 
     const propertiesArr = projectInfo.mavenProperties;
-    let properties;
-    if (propertiesArr) {
-        properties = propertiesArr.toString();
-    }
 
     let userMavenSettings = "";
 
-    if (profiles && profiles.length > 0) {
-        if (profiles.length == 1 && profiles[0] == "") {
-            userMavenSettings = "";
-        } else {
-            userMavenSettings = userMavenSettings.concat(MavenFlags.profile.concat(profiles.toString()));
+    if (profilesArr && profilesArr.length > 0) {
+        if (! (profilesArr.length == 1 && profilesArr[0] == "") ) {
+            userMavenSettings = userMavenSettings.concat(MavenFlags.profile.concat(profilesArr.toString()));
         }
     }
 
-    if (properties && properties.length > 0) {
-        if (properties.length == 1 && properties[0] == "") {
-            userMavenSettings = userMavenSettings.concat("");
-        } else {
-            properties = "";
+    if (propertiesArr && propertiesArr.length > 0) {
+        if (!(propertiesArr.length == 1 && propertiesArr[0] == "")) {
+            let properties = "";
             for (const value of propertiesArr) {
                 properties = properties.concat(MavenFlags.properties).concat(value);
                 properties = properties.concat(" ");

--- a/src/pfe/file-watcher/server/test/functional-test/configs/app.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/app.config.ts
@@ -10,19 +10,20 @@
  *******************************************************************************/
 import * as path from "path";
 
-const MC_WORKSPACE = "codewind-workspace";
 
-export const microclimateWorkspaceDir =  process.env.CW_WORKSPACE || path.resolve(__dirname, "..", "..", "..", "..", "..", "..", "..", MC_WORKSPACE);
-export const microclimateWorkspaceLogsDir =  process.env.CW_LOGS_DIR || path.join(microclimateWorkspaceDir, ".logs");
+const CW_WORKSPACE = "codewind-workspace";
+export const codewindWorkspaceDir =  process.env.CW_WORKSPACE || path.resolve(__dirname, "..", "..", "..", "..", "..", "..", "..", CW_WORKSPACE);
+export const codewindWorkspaceLogsDir =  process.env.CW_LOGS_DIR || path.join(codewindWorkspaceDir, ".logs");
 export const localesDir = process.env.CW_LOCALES_DIR || path.resolve(__dirname, "..", "..", "..", "src", "utils", "locales") + path.sep;
 export const fwDataDir = process.env.CW_FWDATA_DIR || path.join(process.env.HOME, "fwdata");
 export const projectDataDir = process.env.CW_PROJECTDATA_DIR || path.join(fwDataDir, "projects");
-export const workspaceSettingsDir = process.env.CW_WORKSPACESETTINGS_DIR || path.join(microclimateWorkspaceDir, ".config");
+export const workspaceSettingsDir = process.env.CW_WORKSPACESETTINGS_DIR || path.join(codewindWorkspaceDir, ".config");
+export const extensionDir = process.env.CW_EXTENSION_DIR || path.join(codewindWorkspaceDir, ".extensions") + path.sep;
 
 export const projectPrefix = "microclimatetest";
 export const projectConfigs = {
     "appSuffix": Date.now(),
-    "appDirectory": path.join(microclimateWorkspaceDir, projectPrefix)
+    "appDirectory": path.join(codewindWorkspaceDir, projectPrefix)
 };
 
 export const FIXTURES = "idc-fixtures";

--- a/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
@@ -28,6 +28,7 @@ export const mkdirAsync = promisify(fs.mkdir);
 export const copyAsync = promisify(fs.copyFile);
 export const rmdirAsync = promisify(fs.rmdir);
 export const unlinkAsync = promisify(fs.unlink);
+export const writeAsync = promisify(fs.writeFile);
 
 export function pingPFE(callback: request.RequestCallback): request.Request {
     return request.get(pfeURL, callback);

--- a/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
@@ -19,7 +19,7 @@ import * as pfe_configs from "../configs/pfe.config";
 
 const pfeURL = pfe_configs.pfe.PROTOCOL + "://" + pfe_configs.pfe.HOST + ":" + pfe_configs.pfe.PORT + pfe_configs.pfeAPIs.projects;
 
-const mcWorkspace = app_configs.microclimateWorkspaceDir;
+const mcWorkspace = app_configs.codewindWorkspaceDir;
 
 const fixtures = app_configs.fixturesDir;
 
@@ -75,19 +75,20 @@ export function createFWDataDir(): any {
 
 export function cleanUpLogsDir(): any {
     const regex = new RegExp(/microclimatetest*/g);
-    fse.readdirSync(app_configs.microclimateWorkspaceLogsDir)
+    fse.readdirSync(app_configs.codewindWorkspaceLogsDir)
         .filter(folder => regex.test(folder))
         .map((folder) => {
-            const folderPath = path.join(app_configs.microclimateWorkspaceLogsDir, folder);
+            const folderPath = path.join(app_configs.codewindWorkspaceLogsDir, folder);
             fse.rmdirSync(folderPath);
         });
 }
 
 export function setTestEnvVariables(): void {
     process.env.CW_LOCALES_DIR = app_configs.localesDir;
-    process.env.CW_WORKSPACE = app_configs.microclimateWorkspaceDir;
-    process.env.CW_LOGS_DIR = app_configs.microclimateWorkspaceLogsDir;
+    process.env.CW_WORKSPACE = app_configs.codewindWorkspaceDir;
+    process.env.CW_LOGS_DIR = app_configs.codewindWorkspaceLogsDir;
     process.env.CW_FWDATA_DIR = app_configs.fwDataDir;
     process.env.CW_PROJECTDATA_DIR = app_configs.projectDataDir;
     process.env.CW_WORKSPACESETTINGS_DIR = app_configs.workspaceSettingsDir;
+    process.env.CW_EXTENSION_DIR = app_configs.extensionDir;
 }

--- a/src/pfe/file-watcher/server/test/unit-test/configs/module.configs.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/configs/module.configs.ts
@@ -15,7 +15,11 @@ import { localeTestModule } from "../tests/locale.module.test";
 import { workspaceSettingsTestModule } from "../tests/workspaceSettings.module.test";
 import { projectSettingsTestModule } from "../tests/projectSettings.module.test";
 import { projectStatusControllerTestModule } from "../tests/projectStatusController.test";
+<<<<<<< HEAD
 import { projectsControllerTestModule } from "../tests/projectsController.module.test";
+=======
+>>>>>>> 1992da5... first commit for projectUtil unittests
+import { projectUtilTestModule } from "../tests/projectUtil.module.test";
 import * as mocha from "mocha";
 
 interface ModuleExtension {
@@ -53,15 +57,35 @@ const projectStatusControllerModule: ModuleExtension = {
     moduleFunc: projectStatusControllerTestModule
 };
 
+<<<<<<< HEAD
 const projectControllerModule: ModuleExtension = {
     moduleName: "projectsController",
     moduleFunc: projectsControllerTestModule
 };
+=======
+>>>>>>> 1992da5... first commit for projectUtil unittests
 
+const projectUtilModule: ModuleExtension = {
+    moduleName: "projectUtil",
+    moduleFunc: projectUtilTestModule
+};
+
+<<<<<<< HEAD
 export const moduleLists: Array<ModuleExtension> = [logHelperModule,
                                                     utilsModule,
                                                     localeModule,
                                                     workspaceSettingsModule,
                                                     projectSettingsModule,
                                                     projectStatusControllerModule,
-                                                    projectControllerModule];
+                                                    projectControllerModule,
+                                                    projectUtilModule];
+
+=======
+// export const moduleLists: Array<ModuleExtension> = [logHelperModule,
+//                                                     utilsModule,
+//                                                     localeModule,
+//                                                     workspaceSettingsModule,
+//                                                     projectSettingsModule];
+
+export const moduleLists: Array<ModuleExtension> = [projectUtilModule];
+>>>>>>> 1992da5... first commit for projectUtil unittests

--- a/src/pfe/file-watcher/server/test/unit-test/configs/module.configs.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/configs/module.configs.ts
@@ -15,10 +15,7 @@ import { localeTestModule } from "../tests/locale.module.test";
 import { workspaceSettingsTestModule } from "../tests/workspaceSettings.module.test";
 import { projectSettingsTestModule } from "../tests/projectSettings.module.test";
 import { projectStatusControllerTestModule } from "../tests/projectStatusController.test";
-<<<<<<< HEAD
 import { projectsControllerTestModule } from "../tests/projectsController.module.test";
-=======
->>>>>>> 1992da5... first commit for projectUtil unittests
 import { projectUtilTestModule } from "../tests/projectUtil.module.test";
 import * as mocha from "mocha";
 
@@ -57,20 +54,16 @@ const projectStatusControllerModule: ModuleExtension = {
     moduleFunc: projectStatusControllerTestModule
 };
 
-<<<<<<< HEAD
 const projectControllerModule: ModuleExtension = {
     moduleName: "projectsController",
     moduleFunc: projectsControllerTestModule
 };
-=======
->>>>>>> 1992da5... first commit for projectUtil unittests
 
 const projectUtilModule: ModuleExtension = {
     moduleName: "projectUtil",
     moduleFunc: projectUtilTestModule
 };
 
-<<<<<<< HEAD
 export const moduleLists: Array<ModuleExtension> = [logHelperModule,
                                                     utilsModule,
                                                     localeModule,
@@ -79,13 +72,3 @@ export const moduleLists: Array<ModuleExtension> = [logHelperModule,
                                                     projectStatusControllerModule,
                                                     projectControllerModule,
                                                     projectUtilModule];
-
-=======
-// export const moduleLists: Array<ModuleExtension> = [logHelperModule,
-//                                                     utilsModule,
-//                                                     localeModule,
-//                                                     workspaceSettingsModule,
-//                                                     projectSettingsModule];
-
-export const moduleLists: Array<ModuleExtension> = [projectUtilModule];
->>>>>>> 1992da5... first commit for projectUtil unittests

--- a/src/pfe/file-watcher/server/test/unit-test/tests/locale.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/locale.module.test.ts
@@ -3,6 +3,11 @@ import * as locale from "../../../../server/src/utils/locale";
 
 export function localeTestModule(): void {
 
+    it("test getTranslation without NLS initialized", async () => {
+        const actualResult = await locale.getTranslation("filewatcherUtil.fwNLSInitSuccess");
+        expect(actualResult).to.equal("Turbine NLS has been initialized successfully");
+    });
+
     describe("combinational testing of setLocale function", () => {
 
         const combinations: any = {
@@ -67,6 +72,11 @@ export function localeTestModule(): void {
                 } catch (err) {
                     expect(err.code).to.equal(expectedResult);
                 }
+            });
+
+            it("test getTranslation with NLS initialized", async () => {
+                const actualResult = await locale.getTranslation("filewatcherUtil.fwNLSInitSuccess");
+                expect(actualResult).to.equal("Turbine NLS has been initialized successfully");
             });
         }
     });

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
@@ -12,11 +12,96 @@ import { expect } from "chai";
 import * as path from "path";
 import * as fs from "fs";
 
-import * as constants from "../../../../server/src/projects/constants";
+import * as crypto from "crypto";
+import { TransformOptions } from "stream";
 import * as projectUtil from "../../../../server/src/projects/projectUtil";
-
+import * as logHelperModule from "../lib/logHelper.module";
+import * as logHelper from "../../../../server/src/projects/logHelper";
+import * as libertyProject from "../../../../server/src/projects/libertyProject";
+import { existsAsync, mkdirAsync, writeAsync, copyAsync } from "../../functional-test/lib/utils";
+import * as projectsController from "../../../../server/src/controllers/projectsController";
+import { projectConstants } from "../../../../server/src/projects/constants";
+import * as app_configs from "../../functional-test/configs/app.config";
+import * as constants from "../../../../server/src/projects/constants";
 
 export function projectUtilTestModule(): void {
+    const extensionIDDir = path.join(process.env.CW_EXTENSION_DIR, "extensionProject");
+    it("test of getLogName function", async () => {
+        const projectID = "testProjectID";
+        const projectLocation = "directory/testproject";
+        const hash = crypto.createHash("sha1", <TransformOptions>"utf8").update(projectLocation);
+
+        const expectedResult  = projectConstants.containerPrefix + projectID + "-" + hash.digest("hex");
+        const actualResult = await projectUtil.getLogName(projectID, projectLocation);
+        expect(actualResult).to.equal(expectedResult);
+    });
+
+    describe("combinational testing of of getContainerName function", async () => {
+        before("create the extension directory with some fake files", async () => {
+            if (!(await existsAsync(extensionIDDir))) {
+                await mkdirAsync(extensionIDDir, { recursive: true });
+            }
+            expect(fs.statSync(extensionIDDir)).to.exist;
+            const filePath = path.resolve(extensionIDDir, ".sh-extension");
+            await writeAsync(filePath, '{"container": {"prefix": "testprefix-", "suffix": "-testsuffix"}}');
+            const entryPoint = path.resolve(extensionIDDir, "entrypoint.sh");
+            await writeAsync(entryPoint, "echo $(pwd)");
+            fs.chmodSync(entryPoint, 0o777);
+        });
+
+        after("remove the extension directory", async () => {
+            await projectsController.deleteFolder(extensionIDDir);
+            try {
+                fs.statSync(extensionIDDir);
+            } catch (err) {
+                expect(err.code).to.equal("ENOENT");
+            }
+            process.env.IN_K8 = "false";
+        });
+
+        const combinations: any = {
+            "combo1": {
+                "data": {
+                    projectID: "testProjectID",
+                    location: "directory/testproject",
+                    extensionID: "extensionProject",
+                    projectType: "extensionProject"
+                },
+                "result": "testprefix-testproject-testsuffix"
+            },
+            "combo2": {
+                "data": {
+                    projectID: "testProjectID",
+                    location: "directory/testproject",
+                    projectType: "liberty"
+                },
+                "result": projectConstants.containerPrefix + "testproject-testProjectID"
+            },
+            "combo3": {
+                "data": {
+                    projectID: "veryveryveryveryveryve-rylongtestProjectID",
+                    location: "directory/veryveryveryveryveryveryveryverylongTestProject/",
+                    projectType: "liberty"
+                },
+                "K8": true,
+                "result": "cw-veryveryveryveryveryver-veryveryveryveryveryve"
+            },
+        };
+        for (const combo of Object.keys(combinations)) {
+
+            const data = combinations[combo]["data"];
+            const expectedResult = combinations[combo]["result"];
+            const K8 = combinations[combo]["K8"];
+            it(combo + " => data: " + JSON.stringify(data), async() => {
+                if (K8) {
+                    process.env.IN_K8 = "true";
+                }
+                const actualResult = await projectUtil.getContainerName(data);
+                expect(actualResult).to.equal(expectedResult);
+            });
+        }
+    });
+
     describe("combinational testing of getProjectMavenSettings function", () => {
         const projectID = "testProjectID";
         const combinations: any = {
@@ -85,6 +170,297 @@ export function projectUtilTestModule(): void {
                 } catch (err) {
                     expect(err.toString()).to.equal(expectedResult);
                 }
+            });
+        }
+    });
+
+    describe("combinational testing of getProjectLogs function", () => {
+        const testProjectId = "1234";
+        const testProjectName = "abcd";
+        let logDirectory: string;
+        let dirName: string;
+        let appLogDirectory: string;
+        const projectFolder = process.env.CW_WORKSPACE + "/" + testProjectName;
+
+        before("create a log directory with some fake log files", async () => {
+            process.chdir(process.env.CW_LOGS_DIR);
+
+            dirName = await logHelper.getLogDir(testProjectId, testProjectName);
+            logDirectory = path.resolve(process.cwd(), dirName);
+
+            await logHelper.createLogDir(dirName, process.cwd());
+            expect(fs.statSync(logDirectory)).to.exist;
+
+            appLogDirectory = path.resolve(process.env.CW_WORKSPACE + "/" + testProjectName + "/mc-target/liberty/wlp/usr/servers/defaultServer/logs/");
+            if (!(await existsAsync(appLogDirectory))) {
+                await mkdirAsync(appLogDirectory, { recursive: true });
+            }
+            expect(fs.statSync(appLogDirectory)).to.exist;
+
+            if (!(await existsAsync(extensionIDDir))) {
+                await mkdirAsync(extensionIDDir, { recursive: true });
+            }
+            expect(fs.statSync(extensionIDDir)).to.exist;
+            const filePath = path.resolve(extensionIDDir, ".sh-extension");
+            await writeAsync(filePath, '{"buildLogs": ["buildLog"], "appLogs": ["appLog"]}');
+            const entryPoint = path.resolve(extensionIDDir, "entrypoint.sh");
+            await writeAsync(entryPoint, "echo $(pwd)");
+            fs.chmodSync(entryPoint, 0o777);
+
+        });
+
+        after("remove the log directory", async () => {
+            await logHelper.removeLogDir(dirName, process.cwd());
+            try {
+                fs.statSync(logDirectory);
+            } catch (err) {
+                expect(err.code).to.equal("ENOENT");
+            }
+            await projectsController.deleteFolder(projectFolder);
+            try {
+                fs.statSync(projectFolder);
+            } catch (err) {
+                expect(err.code).to.equal("ENOENT");
+            }
+            await projectsController.deleteFolder(extensionIDDir);
+            try {
+                fs.statSync(extensionIDDir);
+            } catch (err) {
+                expect(err.code).to.equal("ENOENT");
+            }
+        });
+        const combinations: any = {
+            "combo1": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: ["log1"],
+                    projectType: "liberty"
+                },
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": []
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": []
+                    }}
+            },
+            "combo2": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: [logHelper.buildLogs.dockerBuild, logHelper.buildLogs.mavenBuild],
+                    projectType: "liberty"
+                },
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.mavenBuild + ".log", process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerBuild + ".log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": []
+                    }}
+            },
+            "combo3": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: [logHelper.buildLogs.dockerBuild, logHelper.buildLogs.mavenBuild],
+                    projectType: "liberty"
+                },
+                "appLogTest": true,
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.mavenBuild + ".log", process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerBuild + ".log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "dir": process.env.CW_WORKSPACE + "/" + testProjectName + "/mc-target/liberty/wlp/usr/servers/defaultServer/logs/ffdc",
+                        "files": [ process.env.CW_WORKSPACE + "/" + testProjectName + "/mc-target/liberty/wlp/usr/servers/defaultServer/logs/console.log",  process.env.CW_WORKSPACE + "/" + testProjectName + "/mc-target/liberty/wlp/usr/servers/defaultServer/logs/messages.log"]
+                    }}
+            },
+            "combo4": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: [logHelper.buildLogs.dockerBuild, logHelper.buildLogs.mavenBuild],
+                    projectType: "spring"
+                },
+                "appLogTest": true,
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.mavenBuild + ".log", process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerBuild + ".log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": [process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.appLogs.app + ".log"]
+                    }}
+            },
+            "combo5": {
+                "data": {
+                    projectID: "invalidProjectID",
+                    location: "invalidProjectLocation",
+                    logSuffixes: ["log1"],
+                    projectType: "invalidProjectType"
+                },
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": []
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": []
+                    }}
+            },
+            "combo6": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: [logHelper.buildLogs.dockerBuild],
+                    projectType: "nodejs"
+                },
+                "appLogTest": true,
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerBuild + ".log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": [process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.appLogs.app + ".log"]
+                    }}
+            },
+            "combo7": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: [logHelper.buildLogs.dockerBuild, logHelper.buildLogs.dockerApp, logHelper.buildLogs.appCompilation],
+                    projectType: "swift"
+                },
+                "appLogTest": true,
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerBuild + ".log",  process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerApp + ".log", process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.appCompilation + ".log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": [process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.appLogs.app + ".log"]
+                    }}
+            },
+            "combo8": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: [logHelper.buildLogs.dockerBuild],
+                    projectType: "docker"
+                },
+                "appLogTest": true,
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.buildLogs.dockerBuild + ".log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": [process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/" + logHelper.appLogs.app + ".log"]
+                    }}
+            },
+            "combo9": {
+                "data": {
+                    projectID: testProjectId,
+                    location: projectFolder,
+                    logSuffixes: ["buildLog", "appLog"],
+                    extensionID: "extensionProject",
+                    projectType: "extensionProject"
+                },
+                "appLogTest": true,
+                "result":  {
+                    "build": {
+                        "origin": "workspace",
+                        "files": [ process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/buildLog.log"]
+                    },
+                    "app": {
+                        "origin": "workspace",
+                        "files": [process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId + "/appLog.log"]
+                    }}
+            },
+        };
+        for (const combo of Object.keys(combinations)) {
+
+            const data = combinations[combo]["data"];
+            const expectedResult = combinations[combo]["result"];
+            const appLogTest = combinations[combo]["appLogTest"];
+            const logSuffixes: string[] = data.logSuffixes;
+            it(combo + " => data: " + JSON.stringify(data), async() => {
+                    for (const suffix of logSuffixes) {
+                        const file = suffix + logHelperModule.getlogExtension();
+                        const filePath = path.resolve(logDirectory, file);
+                        await writeAsync(filePath, "some data");
+                    }
+                    if (appLogTest && data.projectType === "liberty") {
+                        const consoleLogPath = path.resolve(appLogDirectory, libertyProject.libertyAppLogs.console + ".log" );
+                        await writeAsync(consoleLogPath, "some data");
+                        const messagesLogPath = path.resolve(appLogDirectory, libertyProject.libertyAppLogs.messages + ".log");
+                        await writeAsync(messagesLogPath, "some data");
+                        const ffdcDir = path.resolve(appLogDirectory, "ffdc" );
+                        await mkdirAsync(ffdcDir);
+                    } else if (appLogTest) {
+                        const appLogPath = path.resolve(process.env.CW_LOGS_DIR + "/" + testProjectName + "-" + testProjectId, logHelper.appLogs.app + ".log");
+                        await writeAsync(appLogPath, "some data");
+                    }
+                    const actualResult = await projectUtil.getProjectLogs(data);
+                    expect(actualResult.build.files.length).to.equal(expectedResult.build.files.length);
+                    expect(actualResult.build.files).to.have.all.members(expectedResult.build.files);
+                    expect(actualResult.app.files.length).to.equal(expectedResult.app.files.length);
+                    expect(actualResult.app.files).to.have.all.members(expectedResult.app.files);
+                    if (expectedResult.app.dir) {
+                        expect(actualResult.app.dir).to.equal(expectedResult.app.dir);
+                    }
+            });
+        }
+    });
+
+    describe("combinational testing of of getUserFriendlyProjectType function", () => {
+        const combinations: any = {
+            "combo1": {
+                "projectType": "liberty",
+                "result": "Microprofile"
+            },
+            "combo2": {
+                "projectType": "spring",
+                "result": "Spring"
+            },
+            "combo3": {
+                "projectType": "swift",
+                "result": "Swift"
+            },
+            "combo4": {
+                "projectType": "nodejs",
+                "result": "Node.js"
+            },
+            "combo5": {
+                "projectType": "docker",
+                "result": "Docker"
+            },
+            "combo6": {
+                "projectType": "testprojecttype",
+                "result": "Testprojecttype"
+            },
+        };
+        for (const combo of Object.keys(combinations)) {
+
+            const projectType = combinations[combo]["projectType"];
+            const expectedResult = combinations[combo]["result"];
+            it(combo + " => projectType: " + projectType, async() => {
+                const actualResult = await projectUtil.getUserFriendlyProjectType(projectType);
+                expect(actualResult).to.equal(expectedResult);
             });
         }
     });

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
@@ -36,6 +36,20 @@ export function projectUtilTestModule(): void {
         expect(actualResult).to.equal(expectedResult);
     });
 
+    it("test of getLogName function on Kube", () => {
+        const projectID = "testProjectID";
+        const projectLocation = "directory/testproject";
+        const hash = crypto.createHash("sha1", <TransformOptions>"utf8").update(projectLocation);
+        let expectedResult  = projectConstants.containerPrefix + projectID + "-" + hash.digest("hex");
+        if (expectedResult.length > 53) {
+            expectedResult = expectedResult.substring(0, 53);
+        }
+        process.env.IN_K8 = "true";
+        const actualResult = projectUtil.getLogName(projectID, projectLocation);
+        expect(actualResult).to.equal(expectedResult);
+        process.env.IN_K8 = "false";
+    });
+
     describe("combinational testing of of getContainerName function", async () => {
         before("create the extension directory with some fake files", async () => {
             if (!(await existsAsync(extensionIDDir))) {

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+import { expect } from "chai";
+import * as path from "path";
+import * as fs from "fs";
+
+import * as constants from "../../../../server/src/projects/constants";
+import * as projectUtil from "../../../../server/src/projects/projectUtil";
+
+
+export function projectUtilTestModule(): void {
+    describe("combinational testing of getProjectMavenSettings function", () => {
+        const projectID = "testProjectID";
+        const combinations: any = {
+            "combo1": {
+                "data": {
+                    projectID: projectID
+                },
+                "result": ""
+            },
+            "combo2": {
+                "data": {
+                    projectID: projectID,
+                    mavenProfiles: ""
+                },
+                "result": ""
+            },
+            "combo3": {
+                "data": {
+                    projectID: projectID,
+                    mavenProfiles: [""],
+                    mavenProperties: [""]
+                },
+                "result": ""
+            },
+            "combo4": {
+                "data": {
+                    projectID: projectID,
+                    mavenProfiles: ["profile1&"]
+                },
+                "result": "Error: The user maven settings have invalid characters for the project"
+            },
+            "combo5": {
+                "data": {
+                    projectID: projectID,
+                    mavenProperties: ["key=value;"]
+                },
+                "result": "Error: The user maven settings have invalid characters for the project"
+            },
+            "combo6": {
+                "data": {
+                    projectID: projectID,
+                    mavenProfiles: ["profile1"],
+                    mavenProperties: ["key=value"]
+                },
+                "result": "-P profile1 -D key=value "
+            },
+            "combo7": {
+                "data": {
+                    projectID: projectID,
+                    mavenProfiles: ["profile1", "profile2"],
+                    mavenProperties: ["key1=value1", "key2=value2"]
+                },
+                "result": "-P profile1,profile2 -D key1=value1 -D key2=value2 "
+            },
+        };
+        for (const combo of Object.keys(combinations)) {
+
+            const data = combinations[combo]["data"];
+            const expectedResult = combinations[combo]["result"];
+
+            it(combo + " => data: " + JSON.stringify(data), async() => {
+                try {
+                    const actualResult = await projectUtil.getProjectMavenSettings(data);
+                    console.log("actualResult: " + actualResult);
+                    expect(actualResult).to.equal(expectedResult);
+                } catch (err) {
+                    expect(err.toString()).to.equal(expectedResult);
+                }
+            });
+        }
+    });
+
+}

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
@@ -23,6 +23,7 @@ import * as projectsController from "../../../../server/src/controllers/projects
 import { projectConstants } from "../../../../server/src/projects/constants";
 import * as app_configs from "../../functional-test/configs/app.config";
 import * as constants from "../../../../server/src/projects/constants";
+import { threadId } from "worker_threads";
 
 export function projectUtilTestModule(): void {
     const extensionIDDir = path.join(process.env.CW_EXTENSION_DIR, "extensionProject");
@@ -179,7 +180,6 @@ export function projectUtilTestModule(): void {
             it(combo + " => data: " + JSON.stringify(data), async() => {
                 try {
                     const actualResult = await projectUtil.getProjectMavenSettings(data);
-                    console.log("actualResult: " + actualResult);
                     expect(actualResult).to.equal(expectedResult);
                 } catch (err) {
                     expect(err.toString()).to.equal(expectedResult);
@@ -441,7 +441,7 @@ export function projectUtilTestModule(): void {
         }
     });
 
-    describe("combinational testing of of getUserFriendlyProjectType function", () => {
+    describe("combinational testing of getUserFriendlyProjectType function", () => {
         const combinations: any = {
             "combo1": {
                 "projectType": "liberty",


### PR DESCRIPTION
This PR is for #47 
In PR created unittests for `projectUtil.ts`. 
Also increase code coverage for `locale.ts`.

The code coverage for `projectUtil` does not go up much, since most of the functions in `projectUtil` are for project containers. 
However, the functions in `projectUtil` call project handlers' functions. And the code coverage for all project handlers has increased to over 50% line coverred.

```
 PFE - unit test
    projectUtil module
      ✓ test of getLogName function
      ✓ test of getLogName function on Kube
      combinational testing of of getContainerName function
        ✓ combo1 => data: {"projectID":"testProjectID","location":"directory/testproject","extensionID":"extensionProject","projectType":"extensionProject"}
        ✓ combo2 => data: {"projectID":"testProjectID","location":"directory/testproject","projectType":"liberty"}
        ✓ combo3 => data: {"projectID":"veryveryveryveryveryve-rylongtestProjectID","location":"directory/veryveryveryveryveryveryveryverylongTestProject/","projectType":"liberty"}
      combinational testing of getProjectMavenSettings function
        ✓ combo1 => data: {"projectID":"testProjectID"}
        ✓ combo2 => data: {"projectID":"testProjectID","mavenProfiles":""}
        ✓ combo3 => data: {"projectID":"testProjectID","mavenProfiles":[""],"mavenProperties":[""]}
        ✓ combo4 => data: {"projectID":"testProjectID","mavenProfiles":["profile1&"]}
        ✓ combo5 => data: {"projectID":"testProjectID","mavenProperties":["key=value;"]}
        ✓ combo6 => data: {"projectID":"testProjectID","mavenProfiles":["profile1"],"mavenProperties":["key=value"]}
        ✓ combo7 => data: {"projectID":"testProjectID","mavenProfiles":["profile1","profile2"],"mavenProperties":["key1=value1","key2=value2"]}
      combinational testing of getProjectLogs function
        ✓ combo1 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["log1"],"projectType":"liberty"}
        ✓ combo2 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["docker.build","maven.build"],"projectType":"liberty"}
        ✓ combo3 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["docker.build","maven.build"],"projectType":"liberty"}
        ✓ combo4 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["docker.build","maven.build"],"projectType":"spring"}
        ✓ combo5 => data: {"projectID":"invalidProjectID","location":"invalidProjectLocation","logSuffixes":["log1"],"projectType":"invalidProjectType"}
        ✓ combo6 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["docker.build"],"projectType":"nodejs"}
        ✓ combo7 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["docker.build","docker.app","app.compile"],"projectType":"swift"}
        ✓ combo8 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["docker.build"],"projectType":"docker"}
        ✓ combo9 => data: {"projectID":"1234","location":"/Users/stephanie/Documents/microclimate/codewind/src/pfe/file-watcher/server/abcd","logSuffixes":["buildLog","appLog"],"extensionID":"extensionProject","projectType":"extensionProject"}
      combinational testing of of getUserFriendlyProjectType function
        ✓ combo1 => projectType: liberty
        ✓ combo2 => projectType: spring
        ✓ combo3 => projectType: swift
        ✓ combo4 => projectType: nodejs
        ✓ combo5 => projectType: docker
        ✓ combo6 => projectType: testprojecttype


  27 passing (95ms)
```