### PR TITLE
Test loadtest API against our OpenAPI doc

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -413,6 +413,10 @@ paths:
       responses:
         200:
           description: Write to runLoad/config.json successful
+          content:
+            application/json:
+              schema:
+                type: string
         400:
           description: Incorrect parameters given
         404:

--- a/src/pfe/portal/routes/projects/loadtest.route.js
+++ b/src/pfe/portal/routes/projects/loadtest.route.js
@@ -163,7 +163,7 @@ router.post('/api/v1/projects/:id/loadtest/config', validateReq, async function 
       delete configOptions.body;
     }
     await project.writeNewLoadTestConfigFile(configOptions);
-    res.status(200).send(`load-test/config.json successfully written to project ${project.name}`);
+    res.status(200).json(`load-test/config.json successfully written to project ${project.name}`);
   } catch (err) {
     log.error(err.info || err);
     res.status(500).send(err.info || err);

--- a/test/package.json
+++ b/test/package.json
@@ -24,7 +24,7 @@
     "chai": "^4.1.2",
     "chai-files": "^1.4.0",
     "chai-http": "^4.0.0",
-    "chai-openapi-response-validator": "^0.2.3",
+    "chai-openapi-response-validator": "^0.2.4",
     "child-process-promise": "^2.2.1",
     "dateformat": "^3.0.3",
     "dockerode": "^2.5.2",

--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -13,8 +13,10 @@ const chai = require('chai');
 
 const projectService = require('../../../modules/project.service');
 const reqService = require('../../../modules/request.service');
-const { testTimeout, ADMIN_COOKIE } = require('../../../config');
+const { testTimeout, ADMIN_COOKIE, pathToApiSpec } = require('../../../config');
+const chaiResValidator = require('chai-openapi-response-validator');
 
+chai.use(chaiResValidator(pathToApiSpec));
 chai.should();
 
 describe('Load Runner Tests', function() {
@@ -42,7 +44,7 @@ describe('Load Runner Tests', function() {
 
             // workspace_location = await projectService.findWorkspaceLocation();
             // const projectPath = path.join(workspace_location, projectName);
-            //await fs.remove(projectPath);
+            // await fs.remove(projectPath);
         });
 
         describe('POST loadtest/config', function() {
@@ -51,14 +53,14 @@ describe('Load Runner Tests', function() {
                     it('returns status 200 to POST/loadtest/config to the load-test/config.json', async function() {
                         this.timeout(testTimeout.short);
                         const res = await writeToLoadTestConfig(projectID, configOptions);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                     });
 
                     it('returns status 200 to POST/loadtest/config when query parameters are included', async function() {
                         this.timeout(testTimeout.short);
                         configOptions.query = { a: '1', b: '2' };
                         const res = await writeToLoadTestConfig(projectID, configOptions);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                     });
 
                     it('returns status 200 to GET/loadtest/config with the correct decoded options', async function() {
@@ -67,7 +69,7 @@ describe('Load Runner Tests', function() {
                         delete configOptions.query;
                         expectedSavedConfig = modifyOptions(configOptions, { path: '/?a=1&b=2' });
                         const res = await readLoadTestConfig(projectID);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                         res.body.should.deep.equal(expectedSavedConfig);
                     });
                 });
@@ -77,13 +79,13 @@ describe('Load Runner Tests', function() {
                         configOptions.query = { a: '1', b: '2' };
                         configOptions.config = 'Not a valid option';
                         const res = await writeToLoadTestConfig(projectID, configOptions);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                     });
 
                     it('returns status 200 to GET/loadtest/config and not return these non-config fields in loadtest/config.json', async function() {
                         this.timeout(testTimeout.short);
                         const res = await readLoadTestConfig(projectID);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                         res.body.should.deep.equal(expectedSavedConfig);
                     });
                 });
@@ -92,14 +94,14 @@ describe('Load Runner Tests', function() {
                         this.timeout(testTimeout.short);
                         configOptions.query = {};
                         const res = await writeToLoadTestConfig(projectID, configOptions);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                     });
 
                     it('returns status 200 to GET/loadtest/config and not return these non-config fields in loadtest/config.json', async function() {
                         this.timeout(testTimeout.short);
                         expectedSavedConfig.path = '/';
                         const res = await readLoadTestConfig(projectID);
-                        res.should.have.status(200);
+                        res.should.have.status(200).and.satisfyApiSpec;
                         res.body.should.deep.equal(expectedSavedConfig);
                     });
                 });
@@ -142,7 +144,7 @@ describe('Load Runner Tests', function() {
                 it('returns status 200 to GET/loadtest/config from the load-test/config.json', async function() {
                     this.timeout(testTimeout.short);
                     const res = await readLoadTestConfig(projectID);
-                    res.should.have.status(200);
+                    res.should.have.status(200).and.satisfyApiSpec;
                     res.body.should.deep.equal(expectedSavedConfig);
                 });
             });


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Similar to https://github.com/eclipse/codewind/pull/203 and https://github.com/eclipse/codewind/pull/205, this uses our Chai OpenAPI response validator plugin to automatically test that PFE responds as our OpenAPI doc claims it does. 

Discovered and corrected minor mistakes in PFE and our doc. In PFE, we had forgotten to set the `application/json` header for the `200` response to `POST /api/v1/projects/{id}/loadtest/config`. Correspondingly, we had also forgot to specify a response body in our doc.