### PR TITLE
Handle path changes when updating load test preferences

### DIFF
--- a/src/performance/dashboard/src/components/chart/Chart.jsx
+++ b/src/performance/dashboard/src/components/chart/Chart.jsx
@@ -223,9 +223,24 @@ class Chart extends Component {
                 }
             } catch (err) {
                 // unable to show zoom extent
-                console.err("Unable to render zoom extent", err);
+                console.error("Unable to render zoom extent", err);
             }
         }
+    }
+
+    /**
+     * Determine if there is data available to plot on the chart
+     */
+    isDataAvailable(dataBundle) {
+        try {
+            if (dataBundle && dataBundle.columns && dataBundle.columns.length > 0 && dataBundle.columns[0].length > 1) {
+                return true;
+            }
+        } catch (err) {
+            console.error(`Unable to check for available data. ${err}`)
+            return false;
+        }
+        return false;
     }
 
     /**
@@ -254,20 +269,27 @@ class Chart extends Component {
 
     render() {
         const data = buildChartData(this.props.chartData, this.props.projectLanguage, this.props.absolutePath);
+        const testPath = `Path: ${this.props.absolutePath}`;
+        const hasData = this.isDataAvailable(data);
 
         return (
             <div className="Chart">
                 <div className="Chart_actionbar">
                     <div style={{ width: "300px", height: "35px" }}>
+                        {
+                            (hasData) ?
+                                <span className="testPath">{testPath}</span>
+                                : <Fragment />
+                        }
                     </div>
                 </div>
                 <div className="Chart_C3" style={{ padding: "20px" }} >
                     {
-                        data.columns.length === 0 ?
+                        (!hasData) ?
                             <div className="nodata">
                                 <div className="nodata_message">
                                     <div className="nodata_message_title">No metrics available</div>
-                                    <div className="nodata_message_help">Tip: Run a new load test</div>
+                                    <div className="nodata_message_help">Tip: Run a few load tests</div>
                                 </div>
                             </div>
                             : <Fragment />
@@ -292,6 +314,7 @@ const mapStateToProps = stores => {
 Chart.propTypes = {
     chartData: PropTypes.object.isRequired,
     absolutePath: PropTypes.string.isRequired,
+    httpMethod: PropTypes.string.isRequired,
     projectLanguage: PropTypes.string.isRequired,
 }
 

--- a/src/performance/dashboard/src/components/chart/Chart.jsx
+++ b/src/performance/dashboard/src/components/chart/Chart.jsx
@@ -110,13 +110,13 @@ class Chart extends Component {
 
     componentDidUpdate() {
         if (!this.chart) {
-            const colorPattern = { pattern: ChartUtils.getColorPattern(["CPU_PROCESS_MEAN", "MEM_PROCESS_PEAK", "HTTP_RESPONSE", "HTTP_HITS"]) };
-
+           
             // Re-render the entire chart using this base format
             this.chart = c3.generate({
                 data: {
                     columns: [],
                     classes: [],
+                    colors: ChartUtils.getColorPattern(["CPU_PROCESS_MEAN", "MEM_PROCESS_PEAK", "HTTP_RESPONSE", "HTTP_HITS"]) ,
                     selection: {
                         enabled: true,
                         grouped: false,
@@ -163,7 +163,6 @@ class Chart extends Component {
                         }
                     }
                 },
-                color: colorPattern,
                 point: { r: 5, select: { r: 12 }, focus: { expand: { r: 7 } } },
                 zoom: {
                     enabled: true,

--- a/src/performance/dashboard/src/components/chart/Chart.jsx
+++ b/src/performance/dashboard/src/components/chart/Chart.jsx
@@ -81,9 +81,9 @@ class Chart extends Component {
         if (!this.state.lastCounterSelected || this.state.lastCounterSelected === '') {
             return '';
         }
-           
+
         const lineString = getLineData(this.props.chartData, this.state.lastCounterSelected, this.props.projectLanguage, this.props.absolutePath);
-        if (lineString.length > 1) {
+        if (lineString && lineString.length > 1) {
             const values = lineString.slice(1);
             const lineNumbers = values.map(element => { return parseFloat(element) })
             const largestValue = Math.max(...lineNumbers);
@@ -110,13 +110,13 @@ class Chart extends Component {
 
     componentDidUpdate() {
         if (!this.chart) {
-           
+
             // Re-render the entire chart using this base format
             this.chart = c3.generate({
                 data: {
                     columns: [],
                     classes: [],
-                    colors: ChartUtils.getColorPattern(["CPU_PROCESS_MEAN", "MEM_PROCESS_PEAK", "HTTP_RESPONSE", "HTTP_HITS"]) ,
+                    colors: ChartUtils.getColorPattern(["CPU_PROCESS_MEAN", "MEM_PROCESS_PEAK", "HTTP_RESPONSE", "HTTP_HITS"]),
                     selection: {
                         enabled: true,
                         grouped: false,
@@ -194,7 +194,7 @@ class Chart extends Component {
         if (!this.chart) return;
 
         const data = buildChartData(this.props.chartData, this.props.projectLanguage, this.props.absolutePath);
-        
+
         // Change chart properties
         if (this.chart) {
             this.chart.axis.labels({ y: this.state.lastCounterSelected });
@@ -202,9 +202,9 @@ class Chart extends Component {
                 columns: data.columns,
                 classes: data.classes
             })
-            
+
             const enabledCounters = (this.props.chartCounters && this.props.chartCounters.enabledCounters) ? this.props.chartCounters.enabledCounters : []
-           
+
             // focus on selected ids:
             const checkedCounters = enabledCounters.filter(counter => counter.checked);
             let enabledCounterNames = checkedCounters.map(counter => {
@@ -233,7 +233,7 @@ class Chart extends Component {
      * @param {*} d 
      * @param {*} defaultTitleFormat 
      * @param {*} defaultValueFormat 
-     * @param {*} color 
+     * @param {*} color
      */
     chartTooltipContainer(d, defaultTitleFormat, defaultValueFormat, color) {
         const data = this.config.data_classes;

--- a/src/performance/dashboard/src/components/chart/Chart.scss
+++ b/src/performance/dashboard/src/components/chart/Chart.scss
@@ -20,6 +20,10 @@
   overflow: hidden;
 }
 
