### PR TITLE
Update Dockerfile and build context resources for Microprofile project cache

### DIFF
--- a/src/pfe/file-watcher/dockerfiles/liberty/libertyDockerfile
+++ b/src/pfe/file-watcher/dockerfiles/liberty/libertyDockerfile
@@ -10,7 +10,6 @@ USER root
 RUN chmod g+w /config/apps
 RUN configure.sh
 USER 1001
-
 ENV JAVA_VERSION_PREFIX 1.8.0
 ENV HOME /home/default
 

--- a/src/pfe/file-watcher/dockerfiles/liberty/src/main/liberty/config/jvmbx.options
+++ b/src/pfe/file-watcher/dockerfiles/liberty/src/main/liberty/config/jvmbx.options
@@ -1,2 +1,1 @@
 -javaagent:/opt/ibm/wlp/usr/servers/defaultServer/resources/javametrics-agent.jar
--Dorg.osgi.framework.bootdelegation=com.ibm.tivoli.itcam.*

--- a/src/pfe/file-watcher/scripts/root-watcher.sh
+++ b/src/pfe/file-watcher/scripts/root-watcher.sh
@@ -36,7 +36,10 @@ cache_liberty() {
 		if [ -f /file-watcher/dockerfiles/liberty/libertyDockerfile ]; then
 			# Create the empty folders needed for the caching
 			mkdir -p /file-watcher/dockerfiles/liberty/target/liberty/wlp/usr/servers/defaultServer
+			chmod 775 /file-watcher/dockerfiles/liberty/target/liberty/wlp/usr/servers/defaultServer
 			mkdir -p /file-watcher/dockerfiles/liberty/target/liberty/wlp/usr/shared/resources
+			chmod 775 /file-watcher/dockerfiles/liberty/target/liberty/wlp/usr/shared/resources
+			chmod 664 /file-watcher/dockerfiles/liberty/src/main/liberty/config/jvmbx.options
 
 			echo "Pre-building the Liberty app image"
 			$LIBERTY_BUILD_CMD


### PR DESCRIPTION
This PR is to update the Dockerfile and build context resources of Microprofile project image cache to match Microprofile project template

For tracking purpose, the PR is for issue: https://github.com/eclipse/codewind/issues/169

For future, we can pull the project image cache from Dockerhub directly instead of updating he Dockerfile and build context resources

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>