### PR TITLE
Test env API against our OpenAPI doc

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -29,22 +29,26 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - running_in_k8s
+                  - user_string
+                  - socket_namespace
+                  - codewind_version
+                  - os_platform
+                  - tekton_dashboard_url
                 properties:
                   running_in_k8s:
                     type: boolean
                     example: false
                   user_string:
                     type: string
-                    example: null
+                    nullable: true
                   socket_namespace:
                     type: string
                     example: '/default'
                   codewind_version:
                     type: string
                     example: '/latest'
-                  workspace_location:
-                    type: string
-                    example: '/home/user/codewind-workspace'
                   os_platform:
                     type: string
                     example: 'Linux'
@@ -52,6 +56,9 @@ paths:
                     type: string
                     example: '9.20.195.90.nip.io'
                     description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string. May also be 'error' or 'not-installed'."
+                  workspace_location:
+                    type: string
+                    example: '/home/user/codewind-workspace'
         500:
           description: Internal error occurred
   /api/v1/projects:

--- a/test/src/environment.test.js
+++ b/test/src/environment.test.js
@@ -9,29 +9,24 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 const chai = require('chai');
+const chaiResValidator = require('chai-openapi-response-validator');
 
 const reqService = require('../modules/request.service');
-const { ADMIN_COOKIE, USING_K8S, DEFAULT_USER_NAME } = require('../config');
+const { ADMIN_COOKIE, USING_K8S, DEFAULT_USER_NAME, pathToApiSpec } = require('../config');
 
 const SOCKET_NAMESPACE = USING_K8S ? '/admin' : `/${DEFAULT_USER_NAME}`;
-
+chai.use(chaiResValidator(pathToApiSpec));
 chai.should();
 
 describe('Environment API tests', function() {
-
     it('should return expected environment properties', async function() {
         const res = await reqService.chai
             .get('/api/v1/environment')
             .set('Cookie', ADMIN_COOKIE);
 
-        res.should.have.status(200);
-        res.should.have.ownProperty('body');
-        res.body.should.have.ownProperty('running_in_k8s', USING_K8S);
-        res.body.should.have.ownProperty('user_string');
-        res.body.should.have.ownProperty('socket_namespace', SOCKET_NAMESPACE);
-        res.body.should.have.ownProperty('codewind_version');
-        res.body.should.have.ownProperty('tekton_dashboard_url');
-        res.body.should.have.ownProperty('os_platform');
+        res.should.have.status(200).and.satisfyApiSpec;
+        res.body.running_in_k8s.should.equal(USING_K8S);
+        res.body.socket_namespace.should.equal(SOCKET_NAMESPACE);
         if (!USING_K8S) res.body.should.have.ownProperty('workspace_location');
     });
 });


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Similar to https://github.com/eclipse/codewind/pull/203, this uses our Chai OpenAPI response validator plugin to automatically test that PFE responds as our OpenAPI doc claims it does. 

Discovered and corrected a minor mistake in our doc, where we specified that the `user_string` was nullable but in a way not supported by OpenAPI