+.Chart_actionbar {
+  line-height: 40px;
+}
+
 .Chart_actionbar .bx--dropdown__wrapper--inline,
 .Chart_actionbar .bx--dropdown--inline {
   width: 100% !important;
@@ -80,7 +84,7 @@
 .c3-axis.c3-axis-y text,
 .c3-axis.c3-axis-x text {
   fill: $carbon--gray-10;
-  font-size:0.9rem;
+  font-size: 0.9rem;
 }
 
 .c3-grid line {

--- a/src/performance/dashboard/src/components/chart/ChartBuilder.js
+++ b/src/performance/dashboard/src/components/chart/ChartBuilder.js
@@ -55,29 +55,13 @@ export function addMemoryLine(counterKeys, data, chartData) {
     }
 }
 
-export function addHTTPLine(data, chartData, absolutePath) {
-    if (chartData.HTTP.columns && chartData.HTTP.columns.length > 0) {
-        const metricsRow = chartData.HTTP.columns.find(metric => {
-            return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
-        });
+export function addHTTPLine(lineName, rowName, data, chartData) {
+    if (chartData.HTTP.columns && chartData[lineName].columns.length > 0) {
+        const metricsRow = chartData[lineName].columns;
         if (metricsRow) {
             const metricsRowClone = metricsRow.slice();
-            data.columns.push(buildChartRow(metricsRowClone, "HTTP_RESPONSE"));
-            metricsRowClone[0] = "HTTP_RESPONSE";
-            data.classes.push(metricsRowClone);
-        }
-    }
-}
-
-export function addHTTPHits(data, chartData, absolutePath) {
-    if (chartData.HTTPHits.columns && chartData.HTTPHits.columns.length > 0) {
-        const metricsRow = chartData.HTTPHits.columns.find(metric => {
-            return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
-        });
-        if (metricsRow) {
-            const metricsRowClone = metricsRow.slice();
-            data.columns.push(buildChartRow(metricsRowClone, "HTTP_HITS"));
-            metricsRowClone[0] = "HTTP_HITS"
+            data.columns.push(buildChartRow(metricsRowClone, rowName));
+            metricsRowClone[0] = rowName;
             data.classes.push(metricsRowClone);
         }
     }
@@ -103,11 +87,10 @@ export function buildChartData(chartData, projectLanguage, absolutePath) {
     };
 
     const counterKeys = MetricsUtils.getLanguageCounters(projectLanguage);
+    addHTTPLine('HTTPHits', "HTTP_HITS", data, chartData);
+    addHTTPLine('HTTP', "HTTP_RESPONSE", data, chartData);
     addCPULine(counterKeys, data, chartData, absolutePath);
     addMemoryLine(counterKeys, data, chartData, absolutePath);
-    addHTTPLine(data, chartData, absolutePath);
-    addHTTPHits(data, chartData, absolutePath);
-
     return data;
 }
 
@@ -121,6 +104,7 @@ export function buildChartData(chartData, projectLanguage, absolutePath) {
  * @returns a plot line for the specified counter
  */
 export function getLineData(chartData, counterName, projectLanguage, absolutePath) {
+
     const counterKeys = MetricsUtils.getLanguageCounters(projectLanguage);
 
     switch (counterName) {
@@ -142,17 +126,13 @@ export function getLineData(chartData, counterName, projectLanguage, absolutePat
             return [];
         case 'HTTP_RESPONSE':
             if (chartData.HTTP.columns && chartData.HTTP.columns.length > 0) {
-                const metricsRow = chartData.HTTP.columns.find(metric => {
-                    return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
-                });
+                const metricsRow = chartData.HTTP.columns;
                 return metricsRow;
             }
             return [];
         case 'HTTP_HITS':
             if (chartData.HTTPHits.columns && chartData.HTTPHits.columns.length > 0) {
-                const metricsRow = chartData.HTTPHits.columns.find(metric => {
-                    return MetricsUtils.getPathFromURL(metric[0]) === absolutePath;
-                });
+                const metricsRow = chartData.HTTPHits.columns;
                 return metricsRow;
             }
             return [];

--- a/src/performance/dashboard/src/components/chart/ChartUtils.js
+++ b/src/performance/dashboard/src/components/chart/ChartUtils.js
@@ -41,9 +41,9 @@ const counterUnits = {
  * Given an array of counters, return the list of chart colors
  */
 let getColorPattern = function (counters) {
-    var chartColors = [];
+    var chartColors = {};
     counters.forEach(counterkey => {
-        chartColors.push(colorSwatches[counterkey]);
+        chartColors[counterkey] = colorSwatches[counterkey];
     });
     return chartColors;
 }

--- a/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
+++ b/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
@@ -139,7 +139,7 @@ class ChartCounterSelector extends Component {
                             <div className="categoryLabels">
                                 <Checkbox id="response" checked={this.isCounterEnabled('HTTP_RESPONSE')} onClick={(e) => this.handleExpandClick(e, "HTTP_RESPONSE")} labelText='Response (ms)' />
                             </div>
-                            <div className={this.isCounterEnabled('HTTP_RESPONSE') ? `options expanded` : `options`}>
+                            <div className="options expanded">
                                 <div className='option'>
                                     <IconLine className='bx--btn__icon' style={{ 'fill': this.getColor('HTTP_RESPONSE') }} />
                                     <TooltipDefinition tooltipText="HTTP Response time (ms) of this path" align="end" >
@@ -157,7 +157,7 @@ class ChartCounterSelector extends Component {
                             <div className="categoryLabels">
                                 <Checkbox id="hits" checked={this.isCounterEnabled('HTTP_HITS')} onClick={(e) => this.handleExpandClick(e, 'HTTP_HITS')} labelText='Hits' />
                             </div>
-                            <div className={this.isCounterEnabled('HTTP_HITS') ? `options expanded` : `options`}>
+                            <div className="options expanded">
                                 <div className='option'>
                                     <IconLine className='bx--btn__icon' style={{ 'fill': this.getColor('HTTP_HITS') }} />
                                     <span className='label'>
@@ -198,7 +198,7 @@ class ChartCounterSelector extends Component {
                                     </div>
                                 </Tooltip>
                             </div>
-                            <div className={this.isCounterEnabled('CPU_PROCESS_MEAN') ? `options expanded` : `options`}>
+                            <div className="options expanded">
                                 <div className='option'>
                                     <IconLine className='bx--btn__icon' style={{ 'fill': this.getColor('CPU_PROCESS') }} />
                                     <TooltipDefinition tooltipText="CPU used by application" align="end" >
@@ -216,7 +216,7 @@ class ChartCounterSelector extends Component {
                             <div className="categoryLabels">
                                 <Checkbox id="memory" checked={this.isCounterEnabled('MEM_PROCESS_PEAK')} onClick={(e) => this.handleExpandClick(e, 'MEM_PROCESS_PEAK')} labelText='Memory (MB)' />
                             </div>
-                            <div className={this.isCounterEnabled('MEM_PROCESS_PEAK') ? `options expanded` : `options`}>
+                            <div className="options expanded">
                                 <div className='option'>
                                     <IconLine className='bx--btn__icon' style={{ 'fill': this.getColor('MEM_PROCESS_PEAK') }} />
                                     <TooltipDefinition tooltipText="Process memory (Peak)" align="end" >
@@ -228,10 +228,6 @@ class ChartCounterSelector extends Component {
                         :
                         <Fragment />
                     }
-
-
-
-
                 </div>
             </div>
         )

--- a/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
+++ b/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
@@ -72,7 +72,7 @@ class ChartCounterSelector extends Component {
     }
 
     isCounterAvailable(chartData, counterName) {
-        return (chartData && chartData[counterName] && chartData[counterName].columns && chartData[counterName].columns.length > 0);
+        return (chartData && chartData[counterName] && chartData[counterName].columns && chartData[counterName].columns.length > 1);
     }
 
     isCounterEnabled(counterName) {
@@ -88,7 +88,7 @@ class ChartCounterSelector extends Component {
     render() {
         const { chartData, showTip } = this.props;
 
-        // 1. Only display the counter categories if they exist 
+        // 1. Only display the counter categories if they exist
         // 2. The counters must match the AbsolutePath load runner filter
         const hasHits = this.isCounterAvailable(chartData, "HTTPHits");
         const hasResponse = hasHits && this.isCounterAvailable(chartData, "HTTP");

--- a/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
+++ b/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
@@ -124,7 +124,8 @@ class RunTestHistory extends Component {
         })
         const http = snapshot.http.value.value.data;
         const urlMetrics = http.find(list => {
-            return list.url === searchURL
+            let uri = MetricsUtils.getPathFromURL(list.url);
+            return MetricsUtils.getEndpoint(uri) === searchURL;
         })
 
         switch (cell.info.header) {
@@ -178,7 +179,7 @@ class RunTestHistory extends Component {
 
     render() {
         const filteredRows = this.state.filteredRows;
-       
+
         return (
             <div className='RunTestHistory'>
 

--- a/src/performance/dashboard/src/modules/MetricsUtils.js
+++ b/src/performance/dashboard/src/modules/MetricsUtils.js
@@ -208,11 +208,7 @@ let getPathFromURL = function (url) {
  */
 let buildChartDataHTTP = function (params) {
 
-    const scaleFactor = params.scaleFactor;
-    const counterName = params.counterName;
-    const urlFilter = params.urlFilter;
-    const decimals = params.decimals;
-    const filteredData = params.filteredData;
+    const {scaleFactor, counterName, urlFilter, decimals, filteredData} = params;
 
     let columnData = [];
     columnData.push(counterName);
@@ -256,7 +252,8 @@ let getHTTPHitTimestamps = function (metrics, filteredUrl) {
             if (urlRow && urlRow.url) {
                 let uri = getPathFromURL(urlRow.url);
                 return getEndpoint(uri) === filteredUrl;
-            } return false;
+            } 
+            return false;
         });
         if (foundUrlSamples) {
             timestamps.push(snapshot.time);

--- a/src/performance/dashboard/src/modules/MetricsUtils.js
+++ b/src/performance/dashboard/src/modules/MetricsUtils.js
@@ -11,7 +11,7 @@
 
 /**
  * Returns the counter names for each fo the application metrics engines
- * @param {string} appMetricsName 
+ * @param {string} appMetricsName
  */
 let getLanguageCounters = function (appMetricsName) {
     switch (appMetricsName) {
@@ -122,12 +122,12 @@ let updateAllMetricDeltas = function (model, metricTypes, filteredUrl) {
 
 /**
  *  _getCounterNames
- * 
+ *
  *  Different languages return different counters for each of the metric types. 
- * 
+ *
  *  eg.  Memory metrics in Node would be:  [ "usedHeapAfterGCPeak", "usedNativePeak" ]
  *  eg.  Memory metrics in Swift would be:  [ "systemMean", "systemPeak", "processMean", "processPeak" ]
- * 
+ *
  *  Given a metric type,  this function returns the array list above.
  */
 let getCounterNames = function (mcAPIData, metricType) {
@@ -148,60 +148,50 @@ let getCounterNames = function (mcAPIData, metricType) {
 }
 
 /**
- * Formats the data from the Codewind metrics API into something which can 
+ * Formats the data from the Codewind metrics API into something which can
  * be plotted in a chart.  Only selected metrics (metricNames) will be returned
+ * 
  * @param  mcAPIData the data loaded from the REST service
  * @param  metricType  the type of metric being parsed eg  'memory' or 'cpu' or 'http' etc
  * @param  metricNames eg :    ['systemMean', 'systemPeak', 'processMean', 'processPeak']
  * @param  scaleFactor multiplication scale
  */
 
-let buildChartData = function (mcAPIData, metricType, scaleFactor, chartStyle) {
-
+let buildChartData = function (mcAPIData, filteredData, metricType, scaleFactor) {
     let counterNames = getCounterNames(mcAPIData, metricType);
-
-    let loadedData = mcAPIData.metrics;
     let columnData = [];
-    let testMetricsTypes = {};
-
-    if (loadedData.length > 0) {
-        // find the required section in the loaded data (because the API returns all the metric types in one go) 
-        const metrics = loadedData.find(a => a.type === metricType);
-
-        // extract the counters
-        let counters = metrics['metrics'];
-
-        columnData = counterNames.map(metricName => {
-            let metricsData = (counters.map(test => test.value.data[metricName]));
-
-            // scale the data
-            metricsData = metricsData.map(x => { return (x * scaleFactor).toFixed(); });
-            metricsData.unshift(metricName);
-
-            return metricsData;
+    counterNames.map(counterName => {
+        const counterRow = [];
+        counterRow.push(counterName);
+        filteredData.map(snapshot => {
+            const metricCounters = snapshot[metricType].value.value.data;
+            const value = (metricCounters[counterName] * scaleFactor).toFixed();
+            counterRow.push(value);
         });
-        // Set chart rendering
-        counterNames.forEach(name => {
-            testMetricsTypes[name] = chartStyle;
-        });
-    }
+        columnData.push(counterRow);
+    })
 
-    let chartData = {
+    // columnData should result in an array of counter names and values :
+    //  [
+    // `   ["systemMean", "18", "19", "20", "18", "11", "11", "12", "30", "14", "15"],
+    //     ["systemPeak", "23", "23", "23", "21", "14", "14", "15", "33", "16", "19"],
+    //     ["processMean", "15", "17", "18", "6", "8", "9", "9", "10", "11", "11"],
+    //     ["processPeak", "19", "19", "19", "8", "10", "10", "12", "11", "13", "14"]
+    //  ]
+
+    return {
         columns: columnData,
-        types: testMetricsTypes,
         selection: {
             enabled: true,
-            grouped: true, // select all vertical points
+            grouped: true,
             multiple: true,
             draggable: true,
         },
-
     };
-
-    return chartData;
 }
 
-/** 
+
+/**
  * Remove protocol, hostname and port from the URL if they exist
  */
 let getPathFromURL = function (url) {
@@ -218,71 +208,25 @@ let getPathFromURL = function (url) {
  */
 let buildChartDataHTTP = function (params) {
 
-    const mcAPIData = params.projectMetrics;
     const scaleFactor = params.scaleFactor;
     const counterName = params.counterName;
-    const chartType = params.chartType;
     const urlFilter = params.urlFilter;
+    const decimals = params.decimals;
+    const filteredData = params.filteredData;
 
     let columnData = [];
-    let metricTypes = {};
-    let loadedData = mcAPIData.metrics;
+    columnData.push(counterName);
 
-    if (loadedData.length > 0) {
+    filteredData.map(snapshot => {
+        const urlList = snapshot.http.value.value.data;
+        const urlRow = urlList.find(row => { return row.url === urlFilter });
+        let value = urlRow[counterName]
+        value = (value * scaleFactor).toFixed(decimals);
+        columnData.push(value);
+    });
 
-        // find the required section in the loaded data (because the API returns all the metric types in one go) 
-        const metrics = loadedData.find(section => section.type === 'http');
-
-        // extract the counters
-        let counters = metrics['metrics'];
-
-        // get the recorded urls (remove protocol, hostname and port)
-        let availableURLs = counters.map(snapshot => {
-            return snapshot.value.data.map(result => {
-                return getPathFromURL(result.url);
-            })
-        });
-        if (!availableURLs) { availableURLs = []; }
-
-        // get just the URL endpoints in a flat array
-        let flattenedArrayOfURLs = availableURLs.reduce((accumulatedList, currentValue) => {
-            return accumulatedList.concat(currentValue);
-        }, []
-        );
-
-        flattenedArrayOfURLs = flattenedArrayOfURLs.filter(url => (url === urlFilter));
-
-        if (!flattenedArrayOfURLs) {
-            flattenedArrayOfURLs = [];
-        }
-
-        // an array of unique url endpoints
-        let uniqueURLs = flattenedArrayOfURLs.filter((val, idx, arr) => arr.indexOf(val) === idx);
-        columnData = uniqueURLs.map(urlPath => {
-            let metricsData = (counters.map(test => {
-                // check that the URL path was hit in this snapshot and includes the requested metrics
-                // if it does not,  just return the counter value as ZERO 
-                let urlTests = test.value.data.find(x => {
-                    return getPathFromURL(x.url) === urlPath
-                });
-                return (urlTests) ? urlTests[counterName] : 0;
-            }
-            ));
-
-            // scale the data
-            metricsData = metricsData.map(x => { return (x * scaleFactor).toFixed(2); });
-            metricsData.unshift(urlPath);
-            return metricsData;
-        });
-
-        uniqueURLs.forEach(urlPath => {
-            metricTypes[urlPath] = chartType;
-        });
-    }
-
-    let chartData = {
+    return {
         columns: columnData,
-        types: metricTypes,
         selection: {
             enabled: true,
             grouped: true, // select all vertical points
@@ -290,8 +234,28 @@ let buildChartDataHTTP = function (params) {
             draggable: true,
         }
     };
+}
 
-    return chartData;
+/**
+ * Searches for the HTTP Hits (by path) and then returns the snapshot timestamps for that URL
+ *
+ * @param {*} metrics the loaded metrics from redux
+ * @param {string} filteredUrl the URL path
+ */
+let getHTTPHitTimestamps = function (metrics, filteredUrl) {
+
+    let timestamps = [];
+    const http = metrics.find(metric => { return metric.type === "http" });
+    http.metrics.forEach(snapshot => {
+        const urlList = snapshot.value.data;
+        const foundUrlSamples = urlList.find(urlRow => {
+            return urlRow.url === filteredUrl;
+        });
+        if (foundUrlSamples) {
+            timestamps.push(snapshot.time);
+        }
+    })
+    return timestamps;
 }
 
 /**
@@ -299,44 +263,30 @@ let buildChartDataHTTP = function (params) {
 */
 let sortMetrics = function (metrics, filteredUrl) {
 
-    // let metrics = this.props.statsMicroclimate.statsMicroclimate;
-    let timestamps = [];
+    // get timestamps keys from the http hits metric 
+    const httpHitTimestamps = getHTTPHitTimestamps(metrics, filteredUrl);
 
-    // read all the timestamps
-    metrics.forEach(metricType => {
-        timestamps = timestamps.concat(metricType.metrics.map(snapshot => {
-            return snapshot["time"]
-        }));
-    });
-
-    // remove any time duplicates
-    let distinctTimestamps = timestamps.filter((value, index, self) => {
-        return self.indexOf(value) === index;
-    })
-
-    // sort the timestamps in ascending order
-    distinctTimestamps.sort();
-
-    // morph and wrap timestamps, give each entry an ID and a plotNumber
     let x = -1;
-    let model = distinctTimestamps.map(t => {
+    let model = httpHitTimestamps.map(t => {
         x = x + 1;
         return { 'id': t.toString(), 'time': t, 'plotNumber': x }
     })
 
-    // merge all the metrics into the data model
-
+    // merge all the metrics into the data model using a timestamp key
     metrics.forEach(metricType => {
         metricType.metrics.forEach(snapshot => {
-            let timestamp = model.find(element => { return element['time'] === snapshot['time'] })
-            let metricsGroup = {}
-            metricsGroup.type = metricType.type;
-            metricsGroup.value = snapshot;
-            timestamp[metricType.type] = metricsGroup;
+            const timestamp = model.find(element => { return element['time'] === snapshot['time'] });
+            if (timestamp) {
+                let metricsGroup = {}
+                metricsGroup.type = metricType.type;
+                metricsGroup.value = snapshot;
+                timestamp[metricType.type] = metricsGroup;
+            }
         })
     });
 
-    // Make the load test description easier to access by copying it out of a metricType (CPU) and into the parent loadTest. 
+    // Make the load test description easier to access by copying it out of a metricType (CPU)
+    // and into the parent loadTest.
     model.forEach(loadTest => {
         loadTest.desc = loadTest.cpu.value.desc;
     })
@@ -363,7 +313,7 @@ let getURLAverageResponseTime = function (urlArray, urlPath) {
 }
 
 /**
- * 
+ *
  * @param {*} path eg /myApi?a=1
  * @returns {string} /myApi
  */

--- a/src/performance/dashboard/src/modules/MetricsUtils.js
+++ b/src/performance/dashboard/src/modules/MetricsUtils.js
@@ -219,7 +219,11 @@ let buildChartDataHTTP = function (params) {
 
     filteredData.map(snapshot => {
         const urlList = snapshot.http.value.value.data;
-        const urlRow = urlList.find(row => { return row.url === urlFilter });
+        const urlRow = urlList.find(row => {
+            let uri = getPathFromURL(row.url);
+            uri = getEndpoint(uri);
+            return uri === urlFilter
+        });
         let value = urlRow[counterName]
         value = (value * scaleFactor).toFixed(decimals);
         columnData.push(value);
@@ -249,12 +253,15 @@ let getHTTPHitTimestamps = function (metrics, filteredUrl) {
     http.metrics.forEach(snapshot => {
         const urlList = snapshot.value.data;
         const foundUrlSamples = urlList.find(urlRow => {
-            return urlRow.url === filteredUrl;
+            if (urlRow && urlRow.url) {
+                let uri = getPathFromURL(urlRow.url);
+                return getEndpoint(uri) === filteredUrl;
+            } return false;
         });
         if (foundUrlSamples) {
             timestamps.push(snapshot.time);
         }
-    })
+    });
     return timestamps;
 }
 
@@ -304,7 +311,10 @@ let getURLAverageResponseTime = function (urlArray, urlPath) {
         return result;
     }
 
-    let urlEntry = urlArray.find(entry => { return getPathFromURL(entry.url) === urlPath })
+    let urlEntry = urlArray.find(entry => {
+        let uri = getPathFromURL(entry.url);
+        return getEndpoint(uri) === urlPath;
+    });
 
     if (urlEntry) {
         result = urlEntry.averageResponseTime;

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -151,6 +151,7 @@ class PagePerformance extends React.Component {
 
         const { snapshot_1, snapshot_2, snapshot_3 } = this.state;
         const absolutePath = MetricsUtils.getEndpoint(this.props.loadRunnerConfig.config.path) ? MetricsUtils.getEndpoint(this.props.loadRunnerConfig.config.path) : '';
+        const httpMethod = this.props.loadRunnerConfig.config.method;
         const projectLanguage = (this.props.projectInfo.config.language) ? this.props.projectInfo.config.language : '';
         const showTip = !(this.state.chartData && this.state.chartData.CPU && this.state.chartData.CPU.columns && this.state.chartData.CPU.columns.length > 0);
         return (
@@ -198,7 +199,7 @@ class PagePerformance extends React.Component {
                         <div className="chart-component">
                             <ErrorBoundary>
                                 {projectLanguage && absolutePath ?
-                                    <Chart chartData={this.state.chartData} projectLanguage={projectLanguage} absolutePath={absolutePath} />
+                                    <Chart chartData={this.state.chartData} httpMethod={httpMethod} projectLanguage={projectLanguage} absolutePath={absolutePath} />
                                     :
                                     <Fragment />
                                 }

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -18,7 +18,7 @@ import { fetchProjectMetrics, reloadMetricsData } from '../store/actions/project
 import { fetchProjectLoadConfig } from '../store/actions/loadRunnerConfigActions';
 import { fetchProjectConfig } from '../store/actions/projectInfoActions';
 import { SocketEvents } from '../utils/sockets/SocketEvents';
-import { CHART_TYPE_CPU, CHART_TYPE_MEMORY, CHART_TYPE_HITS } from '../AppConstants';
+import { CHART_TYPE_CPU, CHART_TYPE_MEMORY } from '../AppConstants';
 import ActionRunLoad from '../components/actions/ActionRunLoad';
 import ActionModifyLoadTests from '../components/actions/ActionModifyLoadTests';
 import Chart from '../components/chart/Chart';
@@ -63,10 +63,10 @@ class PagePerformance extends React.Component {
         if (!this.props.projectID) { return; }
         this.bindSocketHandlers();
 
-        // read the project configuration        
+        // read the project configuration
         await this.props.dispatch(fetchProjectConfig(this.props.projectID));
 
-        // read the load runner configuration        
+        // read the load runner configuration
         await this.props.dispatch(fetchProjectLoadConfig(this.props.projectID));
 
         // Determine which metrics are available for this project
@@ -106,25 +106,25 @@ class PagePerformance extends React.Component {
             const snapshot_3 = listModel[listModel.length - 3];
 
             // parse the memory metrics for the chart API
-            let memoryData = MetricsUtils.buildChartData(projectMetrics, CHART_TYPE_MEMORY, (1 / 1024 / 1024), 'area-spline');
+            let memoryData = MetricsUtils.buildChartData(projectMetrics, listModel, CHART_TYPE_MEMORY, (1 / 1024 / 1024));
 
             // parse the cpu metrics for the chart API
-            let cpuData = MetricsUtils.buildChartData(projectMetrics, CHART_TYPE_CPU, 100, 'area-spline');
+            let cpuData = MetricsUtils.buildChartData(projectMetrics, listModel, CHART_TYPE_CPU, 100);
 
             // parse the http metrics (ResponseTime) for the chart API
             let params = {
                 projectMetrics: projectMetrics,
+                filteredData: listModel,
                 scaleFactor: 1,
-                counterName: 'averageResponseTime',
-                chartType: 'bar',
+                decimals: 2,
                 urlFilter: absolutePath
             }
+
+            params.counterName = "averageResponseTime";
             let httpResponseData = MetricsUtils.buildChartDataHTTP(params);
 
-            // parse the http metrics (Hits) for the chart API
-            params.chartName = CHART_TYPE_HITS;
-            params.chartType = 'line';
             params.counterName = "hits";
+            params.decimals = 0;
             let httpHitsData = MetricsUtils.buildChartDataHTTP(params);
 
             // Update State
@@ -177,7 +177,7 @@ class PagePerformance extends React.Component {
                                     snapshot_2 ?
                                         <ResultsCard title='Previous test' snapshot={snapshot_2} snapshotPrevious={snapshot_3} projectID={this.props.projectID} absolutePath={absolutePath} projectLanguage={projectLanguage} />
                                         :
-                                        <ResultsCard_Blank title='Previous test'/>
+                                        <ResultsCard_Blank title='Previous test' />
                                 }
                             </ErrorBoundary>
                         </div>
@@ -187,7 +187,7 @@ class PagePerformance extends React.Component {
                                     snapshot_1 ?
                                         <ResultsCard title='Latest test' snapshot={snapshot_1} snapshotPrevious={snapshot_2} projectID={this.props.projectID} absolutePath={absolutePath} projectLanguage={projectLanguage} />
                                         :
-                                        <ResultsCard_Blank title='Latest test'/>
+                                        <ResultsCard_Blank title='Latest test' />
                                 }
                             </ErrorBoundary>
                         </div>


### PR DESCRIPTION
Originated from Issue: https://github.com/eclipse/codewind/issues/164 

# Problem

After changing the PATH field under the load test preferences dialog,  clicking save closes the settings dialog box,  however the chart does will refresh and instead displays the red error handler "Unable to render". 

![Screenshot 2019-08-20 at 15 40 00](https://user-images.githubusercontent.com/28102564/63357460-611c4f00-c361-11e9-8627-fb10037a197a.png)


# Workaround 

Manually refresh the browser page

# Solution

* This PR ensures that when changing the path,  the counter filter is re-applied using the new path value. 
* Since each project type produces path URLs formatted differently,  (Java for example includes protocol and port information, some include query strings etc where as NodeJS does not) the change also normalises the path into its simplest form by stripping off the server/port and query string.

# Additions 

With the chart now showing just HTTP plots for a specific path, these changes ensure non-HTTP counters such as CPU and Memory snapshots are also excluded from the charts if they were measured for an endpoint other than the filtered path. By synchronising the metrics across all types and filtering them by path, the charts behaviour is more predictable. 

Ran existing test bucket : 

Test Suites: 6 passed, 6 total
Tests:       41 passed, 41 total