### PR TITLE
Fix circular dependency from logHelper to libertyProject

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -58,11 +58,6 @@ if (!process.env.IN_K8) {
     defaultIgnoredPath.push("/chart");
 }
 
-export const libertyAppLogs = {
-    "messages": "messages", // for liberty project messages log
-    "console": "console" // for liberty project console log
-};
-
 /**
  * @function
  * @description Create operation for a liberty project.
@@ -266,7 +261,7 @@ export async function getAppLog(logDirectory: string, projectID: string, project
         logDirectory, // for app.log
     ];
 
-    const logSuffixes = [libertyAppLogs.console, libertyAppLogs.messages];
+    const logSuffixes = [logHelper.libertyAppLogs.console, logHelper.libertyAppLogs.messages];
     const ffdclogPath = path.join(logDirs[0], `ffdc`);
     const inWorkspaceLogFiles = await logHelper.getLogFilesWithTimestamp(logDirs[1], [logHelper.appLogs.app]);
 

--- a/src/pfe/file-watcher/server/src/projects/logHelper.ts
+++ b/src/pfe/file-watcher/server/src/projects/logHelper.ts
@@ -19,7 +19,6 @@ import * as logger from "../utils/logger";
 import * as projectsController from "../controllers/projectsController";
 import * as dockerutil from "../utils/dockerutil";
 import { BuildLog, AppLog } from "./Project";
-import { libertyAppLogs } from "./libertyProject";
 
 const statAsync = promisify(fs.stat);
 const existsSync = promisify(fs.exists);
@@ -34,6 +33,11 @@ export const buildLogs = {
 
 const defaultAppLogs = {
     "app": "app" // app container log file available for all projects
+};
+
+export const libertyAppLogs = {
+    "messages": "messages", // for liberty project messages log
+    "console": "console" // for liberty project console log
 };
 
 export const appLogs = Object.assign(defaultAppLogs, libertyAppLogs);

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectUtil.module.test.ts
@@ -418,9 +418,9 @@ export function projectUtilTestModule(): void {
                         await writeAsync(filePath, "some data");
                     }
                     if (appLogTest && data.projectType === "liberty") {
-                        const consoleLogPath = path.resolve(appLogDirectory, libertyProject.libertyAppLogs.console + ".log" );
+                        const consoleLogPath = path.resolve(appLogDirectory, logHelper.libertyAppLogs.console + ".log" );
                         await writeAsync(consoleLogPath, "some data");
-                        const messagesLogPath = path.resolve(appLogDirectory, libertyProject.libertyAppLogs.messages + ".log");
+                        const messagesLogPath = path.resolve(appLogDirectory, logHelper.libertyAppLogs.messages + ".log");
                         await writeAsync(messagesLogPath, "some data");
                         const ffdcDir = path.resolve(appLogDirectory, "ffdc" );
                         await mkdirAsync(ffdcDir);


### PR DESCRIPTION
## Description

We should avoid the circular dependecy from `logHelper` module to `libertyProject` module. Moved the variable to exists in `logHelper` so that the dependency is one way only.

Signed-off-by: ssh24 <sakib@ibm.com>