### PR TITLE
Fix overlapping plot lines on performance dashboard 

### DIFF
--- a/src/performance/dashboard/src/components/chart/ChartBuilder.js
+++ b/src/performance/dashboard/src/components/chart/ChartBuilder.js
@@ -1,0 +1,162 @@
+/*******************************************************************************
+* Copyright (c) 2019 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+******************************************************************************/
+
+import ChartUtils from './ChartUtils';
+import MetricsUtils from '../../modules/MetricsUtils';
+
+export function buildChartRow(metricsRow, counterName) {
+    if (metricsRow) {
+        try {
+            const numbers = metricsRow.slice(1).map(value => { return parseInt(value) })
+            const max = Math.max(...numbers);
+            const percents = numbers.map(value => { return `${parseInt((value * 100) / max)}` });
+            const categoryRow = [counterName].concat(percents);
+            return categoryRow;
+        } catch (err) {
+            return [];
+        }
+    }
+    return [];
+}
+
+export function addCPULine(counterKeys, data, chartData) {
+    if (chartData.CPU.columns && chartData.CPU.columns.length > 0) {
+        const metricsRow = chartData.CPU.columns.find(metric => {
+            return metric[0] === counterKeys["CPU_PROCESS_MEAN"];
+        });
+        if (metricsRow) {
+            const metricsRowClone = metricsRow.slice();
+            data.columns.push(buildChartRow(metricsRowClone, "CPU_PROCESS_MEAN"));
+            metricsRowClone[0] = "CPU_PROCESS_MEAN";
+            data.classes.push(metricsRowClone);
+        }
+    }
+}
+
+export function addMemoryLine(counterKeys, data, chartData) {
+    if (chartData.MEMORY.columns && chartData.MEMORY.columns.length > 0) {
+        const metricsRow = chartData.MEMORY.columns.find(metric => {
+            return metric[0] === counterKeys["MEM_PROCESS_PEAK"];
+        });
+        if (metricsRow) {
+            const metricsRowClone = metricsRow.slice();
+            data.columns.push(buildChartRow(metricsRowClone, "MEM_PROCESS_PEAK"));
+            metricsRowClone[0] = "MEM_PROCESS_PEAK";
+            data.classes.push(metricsRowClone);
+        }
+    }
+}
+
+export function addHTTPLine(data, chartData, absolutePath) {
+    if (chartData.HTTP.columns && chartData.HTTP.columns.length > 0) {
+        const metricsRow = chartData.HTTP.columns.find(metric => {
+            return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
+        });
+        if (metricsRow) {
+            const metricsRowClone = metricsRow.slice();
+            data.columns.push(buildChartRow(metricsRowClone, "HTTP_RESPONSE"));
+            metricsRowClone[0] = "HTTP_RESPONSE";
+            data.classes.push(metricsRowClone);
+        }
+    }
+}
+
+export function addHTTPHits(data, chartData, absolutePath) {
+    if (chartData.HTTPHits.columns && chartData.HTTPHits.columns.length > 0) {
+        const metricsRow = chartData.HTTPHits.columns.find(metric => {
+            return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
+        });
+        if (metricsRow) {
+            const metricsRowClone = metricsRow.slice();
+            data.columns.push(buildChartRow(metricsRowClone, "HTTP_HITS"));
+            metricsRowClone[0] = "HTTP_HITS"
+            data.classes.push(metricsRowClone);
+        }
+    }
+}
+
+/**
+ * Build the chart data model containing each of the counters 
+ * @param {*} chartData 
+ * @param {*} projectLanguage 
+ * @param {*} absolutePath 
+ */
+export function buildChartData(chartData, projectLanguage, absolutePath) {
+
+    const data = {
+        columns: [],
+        classes: [],
+        selection: {
+            enabled: true,
+            grouped: true,
+            multiple: true
+        },
+        types: ChartUtils.chartTypes,
+    };
+
+    const counterKeys = MetricsUtils.getLanguageCounters(projectLanguage);
+    addCPULine(counterKeys, data, chartData, absolutePath);
+    addMemoryLine(counterKeys, data, chartData, absolutePath);
+    addHTTPLine(data, chartData, absolutePath);
+    addHTTPHits(data, chartData, absolutePath);
+
+    return data;
+}
+
+/**
+ * getLineData - gets a plot line for the specififed counter
+ * 
+ * @param chartData chart data model
+ * @param counterName counter being
+ * @param projectLanguage nodejs | java | swift
+ * @param absolutePath application path filter 
+ * @returns a plot line for the specified counter
+ */
+export function getLineData(chartData, counterName, projectLanguage, absolutePath) {
+    const counterKeys = MetricsUtils.getLanguageCounters(projectLanguage);
+
+    switch (counterName) {
+        case 'CPU_PROCESS_MEAN':
+            if (chartData.CPU.columns && chartData.CPU.columns.length > 0) {
+                const metricsRow = chartData.CPU.columns.find(metric => {
+                    return metric[0] === counterKeys[counterName];
+                });
+                return metricsRow;
+            }
+            return [];
+        case 'MEM_PROCESS_PEAK':
+            if (chartData.MEMORY.columns && chartData.MEMORY.columns.length > 0) {
+                const metricsRow = chartData.MEMORY.columns.find(metric => {
+                    return metric[0] === counterKeys["MEM_PROCESS_PEAK"];
+                });
+                return metricsRow;
+            }
+            return [];
+        case 'HTTP_RESPONSE':
+            if (chartData.HTTP.columns && chartData.HTTP.columns.length > 0) {
+                const metricsRow = chartData.HTTP.columns.find(metric => {
+                    return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
+                });
+                return metricsRow;
+            }
+            return [];
+        case 'HTTP_HITS':
+            if (chartData.HTTPHits.columns && chartData.HTTPHits.columns.length > 0) {
+                const metricsRow = chartData.HTTPHits.columns.find(metric => {
+                    return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
+                });
+                return metricsRow;
+            }
+            return [];
+        default:
+            return [];
+    }
+}

