### PR TITLE
Install built-in extensions on startup

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -186,7 +186,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         } as ProjectInfo;
 
         if (req.extension)
-            projInfo.extensionID = req.extension.name;
+            projInfo.extensionID = req.extension.path;
     }
 
     if (! await utils.asyncFileExists(projectLocation)) {

--- a/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
+++ b/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
@@ -168,12 +168,12 @@ async function getExtensionProjectHandler(projectInfo: ProjectInfo): Promise<any
     // is there an extension handler for the project?
     if (!handler) {
 
-        const extensionID = projectInfo.extensionID;
+        const fullPath = projectInfo.extensionID;
 
         // try to load extension handler if ID was provided
-        if (extensionID) {
+        if (fullPath) {
             try {
-                const files = await utils.asyncReadDir(path.join(workspaceConstants.workspaceExtensionDir, extensionID));
+                const files = await utils.asyncReadDir(fullPath);
                 if (files) {
                     if (files.includes(".sh-extension")) {
                         handler = new ShellExtensionProject(projectInfo.projectType);
@@ -183,7 +183,7 @@ async function getExtensionProjectHandler(projectInfo: ProjectInfo): Promise<any
                 }
             }
             catch (err) {
-                logger.logError(`Failed to get extension project handler ${extensionID} for ${projectInfo.location}`);
+                logger.logError(`Failed to get extension project handler ${fullPath} for ${projectInfo.location}`);
                 logger.logError(err);
                 return undefined;
             }

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -22,7 +22,6 @@ import * as projectEventsController from "../controllers/projectEventsController
 import { IExtensionProject } from "../extensions/IExtensionProject";
 import * as processManager from "../utils/processManager";
 import * as logger from "../utils/logger";
-import { workspaceConstants } from "../projects/constants";
 
 /**
  * @interface
@@ -60,7 +59,7 @@ export class ShellExtensionProject implements IExtensionProject {
 
     supportedType: string;
 
-    private id: string;
+    private fullPath: string;
     private config: ShellExtensionProjectConfig;
     private language: string;
 
@@ -92,7 +91,7 @@ export class ShellExtensionProject implements IExtensionProject {
         try {
             const result = await processManager.spawnDetachedAsync(
                 projectInfo.projectID,
-                path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"),
+                path.join(this.fullPath, "entrypoint.sh"),
                 args,
                 {});
 
@@ -117,8 +116,8 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     init = async (projectInfo: ProjectInfo): Promise<void> => {
-        this.id = projectInfo.extensionID;
-        this.config = await fs.readJson(path.join(workspaceConstants.workspaceExtensionDir, this.id, ".sh-extension"));
+        this.fullPath = projectInfo.extensionID;
+        this.config = await fs.readJson(path.join(this.fullPath, ".sh-extension"));
         await this.setLanguage(projectInfo);
     }
 
@@ -129,7 +128,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param operation <Required | Operation> - The create operation.
      */
     create = (operation: Operation): void => {
-        projectUtil.containerCreate(operation, path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"), "create");
+        projectUtil.containerCreate(operation, path.join(this.fullPath, "entrypoint.sh"), "create");
     }
 
     /**
@@ -140,7 +139,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
      */
     update = (operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void => {
-        projectUtil.containerUpdate(operation, path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"), "update");
+        projectUtil.containerUpdate(operation, path.join(this.fullPath, "entrypoint.sh"), "update");
     }
 
     /**
@@ -150,7 +149,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     start = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.runScript(projectInfo, path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"), "start");
+        await projectUtil.runScript(projectInfo, path.join(this.fullPath, "entrypoint.sh"), "start");
     }
 
     /**
@@ -160,7 +159,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     stop = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.runScript(projectInfo, path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"), "stop");
+        await projectUtil.runScript(projectInfo, path.join(this.fullPath, "entrypoint.sh"), "stop");
     }
 
     /**
@@ -170,7 +169,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     rebuild = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.runScript(projectInfo, path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"), "rebuild");
+        await projectUtil.runScript(projectInfo, path.join(this.fullPath, "entrypoint.sh"), "rebuild");
     }
 
     /**
@@ -180,7 +179,7 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     deleteContainer = async (projectInfo: ProjectInfo): Promise<void> => {
-        await projectUtil.containerDelete(projectInfo, path.join(workspaceConstants.workspaceExtensionDir, this.id, "entrypoint.sh"));
+        await projectUtil.containerDelete(projectInfo, path.join(this.fullPath, "entrypoint.sh"));
     }
 
     /**

--- a/src/pfe/portal/modules/Extension.js
+++ b/src/pfe/portal/modules/Extension.js
@@ -62,6 +62,10 @@ module.exports = class Extension {
       let definitionFile = await fs.readFile(path.join(this.path, 'codewind.yaml'));
       let definition = yaml.safeLoad(definitionFile);
 
+      if (definition.hasOwnProperty('name')) {
+        // TODO: validate extension name
+        this.name = definition.name;
+      }
       if (definition.hasOwnProperty('version')) {
         // TODO: validate extension version
         this.version = definition.version;

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -14,8 +14,15 @@ const path = require('path');
 const Extension = require('./Extension.js');
 const Logger = require('./utils/Logger');
 const ExtensionListError = require('./utils/errors/ExtensionListError');
+const utils = require('./utils/sharedFunctions');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
 
 const log = new Logger(__filename);
+
+const extensionsDir = '/extensions';
+const extensionsPattern = /^(\S+)(-[\d.]+)\.zip$/; // e.g. extension-name-0.0.1.zip
+const suffixOld = '__old';
 
 /**
  * The ExtensionList class
@@ -23,6 +30,51 @@ const log = new Logger(__filename);
 module.exports = class ExtensionList {
   constructor() {
     this._list = {};
+  }
+  
+  /**
+   * Install (unzip) built-in extensions that are stored in /extensions to the
+   * given target directory
+   * 
+   * @param {string} targetDir, the target directory to install extensions to 
+   */
+  async installBuiltInExtensions(targetDir) {
+  
+    // get the zips from the /extensions directory
+    const entries = await fs.readdir(extensionsDir, { withFileTypes: true });
+    
+    for (let entry of entries) {
+      
+        let match;
+  
+        // look for files with names matching the expected pattern
+        if (entry.isFile() && (match = extensionsPattern.exec(entry.name))) {
+          
+          const name = match[1];
+          const version = match[2];
+
+          const source = path.join(extensionsDir, entry.name);
+          const target = path.join(targetDir, name);
+          const targetWithVersion = target + version;
+
+          try {
+            await prepForUnzip(target);
+            await exec(`unzip ${source} -d ${targetDir}`);
+
+            // top-level directory in zip will have the version suffix
+            // rename to remove the version
+            await fs.rename(targetWithVersion, target);
+          }
+          catch (err) {
+            log.warn(`Failed to install ${entry.name}`);
+            log.warn(err);
+          }
+          finally {
+            // to be safe, try to remove directory with version name if it still exist
+            await forceRemove(targetWithVersion);
+          }
+        }
+    }
   }
 
   /**
@@ -38,7 +90,7 @@ module.exports = class ExtensionList {
         try {
           let fstats = await fs.lstat(path.join(extensionsPath, entry));
           // Extensions are in sub-directories of the top-level extensions directory
-          if (fstats.isDirectory()) {
+          if (fstats.isDirectory() && !entry.endsWith(suffixOld)) {
             const extension = new Extension({path: path.join(extensionsPath, entry), name: entry});
             await extension.initialise();
             this.add(extension);
@@ -151,5 +203,37 @@ module.exports = class ExtensionList {
       }
     }
     return array;
+  }
+}
+
+/**
+ * Force remove a path, regardless of whether it exists, or it's file or directory that may or may not be empty.
+ * 
+ * @param {string} path, path to remove
+ */
+async function forceRemove(path) {
+  try {
+    await exec(`rm -rf ${path}`);
+  }
+  catch (err) {
+    log.warn(err.message);
+  }
+}
+
+/**
+ * Prepare the directory where an extension will be unzipped to. If directory
+ * exists with the same name, it will be renamed by appending the "__old" suffix to it.
+ * 
+ * @param {string} target, the target directory to unzip to
+ */
+async function prepForUnzip(target) {
+  
+  if (await utils.fileExists(target)) {
+  
+    const targetOld = target + suffixOld;
+
+    // try to remove previous backup that may or may not exist before rename
+    await forceRemove(targetOld);
+    await fs.rename(target, targetOld);
   }
 }

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -23,6 +23,7 @@ const Logger = require('./utils/Logger');
 const LoadRunError = require('./utils/errors/LoadRunError.js');
 const FilewatcherError = require('./utils/errors/FilewatcherError');
 const log = new Logger('User.js');
+const util = require('util');
 
 /**
  * The User class
@@ -85,15 +86,13 @@ module.exports = class User {
       try {
         await this.extensionList.installBuiltInExtensions(this.directories.extensions);
       } catch (error) {
-        log.error('Fail to install built-in Codewind extensions');
-        log.error(error);
+        log.error(`Failed to install built-in Codewind extensions. Error ${util.inspect(error)}`);
       }
 
       try {
         await this.extensionList.initialise(this.directories.extensions, this.templates);
       } catch (error) {
-        log.error('Codewind extensions failed to load');
-        log.error(error);
+        log.error(`Codewind extensions failed to load. Error ${util.inspect(error)}`);
       }
 
       // Create the FileWatcher and LoadRunner classes for this user

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -52,7 +52,7 @@ module.exports = class User {
     }
     this.secure = true;
   }
-
+  
   /**
    * Function to initialise a user
    * Runs functions to create the user directories, start existing projects
@@ -80,6 +80,15 @@ module.exports = class User {
 
       // Create the list of codewind extensions
       this.extensionList = new ExtensionList();
+
+      // Attempt to install built-in extension packages
+      try {
+        await this.extensionList.installBuiltInExtensions(this.directories.extensions);
+      } catch (error) {
+        log.error('Fail to install built-in Codewind extensions');
+        log.error(error);
+      }
+
       try {
         await this.extensionList.initialise(this.directories.extensions, this.templates);
       } catch (error) {


### PR DESCRIPTION
This is a simple initial crack at installing extensions that will be pre-packaged into Codewind (first candidate: https://github.com/eclipse/codewind-appsody-extension)

The high-level idea is:

1) In docker build, we download release zips of extensions to `/extensions` folder in the image. @sghung will submit a separate PR for this

2) When Codewind starts, the zips in `/extensions` are unzipped to `/codewind-workspace/.extensions`
   - for this initial implementation, purposely not trying to do any fancy version checking
   - if a copy of the extension already exists in `/codewind-workspace/.extensions`, it is simply backed-up by renaming it with a `__old` suffix

3) Then extensions in `/codewind-workspace/.extensions` are loaded as usual (directories with `__old` suffix are skipped)

Some of the changes here are necessary to allow the extension's directory name to be different than the extension's name in `codewind.yaml`

@sghung @hhellyer @rwalle61 @rajivnathan could someone review this PR?
