### PR TITLE
missing project ID

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -179,6 +179,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         logger.logProjectInfo("Creating project " + projectLocation, projectID, projectName);
 
         projInfo = {
+            projectID: projectID,
             projectType: projectType,
             location: projectLocation,
             language: req.language


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

I thought this was related to #99 but after speaking with @maysunfaisal, that's not the case.  

However this seems to be a legit problem: when trying to get an extension handler, the project ID (which is used as the key to cache an extension project handler at https://github.com/eclipse/codewind/blob/master/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts#L155) is `null`.  This is causing other projects to incorrectly use the extension project handler.