### PR TITLE
Support Project Https Protocol Pings

### DIFF
--- a/src/initialize/src/controllers/cwSettingsController.ts
+++ b/src/initialize/src/controllers/cwSettingsController.ts
@@ -38,6 +38,7 @@ export function createEmptyCwSettingsObject(projectType: string): CWSettings {
     contextRoot: '',
     internalPort: '',
     healthCheck: '',
+    isHttps: false,
     ignoredPaths: [''],
   };
 

--- a/src/initialize/src/types/initializeTypes.ts
+++ b/src/initialize/src/types/initializeTypes.ts
@@ -39,6 +39,7 @@ export interface CWSettings {
   internalPort: string;
   internalDebugPort?: string;
   healthCheck: string;
+  isHttps: boolean;
   ignoredPaths?: string[];
   mavenProfiles?: string[];
   mavenProperties?: string[];

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -324,7 +324,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
                     projectInfo.isHttps = settings.isHttps;
                 } else {
                     // Default to http if we cannot get the isHttps settings
-                    logger.logProjectInfo("Defaulting isHttps to false as the project settings is not boolean", projectID, projectName);
+                    logger.logProjectInfo("Defaulting isHttps to false as the project setting isHttps is not a boolean", projectID, projectName);
                     await projectUtil.setProjectWWWProtocolMap(projectID, false);
                     projectInfo.isHttps = false;
                 }

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -254,7 +254,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
     }
 
     // Set isHttps to false by default, override if the isHttps settings key is found
-    await projectUtil.setProjectWWWProtocolMap(projectID, false);
+    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, false);
     projectInfo.isHttps = false;
 
     // Persist the Project Settings last since it will have the higher priority over default projectInfo values
@@ -320,12 +320,12 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
             } else if (key == "isHttps") {
                 if (typeof settings.isHttps == "boolean") {
                     logger.logProjectInfo("Setting isHttps from the project settings", projectID, projectName);
-                    await projectUtil.setProjectWWWProtocolMap(projectID, settings.isHttps);
+                    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, settings.isHttps);
                     projectInfo.isHttps = settings.isHttps;
                 } else {
                     // Default to http if we cannot get the isHttps settings
                     logger.logProjectInfo("Defaulting isHttps to false as the project setting isHttps is not a boolean", projectID, projectName);
-                    await projectUtil.setProjectWWWProtocolMap(projectID, false);
+                    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, false);
                     projectInfo.isHttps = false;
                 }
             }

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -253,6 +253,10 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         projectInfo.ignoredPaths = selectedProjectHandler.defaultIgnoredPath;
     }
 
+    // Set isHttps to false by default, override if settings key is found
+    await projectUtil.setProjectWWWProtocolMap(projectID, false);
+    projectInfo.isHttps = false;
+
     // Persist the Project Settings last since it will have the higher priority over default projectInfo values
     if (settings) {
         for (const key in settings) {

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -313,6 +313,17 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
                 } else {
                     projectInfo.ignoredPaths = settings.ignoredPaths;
                 }
+            } else if (key == "isHttps") {
+                if (typeof settings.isHttps == "boolean") {
+                    logger.logInfo("MJF projectsController create setting isHttps from settings");
+                    await projectUtil.setProjectWWWProtocolMap(projectID, settings.isHttps);
+                    projectInfo.isHttps = settings.isHttps;
+                } else {
+                    // Default to http if we cannot get the isHttps settings
+                    logger.logInfo("MJF projectsController create defaulting to isHttps false");
+                    await projectUtil.setProjectWWWProtocolMap(projectID, false);
+                    projectInfo.isHttps = false;
+                }
             }
         }
     }
@@ -1175,6 +1186,7 @@ export interface IProjectSettings {
     mavenProfiles?: string[];
     mavenProperties?: string[];
     ignoredPaths?: string[];
+    isHttps?: boolean;
 }
 
 export interface IProjectActionParams {

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -253,7 +253,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         projectInfo.ignoredPaths = selectedProjectHandler.defaultIgnoredPath;
     }
 
