### PR TITLE
Automatically install appsody into Codewind

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,11 @@ pipeline {
                         # Copy the docs into portal
                         cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 
+                        echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
+                        mkdir -p ${SRC_DIR}/pfe/extensions
+                        rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.3.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.3.0.zip
+
                         # BUILD IMAGES
                         # Uses a build file in each of the directories that we want to use
                         echo -e "\n+++   BUILDING DOCKER IMAGES   +++\n";

--- a/script/build.sh
+++ b/script/build.sh
@@ -56,7 +56,7 @@ cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 # Copy the appsody extension into portal. The zip file must have a version number e.g. codewind-appsody-extension-0.3.0.zip
 # in order for it to be accepted as a valid extension
 mkdir -p ${SRC_DIR}/pfe/extensions
-rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.3.0.zip
+rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.3.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.3.0.zip
 
 # BUILD IMAGES

--- a/script/build.sh
+++ b/script/build.sh
@@ -55,6 +55,7 @@ cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 
 # Copy the appsody extension into portal. The zip file must have a version number e.g. codewind-appsody-extension-0.3.0.zip
 # in order for it to be accepted as a valid extension
+echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
 mkdir -p ${SRC_DIR}/pfe/extensions
 rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.3.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.3.0.zip

--- a/script/build.sh
+++ b/script/build.sh
@@ -53,6 +53,12 @@ cp -r $DIR/NOTICE.md ${SRC_DIR}/performance/
 # Copy the docs into portal
 cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 
+# Copy the appsody extension into portal. The zip file must have a version number e.g. codewind-appsody-extension-0.3.0.zip
+# in order for it to be accepted as a valid extension
+mkdir -p ${SRC_DIR}/pfe/extensions
+rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.3.0.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.3.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.3.0.zip
+
 # BUILD IMAGES
 # Uses a build file in each of the directories that we want to use
 echo -e "\n+++   BUILDING DOCKER IMAGES   +++\n";

--- a/src/pfe/.gitignore
+++ b/src/pfe/.gitignore
@@ -1,3 +1,4 @@
 /initialize
+/extensions
 devbuild.env
 devbuild-example.env

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -159,6 +159,9 @@ RUN chmod -R +rx /file-watcher/idc
 
 WORKDIR /codewind-workspace
 
+WORKDIR /extensions
+COPY /extensions /extensions
+
 EXPOSE 9090
 
 # Moved the FORCE_COLOR env var for colored logs from root-watcher.sh to the Dockerfile

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -81,6 +81,10 @@ RUN chmod 644 /etc/sudoers \
     && ln -s /codewind-workspace /projects \
     && adduser mcuser
 
+######### Extensions setup.
+RUN mkdir /extensions
+COPY /extensions /extensions
+
 ######### File watcher setup.
 RUN mkdir /file-watcher
 WORKDIR /file-watcher
@@ -101,11 +105,6 @@ RUN npm ci \
 
 # Copy translation files to the distribution directory
 RUN cp -r src/utils/locales dist/utils/locales
-
-######### Extensions setup.
-RUN mkdir /extensions
-WORKDIR /extensions
-COPY /extensions /extensions
 
 ######### Portal setup
 # This is copied in a later build stage.

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -81,6 +81,8 @@ RUN chmod 644 /etc/sudoers \
     && ln -s /codewind-workspace /projects \
     && adduser mcuser
 
+COPY /extensions /extensions
+
 ######### File watcher setup.
 RUN mkdir /file-watcher
 WORKDIR /file-watcher
@@ -158,9 +160,6 @@ COPY /file-watcher/idc /file-watcher/idc
 RUN chmod -R +rx /file-watcher/idc
 
 WORKDIR /codewind-workspace
-
-WORKDIR /extensions
-COPY /extensions /extensions
 
 EXPOSE 9090
 

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -81,8 +81,6 @@ RUN chmod 644 /etc/sudoers \
     && ln -s /codewind-workspace /projects \
     && adduser mcuser
 
-COPY /extensions /extensions
-
 ######### File watcher setup.
 RUN mkdir /file-watcher
 WORKDIR /file-watcher
@@ -103,6 +101,11 @@ RUN npm ci \
 
 # Copy translation files to the distribution directory
 RUN cp -r src/utils/locales dist/utils/locales
+
+######### Extensions setup.
+RUN mkdir /extensions
+WORKDIR /extensions
+COPY /extensions /extensions
 
 ######### Portal setup
 # This is copied in a later build stage.


### PR DESCRIPTION
Downloads the appsody zip from the release. I don't use "latest" and choose a static version to ensure the version used in codewind is the version we want.

The zip is copied into the extensions folder into the pfe container. Logic already exists to pickup this zip and extract it into the codewind workspace .extensions directory.

Verified that with a deleted codewind workspace, the appsody extension gets installed with this code change.

@makandre can you help take a look too? Thank you