### PR TITLE
Fix space typo for Swift Ignore List

### DIFF
--- a/src/pfe/.gitignore
+++ b/src/pfe/.gitignore
@@ -1,2 +1,3 @@
 /initialize
 devbuild.env
+devbuild-example.env

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -39,7 +39,7 @@ export const supportedType = "swift";
  */
 export const defaultIgnoredPath: string[] = ["/.project", "/LICENSE", "/Package.resolved", "README.rtf", "/debian", "/manifest.yml", "/load-test*",
                                              "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.bluemix", "/iterative-dev.sh", "/terraform",
-                                            ".swift-version", "/.build-ubuntu ", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json",
+                                            ".swift-version", "/.build-ubuntu", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json",
                                             "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore",
                                             "*/.gitignore", "*/*~", "/.settings"];
 if (!process.env.IN_K8) {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

https://github.com/eclipse/codewind/issues/22

Fixes the space typo.

This bug was essentially an infinite rebuild as Swift uses the `.build-ubuntu` dir during compile and filewatcher always notified Turbine of a change, whenever there was an activity in that dir.

Local:
![Screen Shot 2019-08-16 at 10 37 57 AM](https://user-images.githubusercontent.com/31771087/63175431-fe9a1a80-c011-11e9-877e-6c6cb37b6a8c.png)

Kube:
![Screen Shot 2019-08-16 at 10 39 17 AM](https://user-images.githubusercontent.com/31771087/63175499-212c3380-c012-11e9-8b78-1352b3add10c.png)
