### PR TITLE
Issue#133: remove watchedFiles from cw-settings file

### DIFF
--- a/src/initialize/src/controllers/cwSettingsController.ts
+++ b/src/initialize/src/controllers/cwSettingsController.ts
@@ -39,10 +39,6 @@ export function createEmptyCwSettingsObject(projectType: string): CWSettings {
     internalPort: '',
     healthCheck: '',
     ignoredPaths: [''],
-    watchedFiles: {
-      includeFiles: [''],
-      excludeFiles: [''],
-    },
   };
 
   if (projectTypesWithInternalDebugPort.includes(projectType)) {

--- a/src/initialize/src/types/initializeTypes.ts
+++ b/src/initialize/src/types/initializeTypes.ts
@@ -40,10 +40,6 @@ export interface CWSettings {
   internalDebugPort?: string;
   healthCheck: string;
   ignoredPaths?: string[];
-  watchedFiles: {
-    includeFiles: string[];
-    excludeFiles: string[];
-  };
   mavenProfiles?: string[];
   mavenProperties?: string[];
 }

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -38,7 +38,7 @@ const METRIC_TYPES = ['cpu', 'gc', 'memory', 'http']
 
 const CW_SETTINGS_PROPERTIES = [
   "contextRoot", "internalPort", "internalDebugPort",
-  "healthCheck", "watchedFiles", "mavenProfiles", "mavenProperties"
+  "healthCheck", "ignoredPaths", "mavenProfiles", "mavenProperties"
 ];
 
 /**
@@ -703,11 +703,8 @@ function setDefaultSettingValue(property) {
     return [""];
   case "mavenProperties":
     return [""];
-  case "watchedFiles":
-    return {
-      "includeFiles" : [""],
-      "excludeFiles" : [""]
-    };
+  case "ignoredPaths":
+    return [""];
   default:
     return "";
   }

--- a/test/utils/default-cw-settings.js
+++ b/test/utils/default-cw-settings.js
@@ -3,10 +3,6 @@ const defaultSpringSettings = {
     internalPort: '',
     healthCheck: '',
     ignoredPaths: [''],
-    watchedFiles: {
-        includeFiles: [''],
-        excludeFiles: [''],
-    },
     internalDebugPort: '',
     mavenProfiles: [''],
     mavenProperties: [''],
@@ -18,10 +14,6 @@ const defaultLibertySettings = {
     internalDebugPort: '',
     healthCheck: '',
     ignoredPaths: [''],
-    watchedFiles: {
-        includeFiles: [''],
-        excludeFiles: [''],
-    },
     mavenProfiles: [''],
     mavenProperties: [''],
 };
@@ -32,10 +24,6 @@ const defaultNodeSettings = {
     internalDebugPort: '',
     healthCheck: '',
     ignoredPaths: [''],
-    watchedFiles: {
-        includeFiles: [''],
-        excludeFiles: [''],
-    },
 };
 
 const defaultSwiftSettings = {
@@ -43,10 +31,6 @@ const defaultSwiftSettings = {
     internalPort: '',
     healthCheck: '',
     ignoredPaths: [''],
-    watchedFiles: {
-        includeFiles: [''],
-        excludeFiles: [''],
-    },
 };
 
 const defaultDockerSettings = {
@@ -54,10 +38,6 @@ const defaultDockerSettings = {
     internalPort: '',
     healthCheck: '',
     ignoredPaths: [''],
-    watchedFiles: {
-        includeFiles: [''],
-        excludeFiles: [''],
-    },
 };
 
 module.exports = {


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for #133 

Removes `watchedFiles` field from `.cw-settings` file. 

verified with a go project created from template: 
```
stephaniesmbp2:testgo stephanie$ cat .cw-settings 
{
  "contextRoot": "",
  "internalPort": "",
  "healthCheck": "",
  "ignoredPaths": [
    ""
  ]
}
```