### PR TITLE
Fix deletion of extension project handler

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -764,8 +764,9 @@ export async function projectDeletion(projectID: string): Promise<number> {
         // Call delete on the associated project handler
         if (projectInfo.projectType) {
             // first we find and remove the project handler (note: built-in handers are not actually removed)
-            const selectedProjectHandler = await projectExtensions.removeProjectHandler(projectInfo);
+            const selectedProjectHandler = await projectExtensions.getProjectHandler(projectInfo);
             const returnVal = await selectedProjectHandler.deleteContainer(projectInfo);
+            await projectExtensions.removeProjectHandler(projectInfo);
             if (returnVal instanceof Error) {
                 returnCode = 500;
             } else {

--- a/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
+++ b/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
@@ -237,7 +237,7 @@ export async function removeProjectHandler(projectInfo: ProjectInfo): Promise<an
     // delete to prevent initializing a new handler
     delete projectInfo.extensionID;
 
-    const handler = getProjectHandler(projectInfo);
+    const handler = await getProjectHandler(projectInfo);
 
     const key = projectInfo.projectID;
     if (extensionProjectHandlers[key]) {

--- a/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
+++ b/src/pfe/file-watcher/server/src/extensions/projectExtensions.ts
@@ -234,6 +234,9 @@ export async function getProjectHandler(projectInfo: ProjectInfo): Promise<any> 
  */
 export async function removeProjectHandler(projectInfo: ProjectInfo): Promise<any> {
 
+    // delete to prevent initializing a new handler
+    delete projectInfo.extensionID;
+
     const handler = getProjectHandler(projectInfo);
 
     const key = projectInfo.projectID;


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Fixes #232

The issue was after removing project handler, we call `deleteContainer` which actually was triggering a re-creation of the handler (which fails because the project directory is deleted).  The fix ensures we remove the project handler after `deleteContainer`.