### PR TITLE
Issue#86: introduce timeout for pingTransitApplication

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -461,7 +461,6 @@ function pingInTransitApplications(): void {
                                 if (pingCount >= 10) {
                                     newState = AppState.stopped;
                                     newMsg = "Failed to ping application due to timeout.";
-                                    pingCount = 0;
                                 }
 
                                 if (newState === AppState.started) {


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

introduce timeout for pingTransitApplication. 
If the application cannot be `started` in 10 pings, change the application's status to `stopped`, with message: `Failed to ping application due to timeout.`


```
[21/08/19 22:08:34 libertytest] [INFO] pingInTransitApplications: Application state error message: Failed to ping application due to timeout.
[21/08/19 22:08:34 libertytest] [INFO] pingInTransitApplications: Application state for project a34fb6e0-c457-11e9-b7d0-c99d8978e2fd has changed from starting to stopped
[21/08/19 22:08:34 libertytest] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "a34fb6e0-c457-11e9-b7d0-c99d8978e2fd",
  "appStatus": "stopped"
}
```