### PR TITLE
add APIs to enable and disable template repos

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1345,8 +1345,6 @@ components:
           example: "https://github.com/microclimate-dev2ops/SVTPythonTemplate"
         projectType:
           example: "docker"
-        projectStyle:
-          example: "Codewind"
     TemplateRepo:
       type: object
       required:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -865,6 +865,13 @@ paths:
             type: string
           required: false
           description: Specify this to filter templates returned by project style
+        - name: showEnabledOnly
+          in: query
+          schema:
+            type: string
+            enum: ['true', 'false']
+          required: false
+          description: Set this to 'true' to return only templates from enabled repositories
       responses:
         200:
           description: Returns all the templates that Codewind can generate a project from

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -888,12 +888,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    url:
-                      type: string
-                    description:
-                      type: string
+                  $ref: '#/components/schemas/TemplateRepo'
     post:
       summary: Make Codewind aware of a template repository
       requestBody:
@@ -901,15 +896,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - url
-                - description
-              properties:
-                url:
-                    type: string
-                description:
-                    type: string
+              $ref: '#/components/schemas/TemplateRepo'
       responses:
         200:
           description: Returns all the templates repositories that Codewind will use to find templates
@@ -926,6 +913,36 @@ paths:
                       type: string
         400:
           description: Bad request
+    patch:
+      summary: Change settings for a template repository of which Codewind is aware
+      requestBody:
+        description: repository settings
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/TemplateRepoSetting'
+      responses:
+        207:
+          description: Returns success/failure statuses of settings operations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - status
+                    - requestedOperation
+                  properties:
+                    status:
+                      type: integer
+                    requestedOperation:
+                      $ref: '#/components/schemas/TemplateRepoSetting'
+                    error:
+                      type: string
+
     delete:
       summary: Remove a template repository from the list Codewind is aware of
       requestBody:
@@ -947,12 +964,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    url:
-                      type: string
-                    description:
-                      type: string
+                  $ref: '#/components/schemas/TemplateRepo'
         400:
           description: Bad request
   /api/v1/templates/styles:
@@ -1309,6 +1321,12 @@ components:
       example: 20190326154749
     Template:
       type: object
+      required:
+        - label
+        - description
+        - language
+        - url
+        - projectType
       properties:
         label:
           example: "python hello world"
@@ -1320,6 +1338,38 @@ components:
           example: "https://github.com/microclimate-dev2ops/SVTPythonTemplate"
         projectType:
           example: "docker"
+        projectStyle:
+          example: "Codewind"
+    TemplateRepo:
+      type: object
+      required:
+        - url
+        - description
+      properties:
+        url:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+    TemplateRepoSetting:
+      type: object
+      required:
+        - op
+        - path
+        - value
+      properties:
+        op:
+          description: repository setting to change
+          type: string
+          enum: [enable]
+        path:
+          description: path of the modified resource (i.e., the URL of the target template repository)
+          type: string
+          example: https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json
+        value:
+          type: string
+          example: true
     BasicMetric:
       properties:
         time:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -920,8 +920,33 @@ paths:
                       type: string
         400:
           description: Bad request
+    delete:
+      summary: Remove a template repository from the list Codewind is aware of
+      requestBody:
+        description: repository details
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - url
+              properties:
+                url:
+                    type: string
+      responses:
+        200:
+          description: Returns all the templates repositories that Codewind will use to find templates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TemplateRepo'
+        400:
+          description: Bad request
+  /api/v1/batch/templates/repositories:
     patch:
-      summary: Change settings for a template repository of which Codewind is aware
+      summary: Batch change settings for a template repository of which Codewind is aware
       requestBody:
         description: repository settings
         content:
@@ -949,31 +974,6 @@ paths:
                       $ref: '#/components/schemas/TemplateRepoSetting'
                     error:
                       type: string
-
-    delete:
-      summary: Remove a template repository from the list Codewind is aware of
-      requestBody:
-        description: repository details
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - url
-              properties:
-                url:
-                    type: string
-      responses:
-        200:
-          description: Returns all the templates repositories that Codewind will use to find templates
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TemplateRepo'
-        400:
-          description: Bad request
   /api/v1/templates/styles:
     get:
       summary: List all project styles for which Codewind has templates
@@ -1363,15 +1363,15 @@ components:
       type: object
       required:
         - op
-        - path
+        - url
         - value
       properties:
         op:
           description: repository setting to change
           type: string
           enum: [enable]