--- a/src/performance/dashboard/src/components/chart/ChartUtils.js
+++ b/src/performance/dashboard/src/components/chart/ChartUtils.js
@@ -70,34 +70,10 @@ let getColorPatternLines = function (counters, counterStatus) {
     return chartColors;
 }
 
-/**
- * 
- * Given an array of counters,  return a list of chart colors
- */
-let getColorPatternFiltered = function (counters, counterStatus) {
-    var chartColors = [];
-    counters.forEach(counterkey => {
-        let colorValue = "#555";
-        // check if the counter is enabled, if its not,  set the color to grey
-
-        const counterElement = counterStatus.find(counter => {
-            return counter.name === counterkey;
-        });
-
-        if (counterElement && counterElement.checked) {
-            colorValue = colorSwatches[counterkey];
-        }
-
-
-        chartColors.push(colorValue);
-    });
-    return chartColors;
-}
 
 exports.counterLabels = counterLabels;
 exports.counterUnits = counterUnits;
 exports.colorSwatches = colorSwatches;
 exports.getColorPattern = getColorPattern;
-exports.getColorPatternFiltered = getColorPatternFiltered;
 exports.getColorPatternLines = getColorPatternLines;
 exports.chartTypes = chartTypes;

--- a/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
+++ b/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
@@ -176,7 +176,7 @@ class ChartCounterSelector extends Component {
                             <div className="categoryLabels">
                                 <Checkbox id="cpu" checked={this.isCounterEnabled('CPU_PROCESS_MEAN')} onClick={(e) => this.handleExpandClick(e, 'CPU_PROCESS_MEAN')} labelText='CPU (%)' />
                                 <Tooltip
-                                    showIcon="true"
+                                    showIcon={true}
                                     direction="left"
                                     iconDescription="Helpful Information"
                                     tabIndex={0}


### PR DESCRIPTION

# Problem

1. In some cases when metrics counters overlap,  for example when multiple lines are at 100%, a selected plot line can become buried under a stack of disabled plot lines making its values difficult identify and read.

2. Deselecting all the lines and enabling just one does not help since all disabled lines change to grey making it impossible to identify which disabled line is which counter.

These problems were logged in https://github.com/eclipse/codewind/issues/164. however that issue contains multiple observations so extracted these two as being the same root cause:

* Solve the issue of when to lines overlap in the graph
* The colors associated with each measurement needs to be more obvious.

# Solution

* selected plot lines appear in focus
* Instead of changing to grey,  unselected plot lines now retain their colour but appear muted


## Before : 

<img width="1209" alt="1ffd0580-c016-11e9-842f-f59e78665bce" src="https://user-images.githubusercontent.com/28102564/63161555-3e640080-c018-11e9-954e-c2c8e087b1ef.png">


## After : 

<img width="1172" alt="335ba100-c015-11e9-99ae-6d1878f959f1" src="https://user-images.githubusercontent.com/28102564/63161582-4cb21c80-c018-11e9-98ba-e6371fcde9f5.png">

Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>