### PR TITLE
Use dynamic port allocation for pfe in run.sh

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - codewind-performance
     ports:
-      - "127.0.0.1:9090:9090"
+      - "127.0.0.1:34000-35000:9090"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:

--- a/test/config/index.js
+++ b/test/config/index.js
@@ -9,8 +9,17 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 const path = require('path');
+const { execSync } = require('child_process');
 
-const CODEWIND_URL = process.env.CODEWIND_URL || 'http://localhost:9090';
+// Obtain the host and port Codewind is running on locally if not specifed
+// via the env var.
+let CONTAINER_HOST_INFO = {};
+if (!process.env.CODEWIND_URL) {
+    const CONTAINER_HOST_STDOUT = execSync(`docker inspect --format='{{json (index (index .NetworkSettings.Ports "9090/tcp") 0)}}' codewind-pfe`);
+    CONTAINER_HOST_INFO = JSON.parse(CONTAINER_HOST_STDOUT);
+}
+
+const CODEWIND_URL = process.env.CODEWIND_URL || `http://${CONTAINER_HOST_INFO.HostIp}:${CONTAINER_HOST_INFO.HostPort}`;
 const CODEWIND_HOST = process.env.INGRESS_DOMAIN || 'localhost';
 const DEFAULT_USER_NAME = 'default';
 const ADMIN_COOKIE = process.env.ADMIN_COOKIE || 'connect.sid=dummy';


### PR DESCRIPTION
[This PR is ready to deliver but shouldn't be merged until the IDE plugins are consuming the installer version that finds the ports for our containers for them. This was delivered to the installer under: https://github.com/eclipse/codewind-installer/pull/67 but needs to be in the installer packaged with the plugins otherwise this change will break anyone testing the plugins against a development codewind build.] 

This PR starts codewind on a dynamic port during development to match the behaviour of the installer and updates the tests to dynamically find the IP address and port number for Codewind.

This is so we match the installer behaviour changed under https://github.com/eclipse/codewind-installer/pull/67 and https://github.com/eclipse/codewind-installer/issues/69