### PR TITLE
Remove the MICROCLIMATE_RELEASE_NAME label

### DIFF
--- a/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
+++ b/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
@@ -34,10 +34,8 @@ yq w -i $deploymentFile -- metadata.name $concatenatedReleaseName
 yq w -i $serviceFile -- metadata.name $concatenatedReleaseName
 
 # Add the missing labels to the deployment
-yq w -i $deploymentFile -- metadata.labels.microclimate-release $MICROCLIMATE_RELEASE_NAME
 yq w -i $deploymentFile -- metadata.labels.release $releaseName
 yq w -i $deploymentFile -- spec.template.metadata.labels.release $releaseName
-yq w -i $deploymentFile -- spec.template.metadata.labels.microclimate-release $MICROCLIMATE_RELEASE_NAME
 
 # Add owner reference for deletion when workspace is deleted
 addOwnerReference $deploymentFile
@@ -46,7 +44,6 @@ addOwnerReference $deploymentFile
 yq w -i $deploymentFile -- spec.template.spec.serviceAccountName $SERVICE_ACCOUNT_NAME
 
 # Add the labels to the service
-yq w -i $serviceFile -- metadata.labels.microclimate-release $MICROCLIMATE_RELEASE_NAME
 yq w -i $serviceFile -- metadata.labels.release $releaseName
 
 # Add owner reference for deletion when workspace is deleted

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -1397,7 +1397,6 @@ async function containerBuildAndRun(event: string, buildInfo: BuildRequest, oper
         // Modify the temp copy of the chart to add the needed labels and serviceAccount
         try {
             // Render the chart template
-            const microclimateReleaseName: string = process.env.MICROCLIMATE_RELEASE_NAME;
             await processManager.spawnDetachedAsync(buildInfo.projectID, "helm", ["template", defaultChartLocation, "--name", buildInfo.containerName, "--values=/file-watcher/scripts/override-values.yaml", "--set", "image.repository=" + deploymentRegistry + "/" + buildInfo.containerName, "--output-dir=" + chartParentFolder], {});
 
             // Find the locations of the deployment and service file

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -294,8 +294,7 @@ export async function printHelmStatus(projectID: string, releaseName: string): P
  * @returns Promise<ProcessResult>
  */
 export async function installChart(projectID: string, deploymentName: string, chartLocation: string, deploymentRegistry: string): Promise<ProcessResult> {
-    const microclimateReleaseName: string = process.env.MICROCLIMATE_RELEASE_NAME;
-    const installDeployment: string[] = ["upgrade", "--install", deploymentName, "--recreate-pods", "--values=/file-watcher/scripts/override-values.yaml", "--set", "image.repository=" + deploymentRegistry + "/" + deploymentName, "--set", "microclimate.release.name=" + microclimateReleaseName, chartLocation];
+    const installDeployment: string[] = ["upgrade", "--install", deploymentName, "--recreate-pods", "--values=/file-watcher/scripts/override-values.yaml", "--set", "image.repository=" + deploymentRegistry + "/" + deploymentName, chartLocation];
     let response: ProcessResult;
 
     // Install deployment


### PR DESCRIPTION
Resolves https://github.com/eclipse/codewind/issues/190

Removes the section of code in Turbine that added `$MICROCLIMATE_RELEASE_NAME` as a label to all projects deployed by Codewind. This label is no longer relevant and wasn't be used for anything, and so can be safely removed.