-        path:
-          description: path of the modified resource (i.e., the URL of the target template repository)
+        url:
+          description: url of the modified template repository
           type: string
           example: https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json
         value:

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -42,7 +42,7 @@ module.exports = class ExtensionList {
           await extension.initialise();
           this.add(extension);
           if (extension.templates)
-            templates.addRepository(extension.templates, extension.description);
+            await templates.addRepository(extension.templates, extension.description);
           else if (extension.templatesProvider) {
             templates.addProvider(extension.name, extension.templatesProvider);
             delete extension.templatesProvider;

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -42,7 +42,12 @@ module.exports = class ExtensionList {
           await extension.initialise();
           this.add(extension);
           if (extension.templates)
-            await templates.addRepository(extension.templates, extension.description);
+            try {
+              await templates.addRepository(extension.templates, extension.description);
+            } catch (error) {
+              log.warn(error);
+              // ignore so that we can try to add other repos in the list
+            }
           else if (extension.templatesProvider) {
             templates.addProvider(extension.name, extension.templatesProvider);
             delete extension.templatesProvider;

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -59,18 +59,17 @@ module.exports = class Templates {
   }
 
   getEnabledTemplates() {
-    return this.getTemplateList(this.getEnabledRepositories());
+    return this.getTemplatesFromRepos(this.getEnabledRepositories());
   }
 
   getAllTemplates() {
-    return this.getTemplateList(this.repositoryList);
-  }
-
-  async getTemplateList(repositoryList) {
     if (!this.needsRefresh) {
       return this.projectTemplates;
     }
+    return this.getTemplatesFromRepos(this.repositoryList);
+  }
 
+  async getTemplatesFromRepos(repositoryList) {
     let newProjectTemplates = [];
 
     // apply reduce function to create a copy of the repository list index by url
@@ -91,7 +90,13 @@ module.exports = class Templates {
 
     await Promise.all(Object.values(repos).map(async function getTemplatesFromRepo(repository) {
 
-      let repositoryUrl = new URL(repository.url);
+      let repositoryUrl;
+      try {
+        repositoryUrl = new URL(repository.url);
+      } catch (error) {
+        log.warn(error.message);
+        return; // ignore so that others can continue
+      }
 
       let options = {
         host: repositoryUrl.host,

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -135,12 +135,8 @@ module.exports = class Templates {
 
   // Save the default list to disk so the user can potentially edit it (WHEN CODEWIND IS NOT RUNNING)
   async writeRepositoryList() {
-    try {
-      await fs.writeJson(this.repositoryFile, this.repositoryList, { spaces: '  ' });
-      log.info(`Repository list updated.`);
-    } catch (err) {
-      log.error(`Error writing repository list to ${this.repositoryFile}: ${err}`)
-    }
+    await fs.writeJson(this.repositoryFile, this.repositoryList, { spaces: '  ' });
+    log.info(`Repository list updated.`);
   }
 
   getRepositories() {
@@ -184,7 +180,6 @@ module.exports = class Templates {
     const repo = this.getRepository(url);
     repo.enabled = true;
     await this.writeRepositoryList();
-
   }
 
   async disableRepository(url) {

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -12,9 +12,11 @@
 const fs = require('fs-extra');
 const path = require('path');
 
+const cwUtils = require('../modules/utils/sharedFunctions');
 const Logger = require('./utils/Logger');
+const TemplateError = require('./utils/errors/TemplateError');
+
 const log = new Logger('Templates.js');
-const cwUtils = require('../modules/utils/sharedFunctions.js');
 
 const DEFAULT_REPOSITORY_LIST = [
   {
@@ -243,7 +245,7 @@ module.exports = class Templates {
    */
   async addRepository(repositoryUrl, repositoryDescription) {
     if (this.getRepositories().find(repo => repo.url == repositoryUrl)) {
-      throw new Error('Repository URL must be unique');
+      throw new TemplateError('DUPLICATE_URL', repositoryUrl);
     }
     const newRepo = {
       url: repositoryUrl,

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -189,22 +189,21 @@ module.exports = class Templates {
   }
 
   async performOperation(operation) {
-    const { op, path, value } = operation;
+    const { op, url, value } = operation;
     let operationResult = {};
     if (op === 'enable') {
-      operationResult = await this.performEnableOrDisableOperation({ path, value });
+      operationResult = await this.performEnableOrDisableOperation({ url, value });
     }
     operationResult.requestedOperation = operation;
     return operationResult;
   }
 
   /**
-   *
+   * @param {JSON} { url (URL of template repo to enable or disable), value (true|false)}
    * @returns {JSON} { status, error (optional) }
    */
-  async performEnableOrDisableOperation({ path, value }) {
-    const repoUrl = path;
-    if (!this.doesRepositoryExist(repoUrl)) {
+  async performEnableOrDisableOperation({ url, value }) {
+    if (!this.doesRepositoryExist(url)) {
       return {
         status: 404,
         error: 'Unknown repository URL',
@@ -212,9 +211,9 @@ module.exports = class Templates {
     }
     try {
       if (value === 'true') {
-        await this.enableRepository(repoUrl);
+        await this.enableRepository(url);
       } else {
-        await this.disableRepository(repoUrl);
+        await this.disableRepository(url);
       }
       return {
         status: 200

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -19,8 +19,9 @@ const cwUtils = require('../modules/utils/sharedFunctions.js');
 const DEFAULT_REPOSITORY_LIST = [
   {
     url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-    description: 'Standard Codewind templates.'
-  }
+    description: 'Standard Codewind templates.',
+    enabled: true,
+  },
 ];
 module.exports = class Templates {
 
@@ -40,15 +41,32 @@ module.exports = class Templates {
         this.repositoryList = list;
         this.needsRefresh = true;
       } else {
-        // Save the default list to disk so the user can potentially edit it.
-        this.writeRepositoryList();
+        await this.writeRepositoryList();
       }
     } catch (err) {
       log.error(`Error reading repository list from ${this.repositoryFile}: ${err}`)
     }
   }
+  async getTemplates({ projectStyle, showEnabledOnly }) {
+    let templates = (showEnabledOnly === 'true')
+      ? await this.getEnabledTemplates()
+      : await this.getAllTemplates();
 
-  async getTemplateList() {
+    if (projectStyle) {
+      templates = filterTemplatesByStyle(templates, projectStyle);
+    }
+    return templates;
+  }
+
+  getEnabledTemplates() {
+    return this.getTemplateList(this.getEnabledRepositories());
+  }
+
+  getAllTemplates() {
+    return this.getTemplateList(this.repositoryList);
+  }
+
+  async getTemplateList(repositoryList) {
     if (!this.needsRefresh) {
       return this.projectTemplates;
     }
@@ -56,7 +74,7 @@ module.exports = class Templates {
     let newProjectTemplates = [];
 
     // apply reduce function to create a copy of the repository list index by url
-    const repos = this.repositoryList.reduce(reducer, {});
+    const repos = repositoryList.reduce(reducer, {});
 
     // query providers for more repositories
     for (let provider of Object.values(this.providers)) {
@@ -71,7 +89,7 @@ module.exports = class Templates {
       }
     }
 
-    await Promise.all(Object.values(repos).map(async function getTemplates(repository) {
+    await Promise.all(Object.values(repos).map(async function getTemplatesFromRepo(repository) {
 
       let repositoryUrl = new URL(repository.url);
 
@@ -115,26 +133,103 @@ module.exports = class Templates {
     return this.projectTemplates;
   }
 
-  async getTemplatesOfStyle(projectStyle) {
-    const allTemplates = await this.getTemplateList();
-    const relevantTemplates = allTemplates.filter(template =>
-      getTemplateStyle(template) === projectStyle
-    );
-    return relevantTemplates;
-  }
-
-  writeRepositoryList() {
-    // Use a callback here so we don't block the response to the request.
-    fs.writeJson(this.repositoryFile, this.repositoryList, { spaces: '  ' }, err => {
-      if (err) {
-        log.error(`Error writing repository list to ${this.repositoryFile}: ${err}`)
-      }
+  // Save the default list to disk so the user can potentially edit it (WHEN CODEWIND IS NOT RUNNING)
+  async writeRepositoryList() {
+    try {
+      await fs.writeJson(this.repositoryFile, this.repositoryList, { spaces: '  ' });
       log.info(`Repository list updated.`);
-    });
+    } catch (err) {
+      log.error(`Error writing repository list to ${this.repositoryFile}: ${err}`)
+    }
   }
 
   getRepositories() {
     return this.repositoryList;
+  }
+
+  getEnabledRepositories() {
+    return this.getRepositories().filter(repo =>
+      // if the repo doesn't specify whether it's enabled, consider it enabled
+      (repo.enabled || !repo.hasOwnProperty('enabled'))
+    );
+  }
+
+  doesRepositoryExist(repoUrl) {
+    try {
+      this.getRepository(repoUrl);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  getRepositoryIndex(url) {
+    const repos = this.getRepositories();
+    const index = repos.findIndex(repo => repo.url === url);
+    return index;
+  }
+
+  /**
+   * @param {String} url
+   * @return {JSON} reference to the repo object in this.repositoryList
+   */
+  getRepository(url) {
+    const index = this.getRepositoryIndex(url);
+    if (index < 0) throw new Error(`no repository found with URL '${url}'`);
+    const repo = this.getRepositories()[index];
+    return repo;
+  }
+
+  async enableRepository(url) {
+    const repo = this.getRepository(url);
+    repo.enabled = true;
+    await this.writeRepositoryList();
+
+  }
+
+  async disableRepository(url) {
+    const repo = this.getRepository(url);
+    repo.enabled = false;
+    await this.writeRepositoryList();
+  }
+
+  async performOperation(operation) {
+    const { op, path, value } = operation;
+    let operationResult = {};
+    if (op === 'enable') {
+      operationResult = await this.performEnableOrDisableOperation({ path, value });
+    }
+    operationResult.requestedOperation = operation;
+    return operationResult;
+  }
+
+  /**
+   *
+   * @returns {JSON} { status, error (optional) }
+   */
+  async performEnableOrDisableOperation({ path, value }) {
+    const repoUrl = path;
+    if (!this.doesRepositoryExist(repoUrl)) {
+      return {
+        status: 404,
+        error: 'Unknown repository URL',
+      };
+    }
+    try {
+      if (value === 'true') {
+        await this.enableRepository(repoUrl);
+      } else {
+        await this.disableRepository(repoUrl);
+      }
+      return {
+        status: 200
+      };
+    } catch (error) {
+      return {
+        status: 500,
+        error: error.message,
+      };
+    }
   }
 
   /**
@@ -143,9 +238,9 @@ module.exports = class Templates {
    * @param {*} url - url of the template repository
    * @param {*} description - description of the template repository
    */
-  addRepository(repositoryUrl, repositoryDescription) {
-    if (this.getRepositories().filter(repo => repo.url == repositoryUrl).length != 0) {
-      return false;
+  async addRepository(repositoryUrl, repositoryDescription) {
+    if (this.getRepositories().find(repo => repo.url == repositoryUrl)) {
+      throw new Error('Repository URL must be unique');
     }
     const newRepo = {
       url: repositoryUrl,
@@ -153,14 +248,13 @@ module.exports = class Templates {
     }
     this.repositoryList.push(newRepo);
     this.needsRefresh = true;
-    this.writeRepositoryList();
-    return true;
+    await this.writeRepositoryList();
   }
 
-  deleteRepository(repositoryUrl) {
+  async deleteRepository(repositoryUrl) {
     this.repositoryList = this.repositoryList.filter((repo) => repo.url != repositoryUrl);
     this.needsRefresh = true;
-    this.writeRepositoryList();
+    await this.writeRepositoryList();
   }
 
   addProvider(name, provider) {
@@ -169,11 +263,18 @@ module.exports = class Templates {
   }
 
   async getTemplateStyles() {
-    const templates = await this.getTemplateList();
+    const templates = await this.getAllTemplates();
     const styles = templates.map(template => getTemplateStyle(template));
     const uniqueStyles = [...new Set(styles)];
     return uniqueStyles;
   }
+}
+
+function filterTemplatesByStyle(templates, projectStyle) {
+  const relevantTemplates = templates.filter(template =>
+    getTemplateStyle(template) === projectStyle
+  );
+  return relevantTemplates;
 }
 
 function getTemplateStyle(template) {
@@ -188,3 +289,4 @@ function reducer(repos, repo) {
     repos[repo.url] = repo;
   return repos;
 }
+module.exports.filterTemplatesByStyle =  filterTemplatesByStyle;

--- a/src/pfe/portal/modules/utils/errors/TemplateError.js
+++ b/src/pfe/portal/modules/utils/errors/TemplateError.js
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+'use strict';
+const BaseError = require('./BaseError')
+
+module.exports = class TemplateError extends BaseError {
+  constructor(code = '[Unknown error code]', identifier, message) {
+    super(code, constructMessage(code, identifier, message));
+  }
+}
+
+// Error codes
+module.exports.DUPLICATE_URL = 'DUPLICATE_URL';
+
+/**
+ * Function to construct an error message based on the given error code
+ * @param code, the error code to create the message from
+ * @param identifier, the name of the Project/Project path in question (based on the code being called)
+ * @param message, a message to be appended on the end of a default message
+ */
+function constructMessage(code, identifier, message) {
+  let output = '';
+  switch(code) {
+  case 'DUPLICATE_URL':
+    output = `${identifier} is not a unique URL. Repository URLs must be unique`;
+    break;
+  default:
+    output = 'Unknown template error';
+  }
+
+  // Append message to output if provided
+  return message ? `${output}\n${message}` : output;
+}

--- a/src/pfe/portal/package-lock.json
+++ b/src/pfe/portal/package-lock.json
@@ -1688,6 +1688,11 @@
         "vary": "~1.1.2"
       }
     },
+    "express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng=="
+    },
     "express-openapi-validate": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/express-openapi-validate/-/express-openapi-validate-0.4.4.tgz",

--- a/src/pfe/portal/package.json
+++ b/src/pfe/portal/package.json
@@ -20,6 +20,7 @@
     "deep-equal": "^1.0.1",
     "dockerode": "^2.5.2",
     "express": "^4.15.4",
+    "express-async-errors": "^3.1.1",
     "express-openapi-validate": "^0.4.4",
     "file-watcher": "file:../file-watcher/server",
     "fs-extra": "^7.0.1",

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -60,8 +60,11 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
   try {
     await user.templates.addRepository(repositoryUrl, repositoryDescription);
   } catch (error) {
-    res.status(400).send("Repository url already available.");
-    return;
+    if (error.message === 'Repository URL must be unique') {
+      res.status(400).send(error.message);
+      return;
+    }
+    throw error;
   }
   sendRepositories(req, res, _next);
 });

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -86,10 +86,7 @@ router.patch('/api/v1/batch/templates/repositories', validateReq, async (req, re
   const user = req.cw_user;
   const templateController = user.templates;
   const requestedOperations = req.body;
-  const operationPromises = requestedOperations.map(operation =>
-    templateController.performOperation(operation)
-  );
-  const operationResults = await Promise.all(operationPromises);
+  const operationResults = await templateController.batchUpdate(requestedOperations);
   res.status(207).json(operationResults);
 });
 

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -10,11 +10,12 @@
  *******************************************************************************/
 const express = require('express');
 
+const { validateReq } = require('../middleware/reqValidator');
 const Logger = require('../modules/utils/Logger');
+const TemplateError = require('../modules/utils/errors/TemplateError');
 
 const router = express.Router();
 const log = new Logger(__filename);
-const { validateReq } = require('../middleware/reqValidator');
 
 /**
  * API Function to return a list of available templates
@@ -60,7 +61,8 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
   try {
     await user.templates.addRepository(repositoryUrl, repositoryDescription);
   } catch (error) {
-    if (error.message === 'Repository URL must be unique') {
+    log.error(error);
+    if (error instanceof TemplateError && error.code === 'DUPLICATE_URL') {
       res.status(400).send(error.message);
       return;
     }

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -22,19 +22,17 @@ const { validateReq } = require('../middleware/reqValidator');
  */
 router.get('/api/v1/templates', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
-  const projectStyle = req.query.projectStyle;
-
+  const { projectStyle, showEnabledOnly } = req.query;
+  const templateController = user.templates;
   try {
-    const projectTemplates = (projectStyle)
-      ? await user.templates.getTemplatesOfStyle(projectStyle)
-      : await user.templates.getTemplateList();
+    const templates = await templateController.getTemplates({ projectStyle, showEnabledOnly });
 
-    if (projectTemplates.length == 0) {
+    if (templates.length == 0) {
       log.warn('No templates found');
       res.sendStatus(204);
-    } else {
-      res.status(200).json(projectTemplates);
+      return;
     }
+    res.status(200).json(templates);
   } catch (error) {
     log.error(error);
     res.status(500).json(error);
@@ -47,7 +45,7 @@ router.get('/api/v1/templates', validateReq, async (req, res, _next) => {
  */
 router.get('/api/v1/templates/repositories', sendRepositories);
 
-router.post('/api/v1/templates/repositories', validateReq, (req, res, _next) => {
+router.post('/api/v1/templates/repositories', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
   const repositoryUrl = req.sanitizeBody('url');
   const repositoryDescription = req.sanitizeBody('description');
@@ -59,17 +57,19 @@ router.post('/api/v1/templates/repositories', validateReq, (req, res, _next) => 
     res.status(400).send("Invalid repository URL");
     return;
   }
-  if (!user.templates.addRepository(repositoryUrl, repositoryDescription)) {
+  try {
+    await user.templates.addRepository(repositoryUrl, repositoryDescription);
+  } catch (error) {
     res.status(400).send("Repository url already available.");
     return;
   }
   sendRepositories(req, res, _next);
 });
 
-router.delete('/api/v1/templates/repositories', validateReq, (req, res, _next) => {
+router.delete('/api/v1/templates/repositories', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
   const repositoryUrl = req.sanitizeBody('url');
-  user.templates.deleteRepository(repositoryUrl);
+  await user.templates.deleteRepository(repositoryUrl);
   sendRepositories(req, res, _next);
 });
 
@@ -79,12 +79,24 @@ function sendRepositories(req, res, _next) {
   res.status(200).json(repositoryList);
 }
 
+router.patch('/api/v1/templates/repositories', validateReq, async (req, res) => {
+  const user = req.cw_user;
+  const templateController = user.templates;
+  const requestedOperations = req.body;
+  const operationPromises = requestedOperations.map(operation =>
+    templateController.performOperation(operation)
+  );
+  const operationResults = await Promise.all(operationPromises);
+  res.status(207).json(operationResults);
+});
+
 /**
  * @return {[String]} the list of template styles
  */
 router.get('/api/v1/templates/styles', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
-  const styles = await user.templates.getTemplateStyles();
+  const templateController = user.templates;
+  const styles = await templateController.getTemplateStyles();
   res.status(200).json(styles);
 });
 

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -82,7 +82,7 @@ function sendRepositories(req, res, _next) {
   res.status(200).json(repositoryList);
 }
 
-router.patch('/api/v1/templates/repositories', validateReq, async (req, res) => {
+router.patch('/api/v1/batch/templates/repositories', validateReq, async (req, res) => {
   const user = req.cw_user;
   const templateController = user.templates;
   const requestedOperations = req.body;

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -25,6 +25,7 @@ async function main() {
     require('appmetrics-dash').monitor({ title: "Application Metrics Dashboard - Monitoring codewind Portal" });
   }
   const express = require('express');
+  require('express-async-errors');
   const request = require('request');
   const { promisify } = require('util');
   const Logger = require('./modules/utils/Logger');

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -89,6 +89,13 @@ const styledTemplates = {
     },
 };
 
+const defaultRepo = {
+    url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
+    description: 'Standard Codewind templates.',
+    enabled: true,
+};
+const defaultRepoList = [defaultRepo];
+
 async function getTemplateRepos() {
     const res = await reqService.chai
         .get('/api/v1/templates/repositories')
@@ -167,6 +174,7 @@ async function getTemplateStyles() {
 module.exports = {
     defaultTemplates,
     styledTemplates,
+    defaultRepoList,
     getTemplateRepos,
     addTemplateRepo,
     deleteTemplateRepo,

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ ******************************************************************************/
+const { ADMIN_COOKIE } = require('../config');
+const reqService = require('./request.service');
+
+const defaultTemplates = [
+    {
+        label: 'Go template',
+        description: 'Sample microservice for simple go app',
+        language: 'go',
+        url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
+        projectType: 'docker',
+    },
+    {
+        label: 'Java Lagom template',
+        description: 'Template for building Lagom Reactive microservice in Java',
+        language: 'java',
+        url: 'https://github.com/microclimate-dev2ops/lagomJavaTemplate',
+        projectType: 'docker',
+    },
+    {
+        label: 'Java MicroProfile template',
+        description: 'Cloud Microservice Starter for Java - MicroProfile / Java EE',
+        language: 'java',
+        url: 'https://github.com/microclimate-dev2ops/javaMicroProfileTemplate',
+        projectType: 'liberty',
+    },
+    {
+        label: 'Node.js template',
+        description: 'Cloud-ready Node.js Express sample application',
+        language: 'nodejs',
+        url: 'https://github.com/microclimate-dev2ops/nodeExpressTemplate',
+        projectType: 'nodejs',
+    },
+    {
+        label: 'Open Liberty template',
+        description: 'Template for building an Open Liberty microservice in Java',
+        language: 'java',
+        url: 'https://github.com/microclimate-dev2ops/openLibertyTemplate',
+        projectType: 'docker',
+    },
+    {
+        label: 'Python template',
+        description: 'HelloWorld microservice written in python',
+        language: 'python',
+        url: 'https://github.com/microclimate-dev2ops/SVTPythonTemplate',
+        projectType: 'docker',
+    },
+    {
+        label: 'Spring template',
+        description: 'Template for building a Spring microservice',
+        language: 'java',
+        url: 'https://github.com/microclimate-dev2ops/springJavaTemplate',
+        projectType: 'spring',
+    },
+    {
+        label: 'Swift microservice template',
+        description: 'Template for building a Swift microservice',
+        language: 'swift',
+        url: 'https://github.com/microclimate-dev2ops/swiftTemplate',
+        projectType: 'swift',
+    },
+];
+
+const styledTemplates = {
+    codewind: {
+        label: 'Codewind template',
+        description: 'Codewind template',
+        language: 'go',
+        url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
+        projectType: 'docker',
+    },
+    appsody: {
+        label: 'Appsody template',
+        description: 'Appsody stack',
+        language: 'nodejs',
+        url: 'https://github.com/appsody/template/repo',
+        projectType: 'nodejs',
+        projectStyle: 'Appsody',
+    },
+};
+
+const defaultTemplateRepo = {
+    url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
+    description: 'Default codewind templates.',
+    enabled: true,
+};
+const defaultTemplateRepos = [defaultTemplateRepo];
+
+async function getTemplateRepos() {
+    const res = await reqService.chai
+        .get('/api/v1/templates/repositories')
+        .set('Cookie', ADMIN_COOKIE);
+    return res;
+}
+
+async function addTemplateRepo({ url, description }) {
+    const res = await reqService.chai
+        .post('/api/v1/templates/repositories')
+        .set('Cookie', ADMIN_COOKIE)
+        .send({ url, description });
+    return res;
+}
+
+async function deleteTemplateRepo(repoUrl) {
+    const res = await reqService.chai
+        .delete('/api/v1/templates/repositories')
+        .set('Cookie', ADMIN_COOKIE)
+        .send({ url: repoUrl });
+    return res;
+}
+
+async function patchTemplateRepos(operations) {
+    const res = await reqService.chai
+        .patch('/api/v1/templates/repositories/')
+        .set('Cookie', ADMIN_COOKIE)
+        .send(operations);
+    return res;
+}
+
+async function enableTemplateRepo(repoUrl) {
+    const operation = {
+        op: 'enable',
+        path: repoUrl,
+        value: 'true',
+    };
+    const res = await patchTemplateRepos([operation]);
+    return res;
+}
+
+async function disableTemplateRepo(repoUrl) {
+    const operation = {
+        op: 'enable',
+        path: repoUrl,
+        value: 'false',
+    };
+    const res = await patchTemplateRepos([operation]);
+    return res;
+}
+
+async function getTemplates(queryParams) {
+    const res = await reqService.chai
+        .get('/api/v1/templates')
+        .query(queryParams)
+        .set('Cookie', ADMIN_COOKIE);
+    return res;
+}
+
+async function resetTemplateRepos(repoList) {
+    await Promise.all(repoList.map(repo =>
+        deleteTemplateRepo(repo.url)
+    ));
+    await Promise.all(repoList.map(repo =>
+        addTemplateRepo(repo)
+    ));
+}
+
+async function getTemplateStyles() {
+    const res = await reqService.chai
+        .get('/api/v1/templates/styles')
+        .set('Cookie', ADMIN_COOKIE);
+    return res;
+}
+
+module.exports = {
+    defaultTemplates,
+    styledTemplates,
+    defaultTemplateRepo,
+    defaultTemplateRepos,
+    getTemplateRepos,
+    addTemplateRepo,
+    deleteTemplateRepo,
+    patchTemplateRepos,
+    enableTemplateRepo,
+    disableTemplateRepo,
+    getTemplates,
+    resetTemplateRepos,
+    getTemplateStyles,
+};

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -77,6 +77,7 @@ const styledTemplates = {
         language: 'go',
         url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
         projectType: 'docker',
+        // defaults to projectStyle 'Codewind'
     },
     appsody: {
         label: 'Appsody template',
@@ -87,13 +88,6 @@ const styledTemplates = {
         projectStyle: 'Appsody',
     },
 };
-
-const defaultTemplateRepo = {
-    url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-    description: 'Default codewind templates.',
-    enabled: true,
-};
-const defaultTemplateRepos = [defaultTemplateRepo];
 
 async function getTemplateRepos() {
     const res = await reqService.chai
@@ -173,8 +167,6 @@ async function getTemplateStyles() {
 module.exports = {
     defaultTemplates,
     styledTemplates,
-    defaultTemplateRepo,
-    defaultTemplateRepos,
     getTemplateRepos,
     addTemplateRepo,
     deleteTemplateRepo,

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -89,12 +89,18 @@ const styledTemplates = {
     },
 };
 
-const defaultRepo = {
-    url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-    description: 'Standard Codewind templates.',
-    enabled: true,
+const sampleRepos = {
+    default: {
+        url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
+        description: 'Standard Codewind templates.',
+        enabled: true,
+    },
+    appsody: {
+        url: 'https://raw.githubusercontent.com/kabanero-io/codewind-appsody-templates/master/devfiles/index.json',
+        description: 'Appsody extension for Codewind',
+    },
 };
-const defaultRepoList = [defaultRepo];
+const defaultRepoList = [sampleRepos.default];
 
 async function getTemplateRepos() {
     const res = await reqService.chai
@@ -127,23 +133,27 @@ async function batchPatchTemplateRepos(operations) {
     return res;
 }
 
-async function enableTemplateRepo(repoUrl) {
-    const operation = {
-        op: 'enable',
-        url: repoUrl,
-        value: 'true',
-    };
-    const res = await batchPatchTemplateRepos([operation]);
+async function enableTemplateRepos(repoUrls) {
+    const operations = repoUrls.map(url => {
+        return {
+            url,
+            op: 'enable',
+            value: 'true',
+        };
+    });
+    const res = await batchPatchTemplateRepos(operations);
     return res;
 }
 
-async function disableTemplateRepo(repoUrl) {
-    const operation = {
-        op: 'enable',
-        url: repoUrl,
-        value: 'false',
-    };
-    const res = await batchPatchTemplateRepos([operation]);
+async function disableTemplateRepos(repoUrls) {
+    const operations = repoUrls.map(url => {
+        return {
+            url,
+            op: 'enable',
+            value: 'false',
+        };
+    });
+    const res = await batchPatchTemplateRepos(operations);
     return res;
 }
 
@@ -155,8 +165,9 @@ async function getTemplates(queryParams) {
     return res;
 }
 
-async function resetTemplateRepos(repoList) {
-    await Promise.all(repoList.map(repo =>
+async function resetTemplateReposTo(repoList) {
+    const reposToDelete = (await getTemplateRepos()).body;
+    await Promise.all(reposToDelete.map(repo =>
         deleteTemplateRepo(repo.url)
     ));
     await Promise.all(repoList.map(repo =>
@@ -174,14 +185,15 @@ async function getTemplateStyles() {
 module.exports = {
     defaultTemplates,
     styledTemplates,
+    sampleRepos,
     defaultRepoList,
     getTemplateRepos,
     addTemplateRepo,
     deleteTemplateRepo,
     batchPatchTemplateRepos,
-    enableTemplateRepo,
-    disableTemplateRepo,
+    enableTemplateRepos,
+    disableTemplateRepos,
     getTemplates,
-    resetTemplateRepos,
+    resetTemplateReposTo,
     getTemplateStyles,
 };

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -112,9 +112,9 @@ async function deleteTemplateRepo(repoUrl) {
     return res;
 }
 
-async function patchTemplateRepos(operations) {
+async function batchPatchTemplateRepos(operations) {
     const res = await reqService.chai
-        .patch('/api/v1/templates/repositories/')
+        .patch('/api/v1/batch/templates/repositories')
         .set('Cookie', ADMIN_COOKIE)
         .send(operations);
     return res;
@@ -123,20 +123,20 @@ async function patchTemplateRepos(operations) {
 async function enableTemplateRepo(repoUrl) {
     const operation = {
         op: 'enable',
-        path: repoUrl,
+        url: repoUrl,
         value: 'true',
     };
-    const res = await patchTemplateRepos([operation]);
+    const res = await batchPatchTemplateRepos([operation]);
     return res;
 }
 
 async function disableTemplateRepo(repoUrl) {
     const operation = {
         op: 'enable',
-        path: repoUrl,
+        url: repoUrl,
         value: 'false',
     };
-    const res = await patchTemplateRepos([operation]);
+    const res = await batchPatchTemplateRepos([operation]);
     return res;
 }
 
@@ -170,7 +170,7 @@ module.exports = {
     getTemplateRepos,
     addTemplateRepo,
     deleteTemplateRepo,
-    patchTemplateRepos,
+    batchPatchTemplateRepos,
     enableTemplateRepo,
     disableTemplateRepo,
     getTemplates,

--- a/test/src/integration/templates/enableRepo.test.js
+++ b/test/src/integration/templates/enableRepo.test.js
@@ -52,8 +52,6 @@ describe('Enabling a template repository', function() {
     it(`repo appears as disabled in list of template repos`, async function() {
         const res = await getTemplateRepos();
         res.should.have.status(200);
-        console.log('repo appears as disabled in list of template repos: res.body');
-        console.log(res.body);
         res.body.should.deep.include({
             ...repoToTest,
             enabled: false,

--- a/test/src/integration/templates/enableRepo.test.js
+++ b/test/src/integration/templates/enableRepo.test.js
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const chai = require('chai');
+
+const {
+    getTemplateRepos,
+    enableTemplateRepo,
+    disableTemplateRepo,
+    getTemplates,
+    resetTemplateRepos,
+} = require('../../../modules/template.service');
+
+chai.should();
+
+describe('Enabling a template repository', function() {
+    let originalTemplateRepos;
+    let repoUrl;
+    before(async() => {
+        const res = await getTemplateRepos();
+        originalTemplateRepos = res.body;
+        repoUrl = originalTemplateRepos[0].url;
+    });
+    after(async() => {
+        await resetTemplateRepos(originalTemplateRepos);
+    });
+    it(`can list template repositories`, async function() {
+        const res = await getTemplateRepos();
+        res.should.have.status(200);
+        res.body.should.deep.equal(originalTemplateRepos);
+    });
+    it(`enabling a template repo returns 207 and sub-status 200`, async function() {
+        const res = await enableTemplateRepo(repoUrl);
+        res.should.have.status(207);
+        res.body[0].status.should.equal(200);
+    });
+    it(`repo appears as enabled in list of template repos`, async function() {
+        const res = await getTemplateRepos();
+        res.should.have.status(200);
+        res.body.should.deep.include({
+            url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
+            description: 'Default codewind templates.',
+            enabled: true,
+        });
+    });
+    it(`disabling that template repo returns 207 and sub-status 200`, async function() {
+        const res = await disableTemplateRepo(repoUrl);
+        res.should.have.status(207);
+        res.body[0].status.should.equal(200);
+    });
+    it(`repo appears as disabled in list of template repos`, async function() {
+        const res = await getTemplateRepos();
+        res.should.have.status(200);
+        res.body.should.deep.include({
+            url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
+            description: 'Default codewind templates.',
+            enabled: false,
+        });
+    });
+    it(`templates from the disabled repo do not appear in list of enabled templates`, async function() {
+        const res = await getTemplates({ showEnabledOnly: true });
+        res.should.have.status(204);
+        // TODO: switch over to the below when we have 2 repos (so that 1 repo can still be enabled, so we return 200 rather than 204 No Content)
+        // res.should.have.status(200)
+        // res.body.should.not.include.deep.members(defaultTemplates);
+    });
+});

--- a/test/src/integration/templates/enableRepo.test.js
+++ b/test/src/integration/templates/enableRepo.test.js
@@ -27,14 +27,11 @@ describe('Enabling a template repository', function() {
         const res = await getTemplateRepos();
         originalTemplateRepos = res.body;
         repoUrl = originalTemplateRepos[0].url;
+        console.log('can list template repositories');
+        console.log(res.body);
     });
     after(async() => {
         await resetTemplateRepos(originalTemplateRepos);
-    });
-    it(`can list template repositories`, async function() {
-        const res = await getTemplateRepos();
-        res.should.have.status(200);
-        res.body.should.deep.equal(originalTemplateRepos);
     });
     it(`enabling a template repo returns 207 and sub-status 200`, async function() {
         const res = await enableTemplateRepo(repoUrl);
@@ -44,6 +41,8 @@ describe('Enabling a template repository', function() {
     it(`repo appears as enabled in list of template repos`, async function() {
         const res = await getTemplateRepos();
         res.should.have.status(200);
+        console.log('repo appears as enabled in list of template repos: res.body');
+        console.log(res.body);
         res.body.should.deep.include({
             url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
             description: 'Default codewind templates.',
@@ -58,6 +57,8 @@ describe('Enabling a template repository', function() {
     it(`repo appears as disabled in list of template repos`, async function() {
         const res = await getTemplateRepos();
         res.should.have.status(200);
+        console.log('repo appears as disabled in list of template repos: res.body');
+        console.log(res.body);
         res.body.should.deep.include({
             url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
             description: 'Default codewind templates.',

--- a/test/src/integration/templates/enableRepo.test.js
+++ b/test/src/integration/templates/enableRepo.test.js
@@ -20,7 +20,7 @@ const {
 
 chai.should();
 
-describe('Enabling a template repository', function() {
+describe('Enabling template repositories in batches', function() {
     let originalTemplateRepos;
     let repoToTest;
     before(async() => {
@@ -31,12 +31,12 @@ describe('Enabling a template repository', function() {
     after(async() => {
         await resetTemplateRepos(originalTemplateRepos);
     });
-    it(`enabling a template repo returns 207 and sub-status 200`, async function() {
+    it(`batch enabling a single template repo returns 207 and sub-status 200`, async function() {
         const res = await enableTemplateRepo(repoToTest.url);
         res.should.have.status(207);
         res.body[0].status.should.equal(200);
     });
-    it(`repo appears as enabled in list of template repos`, async function() {
+    it(`that repo appears as enabled in list of template repos`, async function() {
         const res = await getTemplateRepos();
         res.should.have.status(200);
         res.body.should.deep.include({
@@ -44,12 +44,12 @@ describe('Enabling a template repository', function() {
             enabled: true,
         });
     });
-    it(`disabling that template repo returns 207 and sub-status 200`, async function() {
+    it(`batch disabling that template repo returns 207 and sub-status 200`, async function() {
         const res = await disableTemplateRepo(repoToTest.url);
         res.should.have.status(207);
         res.body[0].status.should.equal(200);
     });
-    it(`repo appears as disabled in list of template repos`, async function() {
+    it(`that repo appears as disabled in list of template repos`, async function() {
         const res = await getTemplateRepos();
         res.should.have.status(200);
         res.body.should.deep.include({

--- a/test/src/integration/templates/enableRepo.test.js
+++ b/test/src/integration/templates/enableRepo.test.js
@@ -11,57 +11,117 @@
 const chai = require('chai');
 
 const {
+    sampleRepos,
     getTemplateRepos,
-    enableTemplateRepo,
-    disableTemplateRepo,
+    addTemplateRepo,
+    enableTemplateRepos,
+    disableTemplateRepos,
     getTemplates,
-    resetTemplateRepos,
+    resetTemplateReposTo,
 } = require('../../../modules/template.service');
 
 chai.should();
 
-describe('Enabling template repositories in batches', function() {
-    let originalTemplateRepos;
-    let repoToTest;
-    before(async() => {
-        const res = await getTemplateRepos();
-        originalTemplateRepos = res.body;
-        repoToTest = originalTemplateRepos[0];
-    });
-    after(async() => {
-        await resetTemplateRepos(originalTemplateRepos);
-    });
-    it(`batch enabling a single template repo returns 207 and sub-status 200`, async function() {
-        const res = await enableTemplateRepo(repoToTest.url);
-        res.should.have.status(207);
-        res.body[0].status.should.equal(200);
-    });
-    it(`that repo appears as enabled in list of template repos`, async function() {
-        const res = await getTemplateRepos();
-        res.should.have.status(200);
-        res.body.should.deep.include({
-            ...repoToTest,
-            enabled: true,
+describe('Batch enabling template repositories', function() {
+    describe('when enabling a single repo', function() {
+        let originalTemplateRepos;
+        let repoToTest;
+        before(async() => {
+            const res = await getTemplateRepos();
+            originalTemplateRepos = res.body;
+            repoToTest = { ...originalTemplateRepos[0] };
+        });
+        after(async() => {
+            await resetTemplateReposTo(originalTemplateRepos);
+        });
+        it(`batch enabling a single template repo returns 207 and sub-status 200`, async function() {
+            const res = await enableTemplateRepos([repoToTest.url]);
+            res.should.have.status(207);
+            res.body[0].status.should.equal(200);
+        });
+        it(`that repo appears as enabled in list of template repos`, async function() {
+            const res = await getTemplateRepos();
+            res.should.have.status(200);
+            res.body.should.deep.include({
+                ...repoToTest,
+                enabled: true,
+            });
+        });
+        it(`batch disabling that template repo returns 207 and sub-status 200`, async function() {
+            const res = await disableTemplateRepos([repoToTest.url]);
+            res.should.have.status(207);
+            res.body[0].status.should.equal(200);
+        });
+        it(`that repo appears as disabled in list of template repos`, async function() {
+            const res = await getTemplateRepos();
+            res.should.have.status(200);
+            res.body.should.deep.include({
+                ...repoToTest,
+                enabled: false,
+            });
+        });
+        it(`templates from the disabled repo do not appear in list of enabled templates`, async function() {
+            const res = await getTemplates({ showEnabledOnly: true });
+            res.should.have.status(204);
+            // TODO: switch over to the below when we have 2 repos (so that 1 repo can still be enabled, so we return 200 rather than 204 No Content)
+            // res.should.have.status(200)
+            // res.body.should.not.include.deep.members(defaultTemplates);
         });
     });
-    it(`batch disabling that template repo returns 207 and sub-status 200`, async function() {
-        const res = await disableTemplateRepo(repoToTest.url);
-        res.should.have.status(207);
-        res.body[0].status.should.equal(200);
-    });
-    it(`that repo appears as disabled in list of template repos`, async function() {
-        const res = await getTemplateRepos();
-        res.should.have.status(200);
-        res.body.should.deep.include({
-            ...repoToTest,
-            enabled: false,
+    describe('when enabling multiple template repositories', function() {
+        let originalTemplateRepos;
+        let reposToTest;
+        before(async() => {
+            const res = await getTemplateRepos();
+            originalTemplateRepos = res.body;
+
+            await addTemplateRepo(sampleRepos.appsody);
+            const res2 = await getTemplateRepos();
+            reposToTest = [...res2.body];
         });
-    });
-    it(`templates from the disabled repo do not appear in list of enabled templates`, async function() {
-        const res = await getTemplates({ showEnabledOnly: true });
-        res.should.have.status(204);
-        // TODO: switch over to the below when we have 2 repos (so that 1 repo can still be enabled, so we return 200 rather than 204 No Content)
-        // res.should.have.status(200)
-        // res.body.should.not.include.deep.members(defaultTemplates);
+        after(async function() {
+            await resetTemplateReposTo(originalTemplateRepos);
+        });
+        it(`batch enabling multiple template repos returns 207 and sub-status 200 for each subrequest`, async function() {
+            const repoUrls = reposToTest.map(repo => repo.url);
+            const res = await enableTemplateRepos(repoUrls);
+            res.should.have.status(207);
+            res.body.forEach(subResponse =>
+                subResponse.status.should.equal(200)
+            );
+        });
+        it(`those repos appear as enabled in list of template repos`, async function() {
+            const res = await getTemplateRepos();
+            res.should.have.status(200);
+            reposToTest.forEach(repo =>
+                res.body.should.deep.include({
+                    ...repo,
+                    enabled: true,
+                })
+            );
+        });
+        it(`batch disabling multiple template repos returns 207 and sub-status 200 for each subrequest`, async function() {
+            const repoUrls = reposToTest.map(repo => repo.url);
+            const res = await disableTemplateRepos(repoUrls);
+            res.should.have.status(207);
+            res.body[0].status.should.equal(200);
+        });
+        it(`those repos appear as disabled in list of template repos`, async function() {
+            const res = await getTemplateRepos();
+            res.should.have.status(200);
+            reposToTest.forEach(repo =>
+                res.body.should.deep.include({
+                    ...repo,
+                    enabled: false,
+                })
+            );
+        });
+        it(`templates from the disabled repos do not appear in list of enabled templates`, async function() {
+            const res = await getTemplates({ showEnabledOnly: true });
+            res.should.have.status(204);
+            // TODO: switch over to the below when we have 2 repos (so that 1 repo can still be enabled, so we return 200 rather than 204 No Content)
+            // res.should.have.status(200)
+            // res.body.should.not.include.deep.members(defaultTemplates);
+        });
     });
 });

--- a/test/src/integration/templates/enableRepo.test.js
+++ b/test/src/integration/templates/enableRepo.test.js
@@ -22,35 +22,30 @@ chai.should();
 
 describe('Enabling a template repository', function() {
     let originalTemplateRepos;
-    let repoUrl;
+    let repoToTest;
     before(async() => {
         const res = await getTemplateRepos();
         originalTemplateRepos = res.body;
-        repoUrl = originalTemplateRepos[0].url;
-        console.log('can list template repositories');
-        console.log(res.body);
+        repoToTest = originalTemplateRepos[0];
     });
     after(async() => {
         await resetTemplateRepos(originalTemplateRepos);
     });
     it(`enabling a template repo returns 207 and sub-status 200`, async function() {
-        const res = await enableTemplateRepo(repoUrl);
+        const res = await enableTemplateRepo(repoToTest.url);
         res.should.have.status(207);
         res.body[0].status.should.equal(200);
     });
     it(`repo appears as enabled in list of template repos`, async function() {
         const res = await getTemplateRepos();
         res.should.have.status(200);
-        console.log('repo appears as enabled in list of template repos: res.body');
-        console.log(res.body);
         res.body.should.deep.include({
-            url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-            description: 'Default codewind templates.',
+            ...repoToTest,
             enabled: true,
         });
     });
     it(`disabling that template repo returns 207 and sub-status 200`, async function() {
-        const res = await disableTemplateRepo(repoUrl);
+        const res = await disableTemplateRepo(repoToTest.url);
         res.should.have.status(207);
         res.body[0].status.should.equal(200);
     });
@@ -60,8 +55,7 @@ describe('Enabling a template repository', function() {
         console.log('repo appears as disabled in list of template repos: res.body');
         console.log(res.body);
         res.body.should.deep.include({
-            url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-            description: 'Default codewind templates.',
+            ...repoToTest,
             enabled: false,
         });
     });

--- a/test/src/templates.test.js
+++ b/test/src/templates.test.js
@@ -18,7 +18,7 @@ const {
     getTemplates,
     addTemplateRepo,
     deleteTemplateRepo,
-    resetTemplateRepos,
+    resetTemplateReposTo,
     getTemplateStyles,
 } = require('../modules/template.service');
 
@@ -46,7 +46,6 @@ describe('Template API tests', function() {
                         res.body.should.be.an('array');
                         res.body.forEach((template) => {
                             template.should.be.an('object').with.all.keys('label', 'description', 'url', 'language', 'projectType');
-                            if (template.projectStyle) template.projectStyle.should.equal(projectStyle);
                         });
                         // check that we have a template for each supported language
                         res.body.map((template) => template.language).should.include.members(expectedLanguages);
@@ -87,7 +86,7 @@ describe('Template API tests', function() {
             originalTemplateRepos = res.body;
         });
         after(async() => {
-            await resetTemplateRepos(originalTemplateRepos);
+            await resetTemplateReposTo(originalTemplateRepos);
         });
         it('GET should return a list of available templates repositories', async function() {
             const res = await getTemplateRepos();
@@ -243,7 +242,7 @@ describe('Template API tests', function() {
             originalTemplateRepos = res.body;
         });
         afterEach(async() => {
-            await resetTemplateRepos(originalTemplateRepos);
+            await resetTemplateReposTo(originalTemplateRepos);
         });
         for (const [testName, test] of Object.entries(tests)) {
             describe(`to ${testName}`, function() {

--- a/test/src/templates.test.js
+++ b/test/src/templates.test.js
@@ -103,6 +103,13 @@ describe('Template API tests', function() {
             });
             res.should.have.status(400);
         });
+        it('POST should fail to add template repository with a duplicate url', async function() {
+            const res = await addTemplateRepo({
+                url: originalTemplateRepos[0].url,
+                description: 'Duplicate template URL',
+            });
+            res.should.have.status(400);
+        });
         it('DELETE should remove a template repository', async function() {
             const res = await deleteTemplateRepo(expectedUrl);
             res.should.have.status(200);

--- a/test/src/templates.test.js
+++ b/test/src/templates.test.js
@@ -11,45 +11,77 @@
 
 const chai = require('chai');
 
-const reqService = require('../modules/request.service');
-const { ADMIN_COOKIE } = require('../config');
+const {
+    defaultTemplates,
+    patchTemplateRepos,
+    getTemplateRepos,
+    getTemplates,
+    addTemplateRepo,
+    deleteTemplateRepo,
+    resetTemplateRepos,
+    getTemplateStyles,
+} = require('../modules/template.service');
 
 chai.should();
 const expectedLanguages = ['java', 'swift', 'nodejs', 'go', 'python'];
 
 describe('Template API tests', function() {
-    describe('GET /api/v1/templates?projectStyle=', function() {
-        describe('empty', function() {
-            it('should return a list of all available templates', async function() {
-                const res = await getTemplates();
-                res.should.have.status(200);
-                res.body.should.be.an('array');
-                res.body.forEach((template) => {
-                    template.should.be.an('object').with.all.keys('label', 'description', 'url', 'language', 'projectType');
-                });
-                // check that we have a template for each supported language
-                res.body.map((template) => template.language).should.include.members(expectedLanguages);
-            });
-        });
-        for (const projectStyle of ['Codewind']) {  // TODO: add 'Appsody' when we ship Appsody templates by default
-            describe(projectStyle, function() {
-                it(`should return only ${projectStyle} templates`, async function() {
-                    const res = await getTemplates(projectStyle);
+    let originalTemplateRepos;
+    before(async() => {
+        const res = await getTemplateRepos();
+        originalTemplateRepos = res.body;
+    });
+    after(async() => {
+        await resetTemplateRepos(originalTemplateRepos);
+    });
+    describe('GET /api/v1/templates', function() {
+        describe('?projectStyle=', function() {
+            describe('empty', function() {
+                it('should return a list of all available templates', async function() {
+                    const res = await getTemplates();
                     res.should.have.status(200);
                     res.body.should.be.an('array');
-                    res.body.forEach((template) => {
-                        template.should.be.an('object').with.all.keys('label', 'description', 'url', 'language', 'projectType');
-                        if (template.projectStyle) template.projectStyle.should.equal(projectStyle);
-                    });
+                    res.body.should.deep.equal(defaultTemplates);
                     // check that we have a template for each supported language
                     res.body.map((template) => template.language).should.include.members(expectedLanguages);
                 });
             });
-        }
-        describe('unknownStyle', function() {
-            it('should return 204', async function() {
-                const res = await getTemplates('unknownStyle');
-                res.should.have.status(204);
+            for (const projectStyle of ['Codewind']) {  // TODO: add 'Appsody' when we ship Appsody templates by default
+                describe(projectStyle, function() {
+                    it(`should return only ${projectStyle} templates`, async function() {
+                        const res = await getTemplates({ projectStyle });
+                        res.should.have.status(200);
+                        res.body.should.be.an('array');
+                        res.body.forEach((template) => {
+                            template.should.be.an('object').with.all.keys('label', 'description', 'url', 'language', 'projectType');
+                            if (template.projectStyle) template.projectStyle.should.equal(projectStyle);
+                        });
+                        // check that we have a template for each supported language
+                        res.body.map((template) => template.language).should.include.members(expectedLanguages);
+                    });
+                });
+            }
+            describe('unknownStyle', function() {
+                it('should return 204', async function() {
+                    const res = await getTemplates({ projectStyle: 'unknownStyle' });
+                    res.should.have.status(204);
+                });
+            });
+        });
+        describe('?showEnabledOnly=', function() {
+            describe('false', function() {
+                it('should return all templates (from enabled and disabled repos)', async function() {
+                    const res = await getTemplates({ showEnabledOnly: false });
+                    res.should.have.status(200);
+                    res.body.should.deep.equal(defaultTemplates);
+                });
+            });
+            describe('true', function() {
+                it('should return only templates from enabled repos', async function() {
+                    const res = await getTemplates({ showEnabledOnly: true });
+                    res.should.have.status(200);
+                    res.body.should.deep.equal(defaultTemplates);
+                });
             });
         });
     });
@@ -58,22 +90,22 @@ describe('Template API tests', function() {
         const expectedUrl = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json';
         const testUrl = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json';
         it('GET should return a list of available templates repositories', async function() {
-            const res = await getTemplateRepositories();
+            const res = await getTemplateRepos();
             res.should.have.status(200);
             res.body.should.be.an('array').with.length(1);
             res.body.forEach((repository) => {
-                repository.should.be.an('object').with.all.keys('description', 'url');
+                repository.should.be.an('object').with.keys('description', 'url');
             });
         });
         it('POST should fail to add template repository with a bad url', async function() {
-            const res = await addTemplateRepository({
+            const res = await addTemplateRepo({
                 url: '/home/user/directory',
                 description: 'Bad template url.',
             });
             res.should.have.status(400);
         });
         it('DELETE should remove a template repository', async function() {
-            const res = await deleteTemplateRepository(expectedUrl);
+            const res = await deleteTemplateRepo(expectedUrl);
             res.should.have.status(200);
             res.body.should.be.an('array');
             res.body.should.have.length(0);
@@ -83,7 +115,7 @@ describe('Template API tests', function() {
             res.should.have.status(204);
         });
         it('POST should add a template repository', async function() {
-            const res = await addTemplateRepository({
+            const res = await addTemplateRepo({
                 url: expectedUrl,
                 description: 'Default codewind templates.',
             });
@@ -102,11 +134,9 @@ describe('Template API tests', function() {
                 repository.should.be.an('object').with.all.keys('label', 'description', 'url', 'language', 'projectType');
             });
             firstLength = res.body.length;
-            // check that we have a template for each supported language
-            res.body.map((template) => template.language).should.include.members(expectedLanguages);
         });
         it('POST should add a second template repository', async function() {
-            const res = await addTemplateRepository({
+            const res = await addTemplateRepo({
                 url: testUrl,
                 description: 'Copy of default codewind templates.',
             });
@@ -125,11 +155,9 @@ describe('Template API tests', function() {
             });
             // There are 6 templates listed in the revision referenced by testUrl
             res.body.should.have.length(firstLength + 7);
-            // check that we have a template for each supported language
-            res.body.map((template) => template.language).should.include.members(expectedLanguages);
         });
         it('DELETE should remove second repository', async function() {
-            const res = await deleteTemplateRepository(testUrl);
+            const res = await deleteTemplateRepo(testUrl);
             res.should.have.status(200);
             res.body.should.be.an('array').with.length(1);
         });
@@ -141,9 +169,83 @@ describe('Template API tests', function() {
                 repository.should.be.an('object').with.all.keys('label', 'description', 'url', 'language', 'projectType');
             });
             res.body.should.have.length(firstLength);
-            // check that we have a template for each supported language
-            res.body.map((template) => template.language).should.include.members(expectedLanguages);
         });
+    });
+    describe('PATCH /api/v1/templates/repositories', function() {
+        const existingRepoUrl = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json';
+        const tests = {
+            'enable an existing repo': {
+                input: [{
+                    op: 'enable',
+                    path: existingRepoUrl,
+                    value: 'true',
+                }],
+                output: [{
+                    status: 200,
+                    requestedOperation: {
+                        op: 'enable',
+                        path: existingRepoUrl,
+                        value: 'true',
+                    },
+                }],
+            },
+            'disable an existing repo': {
+                input: [{
+                    op: 'enable',
+                    path: existingRepoUrl,
+                    value: 'false',
+                }],
+                output: [{
+                    status: 200,
+                    requestedOperation: {
+                        op: 'enable',
+                        path: existingRepoUrl,
+                        value: 'false',
+                    },
+                }],
+            },
+            'enable an unknown repo': {
+                input: [{
+                    op: 'enable',
+                    path: 'unknownRepoUrl',
+                    value: 'true',
+                }],
+                output: [{
+                    status: 404,
+                    error: 'Unknown repository URL',
+                    requestedOperation: {
+                        op: 'enable',
+                        path: 'unknownRepoUrl',
+                        value: 'true',
+                    },
+                }],
+            },
+            'disable an unknown repo': {
+                input: [{
+                    op: 'enable',
+                    path: 'unknownRepoUrl',
+                    value: 'false',
+                }],
+                output: [{
+                    status: 404,
+                    error: 'Unknown repository URL',
+                    requestedOperation: {
+                        op: 'enable',
+                        path: 'unknownRepoUrl',
+                        value: 'false',
+                    },
+                }],
+            },
+        };
+        for (const [testName, test] of Object.entries(tests)) {
+            describe(`to ${testName}`, function() {
+                it(`should return 207 and the expected operations info`, async function() {
+                    const res = await patchTemplateRepos(test.input);
+                    res.should.have.status(207);
+                    res.body.should.deep.equal(test.output);
+                });
+            });
+        }
     });
     describe('GET /api/v1/templates/styles', function() {
         it('should return a list of available template styles', async function() {
@@ -153,41 +255,3 @@ describe('Template API tests', function() {
         });
     });
 });
-
-async function getTemplates(projectStyle) {
-    const res = await reqService.chai
-        .get('/api/v1/templates')
-        .query({ projectStyle })
-        .set('Cookie', ADMIN_COOKIE);
-    return res;
-}
-
-async function getTemplateRepositories() {
-    const res = await reqService.chai
-        .get('/api/v1/templates/repositories')
-        .set('Cookie', ADMIN_COOKIE);
-    return res;
-}
-
-async function addTemplateRepository({ url, description }) {
-    const res = await reqService.chai
-        .post('/api/v1/templates/repositories')
-        .set('Cookie', ADMIN_COOKIE)
-        .send({ url, description });
-    return res;
-}
-
-async function deleteTemplateRepository(repoUrl) {
-    const res = await reqService.chai
-        .delete('/api/v1/templates/repositories')
-        .set('Cookie', ADMIN_COOKIE)
-        .send({ url: repoUrl });
-    return res;
-}
-
-async function getTemplateStyles() {
-    const res = await reqService.chai
-        .get('/api/v1/templates/styles')
-        .set('Cookie', ADMIN_COOKIE);
-    return res;
-}

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -47,7 +47,6 @@ const sampleRepos = {
 const sampleRepoList = Object.values(sampleRepos);
 
 describe('Templates.js', function() {
-    // class functions
     describe('getTemplateStyles() when Codewind is aware of:', function() {
         describe('Codewind and Appsody templates', function() {
             const sampleTemplateList = [
@@ -382,7 +381,7 @@ describe('Templates.js', function() {
             };
             for (const [testName, test] of Object.entries(tests)) {
                 describe(testName, function() { // eslint-disable-line
-                    it(`returns the expectedNumTemplates operation info`, async function() {
+                    it(`returns the expected operation info`, async function() {
                         const output = await templateController.performOperation(test.input);
                         output.should.deep.equal(test.output);
 
@@ -429,7 +428,7 @@ describe('Templates.js', function() {
             };
             for (const [testName, test] of Object.entries(tests)) {
                 describe(testName, function() { // eslint-disable-line
-                    it(`returns the expectedNumTemplates operation info`, async function() {
+                    it(`returns the expected operation info`, async function() {
                         const output = await templateController.performOperation(test.input);
                         output.should.deep.equal(test.output);
                     });
@@ -451,7 +450,7 @@ describe('Templates.js', function() {
             });
         });
     });
-    // Non-class functions
+
     describe('filterTemplatesByStyle(templates, projectStyle)', function() {
         const templates = [sampleCodewindTemplate, sampleAppsodyTemplate];
         describe(`projectStyle='Codewind'`, function() {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -205,19 +205,19 @@ describe('Templates.js', function() {
         afterEach(() => {
             fs.removeSync(testWorkspaceDir);
         });
-        describe('when `operation.path` is an existing url', function() {
+        describe('when `operation.url` is an existing url', function() {
             const tests = {
                 'enable an existing repo': {
                     input: {
                         op: 'enable',
-                        path: '1',
+                        url: '1',
                         value: 'true',
                     },
                     output: {
                         status: 200,
                         requestedOperation: {
                             op: 'enable',
-                            path: '1',
+                            url: '1',
                             value: 'true',
                         },
                     },
@@ -230,14 +230,14 @@ describe('Templates.js', function() {
                 'disable an existing repo': {
                     input: {
                         op: 'enable',
-                        path: '1',
+                        url: '1',
                         value: 'false',
                     },
                     output: {
                         status: 200,
                         requestedOperation: {
                             op: 'enable',
-                            path: '1',
+                            url: '1',
                             value: 'false',
                         },
                     },
@@ -260,12 +260,12 @@ describe('Templates.js', function() {
                 });
             }
         });
-        describe('when `operation.path` is an unknown url', function() {
+        describe('when `operation.url` is an unknown url', function() {
             const tests = {
                 'enable an unknown repo': {
                     input: {
                         op: 'enable',
-                        path: 'unknownRepoUrl',
+                        url: 'unknownRepoUrl',
                         value: 'true',
                     },
                     output: {
@@ -273,7 +273,7 @@ describe('Templates.js', function() {
                         error: 'Unknown repository URL',
                         requestedOperation: {
                             op: 'enable',
-                            path: 'unknownRepoUrl',
+                            url: 'unknownRepoUrl',
                             value: 'true',
                         },
                     },
@@ -281,7 +281,7 @@ describe('Templates.js', function() {
                 'disable an unknown repo': {
                     input: {
                         op: 'enable',
-                        path: 'unknownRepoUrl',
+                        url: 'unknownRepoUrl',
                         value: 'false',
                     },
                     output: {
@@ -289,7 +289,7 @@ describe('Templates.js', function() {
                         error: 'Unknown repository URL',
                         requestedOperation: {
                             op: 'enable',
-                            path: 'unknownRepoUrl',
+                            url: 'unknownRepoUrl',
                             value: 'false',
                         },
                     },

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -534,7 +534,7 @@ describe('Templates.js', function() {
                 },
             };
             for (const [testName, test] of Object.entries(tests)) {
-                describe.only(testName, function() { // eslint-disable-line
+                describe(testName, function() { // eslint-disable-line
                     it(`returns the expected operation info and correctly updates the repository file`, async function() {
                         const output = await templateController.batchUpdate(test.input);
                         output.should.deep.equal(test.output);


### PR DESCRIPTION
Resolves the first part of https://github.ibm.com/dev-ex/portal/issues/1106

Added a PATCH templates/repositories API that can enable and disable template repos in batches:
<img width="717" alt="image" src="https://user-images.githubusercontent.com/18170169/62839617-e5951080-bc83-11e9-8b12-575b48066445.png">

Also edited the GET templates/ API to allow filtering templates via a `showEnabledOnly` query parameter:
![image](https://user-images.githubusercontent.com/18170169/62623243-4afda000-b918-11e9-9af9-dd8e9b100778.png)

Apologies for the large diff - these APIs affect each other so I had to change several things. Much of the diff in `Templates.js` and the test files should just be moving existing blocks/functions around to accommodate the new functionality and tests.

## Test output: 
<img width="128" alt="image" src="https://user-images.githubusercontent.com/18170169/62839598-a9fa4680-bc83-11e9-846e-6d21115c65f0.png">

Integration test:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/18170169/62839566-77e8e480-bc83-11e9-884f-afe0278195e6.png">

API tests:
<img width="583" alt="image" src="https://user-images.githubusercontent.com/18170169/62839572-86370080-bc83-11e9-95c1-b22ec5b1b06c.png">

Unit tests:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/18170169/62839588-9818a380-bc83-11e9-82f0-6abd6e91b09c.png">
<img width="683" alt="image" src="https://user-images.githubusercontent.com/18170169/62839595-a4046580-bc83-11e9-8bfd-09ebf4d2d8b7.png">