-    // Set isHttps to false by default, override if settings key is found
+    // Set isHttps to false by default, override if the isHttps settings key is found
     await projectUtil.setProjectWWWProtocolMap(projectID, false);
     projectInfo.isHttps = false;
 
@@ -319,12 +319,12 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
                 }
             } else if (key == "isHttps") {
                 if (typeof settings.isHttps == "boolean") {
-                    logger.logInfo("MJF projectsController create setting isHttps from settings");
+                    logger.logProjectInfo("Setting isHttps from the project settings", projectID, projectName);
                     await projectUtil.setProjectWWWProtocolMap(projectID, settings.isHttps);
                     projectInfo.isHttps = settings.isHttps;
                 } else {
                     // Default to http if we cannot get the isHttps settings
-                    logger.logInfo("MJF projectsController create defaulting to isHttps false");
+                    logger.logProjectInfo("Defaulting isHttps to false as the project settings is not boolean", projectID, projectName);
                     await projectUtil.setProjectWWWProtocolMap(projectID, false);
                     projectInfo.isHttps = false;
                 }

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -254,7 +254,6 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
     }
 
     // Set isHttps to false by default, override if the isHttps settings key is found
-    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, false);
     projectInfo.isHttps = false;
 
     // Persist the Project Settings last since it will have the higher priority over default projectInfo values
@@ -320,12 +319,10 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
             } else if (key == "isHttps") {
                 if (typeof settings.isHttps == "boolean") {
                     logger.logProjectInfo("Setting isHttps from the project settings", projectID, projectName);
-                    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, settings.isHttps);
                     projectInfo.isHttps = settings.isHttps;
                 } else {
                     // Default to http if we cannot get the isHttps settings
                     logger.logProjectInfo("Defaulting isHttps to false as the project setting isHttps is not a boolean", projectID, projectName);
-                    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, false);
                     projectInfo.isHttps = false;
                 }
             }

