### PR TITLE
Add host home and maven opts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,6 +12,8 @@ services:
       - CODEWIND_VERSION=${TAG}
       - PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}
       - REMOTE_MODE=${REMOTE_MODE}
+      - HOST_HOME=${HOST_HOME}
+      - HOST_MAVEN_OPTS=${HOST_MAVEN_OPTS}
     depends_on:
       - codewind-performance
     ports:

--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+# Set before mvn is run to prevent the reset of the MAVEN_OPTS that can happen if its in the start.sh script
+export HOST_MAVEN_OPTS=$MAVEN_OPTS
+
 mvn -v > /dev/null 2>&1
 MVN_RET_CODE=$?
 

--- a/start.sh
+++ b/start.sh
@@ -137,6 +137,7 @@ export WORKSPACE_DIRECTORY=$PWD/codewind-workspace;
 # Export HOST_OS for fix to Maven failing on Windows only as host
 export HOST_OS=$(uname);
 export REMOTE_MODE;
+export HOST_HOME=$HOME
 
 export ARCH=$(uname -m);
 # Select the right images for this architecture.


### PR DESCRIPTION
Mirrors the change from codewind-installer into the codewind repo (https://github.com/eclipse/codewind-installer/pull/63).

I made a note about setting MAVEN_OPTS in a different place. When calling mvn, it can potentially reset that variable, so it needs to be saved before that.