--- a/src/pfe/file-watcher/server/src/projects/Project.ts
+++ b/src/pfe/file-watcher/server/src/projects/Project.ts
@@ -32,6 +32,7 @@ export interface ProjectInfo {
     ignoredPaths?: string[];
     extensionID?: string;
     language?: string;
+    isHttps?: boolean;
 }
 
 export interface ProjectMetadata {
@@ -84,7 +85,7 @@ export interface ProjectSettingsEvent {
     ignoredPaths?: string[];
     mavenProfiles?: string[];
     mavenProperties?: string[];
-    isSecure?: boolean;
+    isHttps?: boolean;
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/Project.ts
+++ b/src/pfe/file-watcher/server/src/projects/Project.ts
@@ -84,6 +84,7 @@ export interface ProjectSettingsEvent {
     ignoredPaths?: string[];
     mavenProfiles?: string[];
     mavenProperties?: string[];
+    isSecure?: boolean;
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -471,7 +471,6 @@ const reconfigWWWProtocol = async function (isHttps: boolean, operation: Operati
     projectInfo = await projectsController.updateProjectInfo(projectID, keyValuePair);
 
     logger.logProjectInfo("The project has been updated", projectInfo.projectID);
-    logger.logProjectInfo("MJF updated ProjectInfo: " + JSON.stringify(projectInfo), projectInfo.projectID);
     logger.logProjectTrace(JSON.stringify(projectInfo), projectInfo.projectID);
 
     const data: ProjectSettingsEvent = {
@@ -481,7 +480,6 @@ const reconfigWWWProtocol = async function (isHttps: boolean, operation: Operati
         isHttps: isHttps
     };
 
-    // Only emit a socket msg when it is true since the project default is always false
     io.emitOnListener("projectSettingsChanged", data);
 
     logger.logProjectInfo("The WWW protocol for the project has been changed to: " + isHttps ? "https" : "http", projectID);

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -437,6 +437,42 @@ const reconfigIgnoredFilesForDaemon = async function (ignoredPaths: string[], op
     io.emitOnListener("projectSettingsChanged", data);
 };
 
+/**
+ * @function
+ * @description Reconfig the ignored files for a project.
+ *
+ * @param args <Required | Any> - Required arguments for reconfiguration of ignroed files.
+ *
+ * @returns Promise<any>
+ */
+const reconfigWWWProtocol = async function (isSecure: boolean, operation: Operation): Promise<any> {
+    const projectInfo: ProjectInfo = operation.projectInfo;
+    const projectID = projectInfo.projectID;
+
+    const isSecurePreviously: boolean = await projectUtil.getProjectWWWProtocolMap(projectID);
+
+    if (isSecure == isSecurePreviously) {
+        logger.logProjectInfo("The project WWW protocol is already set to: " + isSecure ? "https" : "http", projectID);
+        return;
+    }
+
+    await projectUtil.setProjectWWWProtocolMap(projectID, isSecure);
+
+    if (isSecure) {
+        const data: ProjectSettingsEvent = {
+            operationId: operation.operationId,
+            projectID: projectID,
+            status: "success",
+            isSecure: isSecure
+        };
+
+        // Only emit a socket msg when it is true since the project default is always false
+        io.emitOnListener("projectSettingsChanged", data);
+    }
+
+    logger.logProjectInfo("The WWW protocol for the project has been changed to: " + isSecure ? "https" : "http", projectID);
+    return;
+};
 
  /**
   * @function
@@ -796,3 +832,4 @@ specificationSettingMap.set("healthCheck", changeHealthCheck);
 specificationSettingMap.set("mavenProfiles", changeMavenProfiles);
 specificationSettingMap.set("mavenProperties", changeMavenProperties);
 specificationSettingMap.set("ignoredPaths", reconfigIgnoredFilesForDaemon);
+specificationSettingMap.set("isSecure", reconfigWWWProtocol);

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -456,15 +456,12 @@ const reconfigWWWProtocol = async function (isHttps: boolean, operation: Operati
         return;
     }
 
-    // MAYSUN const isHttpsPreviously: boolean = await projectUtil.getProjectWWWProtocolMap(projectID);
     const isHttpsPreviously: boolean = projectInfo.isHttps;
 
     if (isHttps == isHttpsPreviously) {
         logger.logProjectInfo("The project WWW protocol is already set to: " + isHttps ? "https" : "http", projectID);
         return;
     }
-
-    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, isHttps);
 
     const keyValuePair: UpdateProjectInfoPair = {
         key: "isHttps",

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -439,9 +439,11 @@ const reconfigIgnoredFilesForDaemon = async function (ignoredPaths: string[], op
 
 /**
  * @function
- * @description Reconfig the ignored files for a project.
+ * @description Reconfig the WWW protocol for a project.
  *
- * @param args <Required | Any> - Required arguments for reconfiguration of ignroed files.
+ * @param isHttps <Required | Boolean> - isHttps tells if a project is https enabled.
+ *
+ * @param operation <Required | Any> - Operation for a project.
  *
  * @returns Promise<any>
  */

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -456,14 +456,15 @@ const reconfigWWWProtocol = async function (isHttps: boolean, operation: Operati
         return;
     }
 
-    const isHttpsPreviously: boolean = await projectUtil.getProjectWWWProtocolMap(projectID);
+    // MAYSUN const isHttpsPreviously: boolean = await projectUtil.getProjectWWWProtocolMap(projectID);
+    const isHttpsPreviously: boolean = projectInfo.isHttps;
 
     if (isHttps == isHttpsPreviously) {
         logger.logProjectInfo("The project WWW protocol is already set to: " + isHttps ? "https" : "http", projectID);
         return;
     }
 
-    await projectUtil.setProjectWWWProtocolMap(projectID, isHttps);
+    // MAYSUN await projectUtil.setProjectWWWProtocolMap(projectID, isHttps);
 
     const keyValuePair: UpdateProjectInfoPair = {
         key: "isHttps",

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -60,7 +60,6 @@ export const LOCAL_WORKSPACE = process.env.NODE_ENV === "test" ? process.env.HOS
 const projectList: Array<string> = [];
 
 const isApplicationPodUpIntervalMap = new Map();
-// MAYSUN const projectWWWProtocolMap = new Map();
 
 export interface ProjectEvent {
     operationId: string;
@@ -632,7 +631,7 @@ export async function containerDelete(projectInfo: ProjectInfo, script: string):
 
     containerInfoMap.delete(projectInfo.projectID);
     containerInfoForceRefreshMap.delete(projectInfo.projectID);
-    // MAYSUN projectWWWProtocolMap.delete(projectInfo.projectID);
+
     if (process.env.IN_K8 === "true") {
         logger.logProjectInfo(`Removing dangling images for ${projectInfo.projectID}`, projectInfo.projectID);
         dockerutil.removeDanglingImages();
@@ -907,44 +906,6 @@ export async function isContainerActive(projectID: string, handler: any): Promis
         logger.logError(msg);
     }
 }
-
-// /**
-//  * @function
-//  * @description Function to set the project's WWW protocol in the Map.
-//  *
-//  * @param projectID <Required | String> - The projectID.
-//  * @param isHttps <Optional | Boolean> - The WWW Protocol. The default value is false.
-//  *
-//  * @returns Promise<void>
-//  */
-// export async function setProjectWWWProtocolMap(projectID: string, isHttps: boolean = false): Promise<void> {
-//     if (!projectID) {
-//         logger.logError("Cannot set the WWW protocol for an invalid projectID: " + projectID);
-//         return;
-//     }
-//     projectWWWProtocolMap.set(projectID, isHttps);
-// }
-
-// /**
-//  * @function
-//  * @description Function to get the project's WWW protocol from the Map.
-//  *
-//  * @param projectID <Required | String> - The projectID.
-//  *
-//  * @returns Promise<void>
-//  */
-// export async function getProjectWWWProtocolMap(projectID: string): Promise<boolean> {
-//     if (!projectID) {
-//         logger.logError("Cannot get the WWW protocol for an invalid projectID: " + projectID);
-//         return;
-//     }
-
-//     if (projectWWWProtocolMap.get(projectID)) {
-//         return true;
-//     } else {
-//         return false;
-//     }
-// }
 
 /**
  * @function
@@ -1786,7 +1747,7 @@ export async function removeProject(projectInfo: ProjectInfo): Promise<void> {
 
     containerInfoMap.delete(projectInfo.projectID);
     containerInfoForceRefreshMap.delete(projectInfo.projectID);
-    // MAYSUN projectWWWProtocolMap.delete(projectInfo.projectID);
+
     if (process.env.IN_K8 === "true") {
         dockerutil.removeDanglingImages();
     }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -60,7 +60,7 @@ export const LOCAL_WORKSPACE = process.env.NODE_ENV === "test" ? process.env.HOS
 const projectList: Array<string> = [];
 
 const isApplicationPodUpIntervalMap = new Map();
-const projectWWWProtocolMap = new Map();
+// MAYSUN const projectWWWProtocolMap = new Map();
 
 export interface ProjectEvent {
     operationId: string;
@@ -632,7 +632,7 @@ export async function containerDelete(projectInfo: ProjectInfo, script: string):
 
     containerInfoMap.delete(projectInfo.projectID);
     containerInfoForceRefreshMap.delete(projectInfo.projectID);
-    projectWWWProtocolMap.delete(projectInfo.projectID);
+    // MAYSUN projectWWWProtocolMap.delete(projectInfo.projectID);
     if (process.env.IN_K8 === "true") {
         logger.logProjectInfo(`Removing dangling images for ${projectInfo.projectID}`, projectInfo.projectID);
         dockerutil.removeDanglingImages();
@@ -908,43 +908,43 @@ export async function isContainerActive(projectID: string, handler: any): Promis
     }
 }
 
-/**
- * @function
- * @description Function to set the project's WWW protocol in the Map.
- *
- * @param projectID <Required | String> - The projectID.
- * @param isHttps <Optional | Boolean> - The WWW Protocol. The default value is false.
- *
- * @returns Promise<void>
- */
-export async function setProjectWWWProtocolMap(projectID: string, isHttps: boolean = false): Promise<void> {
-    if (!projectID) {
-        logger.logError("Cannot set the WWW protocol for an invalid projectID: " + projectID);
-        return;
-    }
-    projectWWWProtocolMap.set(projectID, isHttps);
-}
+// /**
+//  * @function
+//  * @description Function to set the project's WWW protocol in the Map.
+//  *
+//  * @param projectID <Required | String> - The projectID.
+//  * @param isHttps <Optional | Boolean> - The WWW Protocol. The default value is false.
+//  *
+//  * @returns Promise<void>
+//  */
+// export async function setProjectWWWProtocolMap(projectID: string, isHttps: boolean = false): Promise<void> {
+//     if (!projectID) {
+//         logger.logError("Cannot set the WWW protocol for an invalid projectID: " + projectID);
+//         return;
+//     }
+//     projectWWWProtocolMap.set(projectID, isHttps);
+// }
 
-/**
- * @function
- * @description Function to get the project's WWW protocol from the Map.
- *
- * @param projectID <Required | String> - The projectID.
- *
- * @returns Promise<void>
- */
-export async function getProjectWWWProtocolMap(projectID: string): Promise<boolean> {
-    if (!projectID) {
-        logger.logError("Cannot get the WWW protocol for an invalid projectID: " + projectID);
-        return;
-    }
+// /**
+//  * @function
+//  * @description Function to get the project's WWW protocol from the Map.
+//  *
+//  * @param projectID <Required | String> - The projectID.
+//  *
+//  * @returns Promise<void>
+//  */
+// export async function getProjectWWWProtocolMap(projectID: string): Promise<boolean> {
+//     if (!projectID) {
+//         logger.logError("Cannot get the WWW protocol for an invalid projectID: " + projectID);
+//         return;
+//     }
 
-    if (projectWWWProtocolMap.get(projectID)) {
-        return true;
-    } else {
-        return false;
-    }
-}
+//     if (projectWWWProtocolMap.get(projectID)) {
+//         return true;
+//     } else {
+//         return false;
+//     }
+// }
 
 /**
  * @function
@@ -1011,7 +1011,11 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
             updateDetailedAppStatus(projectID, containerInfo.ip, port, path);
         }
 
-        const isHttps: boolean = await getProjectWWWProtocolMap(projectID);
+        // default value of isHttps is false, overwrite if we have valid projectInfo.isHttps
+        let isHttps: boolean = false;
+        if (typeof projectInfo.isHttps == "boolean") {
+            isHttps = projectInfo.isHttps;
+        }
 
         const protocol = isHttps ? https : http;
 
@@ -1782,7 +1786,7 @@ export async function removeProject(projectInfo: ProjectInfo): Promise<void> {
 
     containerInfoMap.delete(projectInfo.projectID);
     containerInfoForceRefreshMap.delete(projectInfo.projectID);
-    projectWWWProtocolMap.delete(projectInfo.projectID);
+    // MAYSUN projectWWWProtocolMap.delete(projectInfo.projectID);
     if (process.env.IN_K8 === "true") {
         dockerutil.removeDanglingImages();
     }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -912,12 +912,12 @@ export async function isContainerActive(projectID: string, handler: any): Promis
  *
  * @returns Promise<void>
  */
-export async function setProjectWWWProtocolMap(projectID: string, isSecure: boolean = false): Promise<void> {
+export async function setProjectWWWProtocolMap(projectID: string, isHttps: boolean = false): Promise<void> {
     if (!projectID) {
         logger.logError("Cannot set the WWW protocol for an invalid projectID: " + projectID);
         return;
     }
-    projectWWWProtocolMap.set(projectID, isSecure);
+    projectWWWProtocolMap.set(projectID, isHttps);
 }
 
 /**
@@ -1006,9 +1006,9 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
             updateDetailedAppStatus(projectID, containerInfo.ip, port, path);
         }
 
-        const isSecure: boolean = await getProjectWWWProtocolMap(projectID);
+        const isHttps: boolean = await getProjectWWWProtocolMap(projectID);
 
-        const protocol = isSecure ? https : http;
+        const protocol = isHttps ? https : http;
 
         // Try to ping the application
         const options: any = {
@@ -1019,7 +1019,7 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
             timeout: 1000
         };
 
-        if (isSecure) {
+        if (isHttps) {
             options.rejectUnauthorized = false;
             options.secure = true;
         }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -632,6 +632,7 @@ export async function containerDelete(projectInfo: ProjectInfo, script: string):
 
     containerInfoMap.delete(projectInfo.projectID);
     containerInfoForceRefreshMap.delete(projectInfo.projectID);
+    projectWWWProtocolMap.delete(projectInfo.projectID);
     if (process.env.IN_K8 === "true") {
         logger.logProjectInfo(`Removing dangling images for ${projectInfo.projectID}`, projectInfo.projectID);
         dockerutil.removeDanglingImages();
@@ -909,10 +910,10 @@ export async function isContainerActive(projectID: string, handler: any): Promis
 
 /**
  * @function
- * @description Function to set the project's WWW protocol in the Map. This function is only invoked by the project settings API
+ * @description Function to set the project's WWW protocol in the Map.
  *
  * @param projectID <Required | String> - The projectID.
- * @param buildOutput <Optional | Boolean> - The WWW Protocol. The default value is false.
+ * @param isHttps <Optional | Boolean> - The WWW Protocol. The default value is false.
  *
  * @returns Promise<void>
  */
@@ -1252,8 +1253,6 @@ export async function buildAndRun(operation: Operation, command: string): Promis
         status: "failed"
     };
 
-    logger.logInfo("MJF operation is " + JSON.stringify(operation));
-
     if (operation.projectInfo.ignoredPaths) {
         projectEvent.ignoredPaths = operation.projectInfo.ignoredPaths;
     }
@@ -1377,7 +1376,6 @@ export async function buildAndRun(operation: Operation, command: string): Promis
  * @returns Promise<void>
  */
 async function containerBuildAndRun(event: string, buildInfo: BuildRequest, operation: Operation): Promise<void> {
-    logger.logInfo("MJF opertaion containerBuildAndRun " + JSON.stringify(operation));
     const normalizedProjectLocation = path.resolve(buildInfo.projectLocation);
     const projectName = normalizedProjectLocation.split("/").reverse()[0];
     const logDir = await logHelper.getLogDir(buildInfo.projectID, projectName);
@@ -1784,6 +1782,7 @@ export async function removeProject(projectInfo: ProjectInfo): Promise<void> {
 
     containerInfoMap.delete(projectInfo.projectID);
     containerInfoForceRefreshMap.delete(projectInfo.projectID);
+    projectWWWProtocolMap.delete(projectInfo.projectID);
     if (process.env.IN_K8 === "true") {
         dockerutil.removeDanglingImages();
     }
@@ -1840,8 +1839,6 @@ async function getPODInfoAndSendToPortal(operation: Operation): Promise<any> {
         key: "buildRequest",
         value: false
     };
-
-    logger.logInfo("MJF operation getPODInfoAndSendToPortal " + JSON.stringify(operation));
 
     if (projectInfo.ignoredPaths) {
         projectEvent.ignoredPaths = projectInfo.ignoredPaths;

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -54,6 +54,7 @@ module.exports = class FileWatcher {
           logEvent("projectSettingsChanged", fwProject);
           // Handle the projectSettingsChanged event only when we get a success
           if(fwProject.status === 'success') {
+            log.info("MJF registerFWListener success ");
             await this.handleNewOrUpdatedProject("projectSettingsChanged", fwProject);
           }
           this.user.uiSocket.emit("projectSettingsChanged", fwProject);
@@ -433,8 +434,9 @@ module.exports = class FileWatcher {
         let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
         await this.handleFWProjectEvent(event, projectUpdate);
         WebSocket.watchListChanged(data);
-      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties) {
+      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || fwProject.isHttps) {
         // Update the project.inf on project settings change
+        log.info("MJF handleNewOrUpdatedProject: " + JSON.stringify(fwProject));
         await this.handleFWProjectEvent(event, fwProject);
       }
     } catch (err) {
@@ -462,6 +464,7 @@ module.exports = class FileWatcher {
       if(error) {
         results.error = error;
       }
+      log.info("MJF handleFWProjectEvent: " + JSON.stringify(projectUpdate));
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
       this.user.uiSocket.emit(event, {...results , ...updatedProject});
       if (fwProject.buildStatus === 'inProgress') {

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -434,7 +434,7 @@ module.exports = class FileWatcher {
         let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
         await this.handleFWProjectEvent(event, projectUpdate);
         WebSocket.watchListChanged(data);
-      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || fwProject.isHttps) {
+      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || typeof fwProject.isHttps == "boolean") {
         // Update the project.inf on project settings change
         log.info("MJF handleNewOrUpdatedProject: " + JSON.stringify(fwProject));
         await this.handleFWProjectEvent(event, fwProject);

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -54,7 +54,6 @@ module.exports = class FileWatcher {
           logEvent("projectSettingsChanged", fwProject);
           // Handle the projectSettingsChanged event only when we get a success
           if(fwProject.status === 'success') {
-            log.info("MJF registerFWListener success ");
             await this.handleNewOrUpdatedProject("projectSettingsChanged", fwProject);
           }
           this.user.uiSocket.emit("projectSettingsChanged", fwProject);
@@ -436,7 +435,6 @@ module.exports = class FileWatcher {
         WebSocket.watchListChanged(data);
       } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || typeof fwProject.isHttps == "boolean") {
         // Update the project.inf on project settings change
-        log.info("MJF handleNewOrUpdatedProject: " + JSON.stringify(fwProject));
         await this.handleFWProjectEvent(event, fwProject);
       }
     } catch (err) {
@@ -464,7 +462,6 @@ module.exports = class FileWatcher {
       if(error) {
         results.error = error;
       }
-      log.info("MJF handleFWProjectEvent: " + JSON.stringify(projectUpdate));
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
       this.user.uiSocket.emit(event, {...results , ...updatedProject});
       if (fwProject.buildStatus === 'inProgress') {

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -38,7 +38,7 @@ const METRIC_TYPES = ['cpu', 'gc', 'memory', 'http']
 
 const CW_SETTINGS_PROPERTIES = [
   "contextRoot", "internalPort", "internalDebugPort",
-  "healthCheck", "ignoredPaths", "mavenProfiles", "mavenProperties"
+  "healthCheck", "isHttps", "ignoredPaths", "mavenProfiles", "mavenProperties"
 ];
 
 /**

--- a/test/utils/default-cw-settings.js
+++ b/test/utils/default-cw-settings.js
@@ -6,6 +6,7 @@ const defaultSpringSettings = {
     internalDebugPort: '',
     mavenProfiles: [''],
     mavenProperties: [''],
+    isHttps: false,
 };
 
 const defaultLibertySettings = {
@@ -16,6 +17,7 @@ const defaultLibertySettings = {
     ignoredPaths: [''],
     mavenProfiles: [''],
     mavenProperties: [''],
+    isHttps: false,
 };
 
 const defaultNodeSettings = {
@@ -24,6 +26,7 @@ const defaultNodeSettings = {
     internalDebugPort: '',
     healthCheck: '',
     ignoredPaths: [''],
+    isHttps: false,
 };
 
 const defaultSwiftSettings = {
@@ -31,6 +34,7 @@ const defaultSwiftSettings = {
     internalPort: '',
     healthCheck: '',
     ignoredPaths: [''],
+    isHttps: false,
 };
 
 const defaultDockerSettings = {
@@ -38,6 +42,7 @@ const defaultDockerSettings = {
     internalPort: '',
     healthCheck: '',
     ignoredPaths: [''],
+    isHttps: false,
 };
 
 module.exports = {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

Issue https://github.com/eclipse/codewind/issues/269

This PR enables Turbine layer to ping a project successfully if it's https enabled. This will allow the Codewind IDE plugins to open the application over https on the browser.

This feature is enabled by setting the boolean property `isHttps` in `.cw-settings`

Tested on both Local & Kube. Also updated the Portal cw-settings tests.

IDE now reports an https project as running in the overview page:
![Screen Shot 2019-08-16 at 5 50 38 PM](https://user-images.githubusercontent.com/31771087/63200419-2fe50b80-c04f-11e9-8676-65e68bc34bb2.png)

Here is my python application over https in the browser:
![Screen Shot 2019-08-16 at 5 50 44 PM](https://user-images.githubusercontent.com/31771087/63200432-3b383700-c04f-11e9-97ea-ae4faa6ef1b7.png)
