### PR TITLE
Unskip templates tests

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -109,10 +109,7 @@ module.exports = class Templates {
   }
 
   getEnabledRepositories() {
-    return this.getRepositories().filter(repo =>
-      // if the repo doesn't specify whether it's enabled, consider it enabled
-      (repo.enabled || !repo.hasOwnProperty('enabled'))
-    );
+    return this.getRepositories().filter(repo => repo.enabled);
   }
 
   doesRepositoryExist(repoUrl) {
@@ -205,6 +202,7 @@ module.exports = class Templates {
     const newRepo = {
       url: repoUrl,
       description: repoDescription,
+      enabled: true,
     }
     this.repositoryList.push(newRepo);
     this.needsRefresh = true;

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -253,13 +253,17 @@ async function getTemplatesFromRepo(repository) {
     throw new Error(`URL '${repoUrl}' should return JSON`);
   }
   const templates = templateSummaries.map(summary => {
-    return {
+    const template = {
       label: summary.displayName,
       description: summary.description,
       language: summary.language,
       url: summary.location,
-      projectType: summary.projectType
+      projectType: summary.projectType,
     };
+    if (summary.projectStyle) {
+      template.projectStyle = summary.projectStyle;
+    }
+    return template;
   });
   return templates;
 }

--- a/test/modules/log.service.js
+++ b/test/modules/log.service.js
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+require('mocha-sinon');
+const sinonChai = require('sinon-chai');
+const chai = require('chai');
+
+chai.use(sinonChai);
+
+ /**
+ * To help unit testing.
+ * Use in a Mocha `describe` block to suppress logger output.
+ * @param rewiredModule instantiate one via something like `const rewiredModule = rewire('path/to/module');`
+ */
+function suppressLogOutput(rewiredModule) {
+    const log = rewiredModule.__get__('log');
+    const logLevels = ['error', 'warn', 'info', 'debug', 'trace'];
+
+    beforeEach(function() {
+        logLevels.forEach(level =>
+            this.sinon.stub(log, level)
+        );
+    });
+    afterEach(function() {
+        logLevels.forEach(level =>
+            log[level].restore()
+        );
+    });
+}
+
+module.exports = {
+    suppressLogOutput,
+};

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -11,7 +11,7 @@
 const { ADMIN_COOKIE } = require('../config');
 const reqService = require('./request.service');
 
-const defaultTemplates = [
+const defaultCodewindTemplates = [
     {
         label: 'Go template',
         description: 'Sample microservice for simple go app',
@@ -70,6 +70,78 @@ const defaultTemplates = [
     },
 ];
 
+const defaultAppsodyTemplates = [
+    {
+        label: 'Appsody Eclipse MicroProfile® template',
+        description: 'Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven',
+        language: 'java',
+        url: 'https://github.com/appsody/stacks/releases/download/java-microprofile-v0.2.7/incubator.java-microprofile.templates.default.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody LoopBack 4 template',
+        description: 'LoopBack 4 API Framework for Node.js',
+        language: 'nodejs',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-loopback-v0.1.1/incubator.nodejs-loopback.templates.scaffold.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Node.js Express simple template',
+        description: 'Express web framework for Node.js',
+        language: 'nodejs',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.3/incubator.nodejs-express.templates.simple.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Node.js Express skaffold template',
+        description: 'Express web framework for Node.js',
+        language: 'nodejs',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.3/incubator.nodejs-express.templates.skaffold.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Node.js template',
+        description: 'Runtime for Node.js applications',
+        language: 'nodejs',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Spring Boot® default template',
+        description: 'Spring Boot using OpenJ9 and Maven',
+        language: 'java',
+        url: 'https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.4/incubator.java-spring-boot2.templates.default.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Spring Boot® kotlin template',
+        description: 'Spring Boot using OpenJ9 and Maven',
+        language: 'java',
+        url: 'https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.4/incubator.java-spring-boot2.templates.kotlin.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Swift template',
+        description: 'Runtime for Swift applications',
+        language: 'swift',
+        url: 'https://github.com/appsody/stacks/releases/download/swift-v0.1.2/incubator.swift.templates.simple.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+];
+
+const defaultTemplates = [
+    ...defaultCodewindTemplates,
+    ...defaultAppsodyTemplates,
+];
+
 const styledTemplates = {
     codewind: {
         label: 'Codewind template',
@@ -90,17 +162,20 @@ const styledTemplates = {
 };
 
 const sampleRepos = {
-    default: {
+    codewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-        description: 'Standard Codewind templates.',
-        enabled: true,
+        description: 'Default codewind templates.',
+    },
+    anotherCodewind: {
+        url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json',
+        description: 'Additional Codewind templates.',
     },
     appsody: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-appsody-templates/master/devfiles/index.json',
         description: 'Appsody extension for Codewind',
     },
 };
-const defaultRepoList = [sampleRepos.default];
+const defaultRepoList = [sampleRepos.codewind];
 
 async function getTemplateRepos() {
     const res = await reqService.chai
@@ -165,6 +240,10 @@ async function getTemplates(queryParams) {
     return res;
 }
 
+/**
+ * Removes all templates repos known to PFE, and adds the supplied repos
+ * @param {[JSON]} repoList
+ */
 async function resetTemplateReposTo(repoList) {
     const reposToDelete = (await getTemplateRepos()).body;
     await Promise.all(reposToDelete.map(repo =>
@@ -184,6 +263,7 @@ async function getTemplateStyles() {
 
 module.exports = {
     defaultTemplates,
+    defaultCodewindTemplates,
     styledTemplates,
     sampleRepos,
     defaultRepoList,

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -75,7 +75,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Eclipse MicroProfile® template',
         description: 'Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven',
         language: 'java',
-        url: 'https://github.com/appsody/stacks/releases/download/java-microprofile-v0.2.7/incubator.java-microprofile.templates.default.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/java-microprofile-v0.2.11/incubator.java-microprofile.v0.2.11.templates.default.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -83,7 +83,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody LoopBack 4 template',
         description: 'LoopBack 4 API Framework for Node.js',
         language: 'nodejs',
-        url: 'https://github.com/appsody/stacks/releases/download/nodejs-loopback-v0.1.1/incubator.nodejs-loopback.templates.scaffold.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-loopback-v0.1.4/incubator.nodejs-loopback.templates.scaffold.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -91,7 +91,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Node.js Express simple template',
         description: 'Express web framework for Node.js',
         language: 'nodejs',
-        url: 'https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.3/incubator.nodejs-express.templates.simple.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.5/incubator.nodejs-express.templates.simple.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -99,7 +99,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Node.js Express skaffold template',
         description: 'Express web framework for Node.js',
         language: 'nodejs',
-        url: 'https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.3/incubator.nodejs-express.templates.skaffold.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-express-v0.2.5/incubator.nodejs-express.templates.skaffold.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -107,7 +107,15 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Node.js template',
         description: 'Runtime for Node.js applications',
         language: 'nodejs',
-        url: 'https://github.com/appsody/stacks/releases/download/nodejs-v0.2.3/incubator.nodejs.templates.simple.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/nodejs-v0.2.5/incubator.nodejs.templates.simple.tar.gz',
+        projectType: 'appsodyExtension',
+        projectStyle: 'Appsody',
+    },
+    {
+        label: 'Appsody Python Flask template',
+        description: 'Flask web Framework for Python',
+        language: 'python',
+        url: 'https://github.com/appsody/stacks/releases/download/python-flask-v0.1.3/incubator.python-flask.v0.1.3.templates.simple.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -115,7 +123,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Spring Boot® default template',
         description: 'Spring Boot using OpenJ9 and Maven',
         language: 'java',
-        url: 'https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.4/incubator.java-spring-boot2.templates.default.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.9/incubator.java-spring-boot2.v0.3.9.templates.default.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -123,7 +131,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Spring Boot® kotlin template',
         description: 'Spring Boot using OpenJ9 and Maven',
         language: 'java',
-        url: 'https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.4/incubator.java-spring-boot2.templates.kotlin.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/java-spring-boot2-v0.3.9/incubator.java-spring-boot2.v0.3.9.templates.kotlin.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -131,7 +139,7 @@ const defaultAppsodyTemplates = [
         label: 'Appsody Swift template',
         description: 'Runtime for Swift applications',
         language: 'swift',
-        url: 'https://github.com/appsody/stacks/releases/download/swift-v0.1.2/incubator.swift.templates.simple.tar.gz',
+        url: 'https://github.com/appsody/stacks/releases/download/swift-v0.1.4/incubator.swift.templates.simple.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
     },
@@ -247,7 +255,7 @@ async function getTemplates(queryParams) {
  * Removes all templates repos known to PFE, and adds the supplied repos
  * @param {[JSON]} repoList
  */
-async function resetTemplateReposTo(repoList) {
+async function setTemplateReposTo(repoList) {
     const reposToDelete = (await getTemplateRepos()).body;
     await Promise.all(reposToDelete.map(repo =>
         deleteTemplateRepo(repo.url)
@@ -264,6 +272,28 @@ async function getTemplateStyles() {
     return res;
 }
 
+function saveReposBeforeTestAndRestoreAfter() {
+    let originalTemplateRepos;
+    before(async() => {
+        const res = await getTemplateRepos();
+        originalTemplateRepos = res.body;
+    });
+    after(async() => {
+        await setTemplateReposTo(originalTemplateRepos);
+    });
+}
+
+function saveReposBeforeEachTestAndRestoreAfterEach() {
+    let originalTemplateRepos;
+    beforeEach(async() => {
+        const res = await getTemplateRepos();
+        originalTemplateRepos = res.body;
+    });
+    afterEach(async() => {
+        await setTemplateReposTo(originalTemplateRepos);
+    });
+}
+
 module.exports = {
     defaultTemplates,
     defaultCodewindTemplates,
@@ -277,6 +307,8 @@ module.exports = {
     enableTemplateRepos,
     disableTemplateRepos,
     getTemplates,
-    resetTemplateReposTo,
+    setTemplateReposTo,
     getTemplateStyles,
+    saveReposBeforeTestAndRestoreAfter,
+    saveReposBeforeEachTestAndRestoreAfterEach,
 };

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -164,15 +164,18 @@ const styledTemplates = {
 const sampleRepos = {
     codewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-        description: 'Default codewind templates.',
+        description: 'Standard Codewind templates.',
+        enabled: true,
     },
     anotherCodewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json',
         description: 'Additional Codewind templates.',
+        enabled: true,
     },
     appsody: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-appsody-templates/master/devfiles/index.json',
         description: 'Appsody extension for Codewind',
+        enabled: true,
     },
 };
 const defaultRepoList = [sampleRepos.codewind];

--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -10,8 +10,6 @@
  *******************************************************************************/
 
 const chai = require('chai');
-//const fs = require('fs-extra');
-const path = require('path');
 
 const projectService = require('../../../modules/project.service');
 const reqService = require('../../../modules/request.service');
@@ -21,7 +19,7 @@ chai.should();
 
 describe('Load Runner Tests', function() {
     describe('loadtest/config Tests', function() {
-        let projectID, workspace_location, expectedSavedConfig;
+        let projectID, expectedSavedConfig;
         const projectName = `loadrunnerconfigtest${Date.now()}`;
         const configOptions = {
             path: '/',
@@ -34,15 +32,16 @@ describe('Load Runner Tests', function() {
             this.timeout(testTimeout.med);
             projectID = await projectService.cloneAndBindProject(projectName, 'nodejs');
         });
-        
+
         after(async function() {
             this.timeout(2 * testTimeout.med);
-            workspace_location = await projectService.findWorkspaceLocation();
-            const projectPath = path.join(workspace_location, projectName);
             await projectService.unbindProject(projectID);
-            // after is failing in jenkins with permission issues.  This is not
-            // actually part of the test, its us trying to be good and clean up   
 
+            // after is failing in jenkins with permission issues.  This is not
+            // actually part of the test, its us trying to be good and clean up
+
+            // workspace_location = await projectService.findWorkspaceLocation();
+            // const projectPath = path.join(workspace_location, projectName);
             //await fs.remove(projectPath);
         });
 
@@ -102,7 +101,7 @@ describe('Load Runner Tests', function() {
                         const res = await readLoadTestConfig(projectID);
                         res.should.have.status(200);
                         res.body.should.deep.equal(expectedSavedConfig);
-                    });   
+                    });
                 });
             });
 
@@ -137,7 +136,7 @@ describe('Load Runner Tests', function() {
                 });
             });
         });
-        
+
         describe('GET loadtest/config', () => {
             describe('Valid Input', () => {
                 it('returns status 200 to GET/loadtest/config from the load-test/config.json', async function() {
@@ -160,18 +159,19 @@ describe('Load Runner Tests', function() {
     describe('runLoad Tests', function() {
         const projectName = `loadrunnertest${Date.now()}`;
         let projectID;
- 
+
         before(async function() {
             this.timeout(3 * testTimeout.med);
             projectID = await projectService.cloneAndBindAndBuildProject(projectName, 'nodejs');
             await projectService.awaitProjectStarted(projectID);
         });
-        
+
         after(async function() {
             this.timeout(2 * testTimeout.med);
-            const workspace_location = await projectService.findWorkspaceLocation();
-            const projectPath = path.join(workspace_location, projectName);
             await projectService.unbindProject(projectID);
+
+            // const workspace_location = await projectService.findWorkspaceLocation();
+            // const projectPath = path.join(workspace_location, projectName);
             //await fs.remove(projectPath);
         });
 

--- a/test/src/API/templates.test.js
+++ b/test/src/API/templates.test.js
@@ -21,15 +21,21 @@ const {
     getTemplates,
     addTemplateRepo,
     deleteTemplateRepo,
-    resetTemplateReposTo,
+    setTemplateReposTo,
     getTemplateStyles,
-} = require('../../modules/template.service');
-const { pathToApiSpec } = require('../../config');
+    saveReposBeforeTestAndRestoreAfter,
+    saveReposBeforeEachTestAndRestoreAfterEach,
+} = require('../modules/template.service');
+const { pathToApiSpec } = require('../config');
 
 chai.should();
 chai.use(chaiResValidator(pathToApiSpec));
 
 describe('Template API tests', function() {
+    saveReposBeforeTestAndRestoreAfter();
+    before(async() => {
+        await setTemplateReposTo([{ ...sampleRepos.codewind }]);
+    });
     describe('GET /api/v1/templates', function() {
         describe('?projectStyle=', function() {
             describe('empty', function() {
@@ -100,7 +106,7 @@ describe('Template API tests', function() {
             originalNumTemplates = res2.body.length;
         });
         after(async() => {
-            await resetTemplateReposTo(originalTemplateRepos);
+            await setTemplateReposTo(originalTemplateRepos);
         });
         it('GET should return a list of available template repositories', async function() {
             const res = await getTemplateRepos();
@@ -223,14 +229,7 @@ describe('Template API tests', function() {
                 }],
             },
         };
-        let originalTemplateRepos;
-        beforeEach(async() => {
-            const res = await getTemplateRepos();
-            originalTemplateRepos = res.body;
-        });
-        afterEach(async() => {
-            await resetTemplateReposTo(originalTemplateRepos);
-        });
+        saveReposBeforeEachTestAndRestoreAfterEach();
         for (const [testName, test] of Object.entries(tests)) {
             describe(`to ${testName}`, function() {
                 it(`should return 207 and the expected operations info`, async function() {

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -12,116 +12,100 @@ const chai = require('chai');
 
 const {
     sampleRepos,
+    getTemplates,
     getTemplateRepos,
-    addTemplateRepo,
     enableTemplateRepos,
     disableTemplateRepos,
-    getTemplates,
     resetTemplateReposTo,
 } = require('../../../modules/template.service');
 
 chai.should();
 
-describe.skip('Batch enabling template repositories', function() {
-    describe('when enabling a single repo', function() {
-        let originalTemplateRepos;
-        let repoToTest;
-        before(async() => {
-            const res = await getTemplateRepos();
-            originalTemplateRepos = res.body;
-            repoToTest = { ...originalTemplateRepos[0] };
-        });
-        after(async() => {
-            await resetTemplateReposTo(originalTemplateRepos);
-        });
-        it(`batch enabling a single template repo returns 207 and sub-status 200`, async function() {
-            const res = await enableTemplateRepos([repoToTest.url]);
-            res.should.have.status(207);
-            res.body[0].status.should.equal(200);
-        });
-        it(`that repo appears as enabled in list of template repos`, async function() {
-            const res = await getTemplateRepos();
-            res.should.have.status(200);
-            res.body.should.deep.include({
-                ...repoToTest,
-                enabled: true,
-            });
-        });
-        it(`batch disabling that template repo returns 207 and sub-status 200`, async function() {
-            const res = await disableTemplateRepos([repoToTest.url]);
-            res.should.have.status(207);
-            res.body[0].status.should.equal(200);
-        });
-        it(`that repo appears as disabled in list of template repos`, async function() {
-            const res = await getTemplateRepos();
-            res.should.have.status(200);
-            res.body.should.deep.include({
-                ...repoToTest,
-                enabled: false,
-            });
-        });
-        it(`templates from the disabled repo do not appear in list of enabled templates`, async function() {
-            const res = await getTemplates({ showEnabledOnly: true });
-            res.should.have.status(204);
-            // TODO: switch over to the below when we have 2 repos (so that 1 repo can still be enabled, so we return 200 rather than 204 No Content)
-            // res.should.have.status(200)
-            // res.body.should.not.include.deep.members(defaultTemplates);
-        });
-    });
-    describe('when enabling multiple template repositories', function() {
-        let originalTemplateRepos;
-        let reposToTest;
-        before(async() => {
-            const res = await getTemplateRepos();
-            originalTemplateRepos = res.body;
+describe('Batch enabling repositories', function() {
+    const tests = {
+        '1 repo': {
+            testRepos: [{ ...sampleRepos.codewind }],
+        },
+        'multiple repos': {
+            testRepos: [
+                { ...sampleRepos.codewind },
+                { ...sampleRepos.appsody },
+            ],
+        },
+    };
 
-            await addTemplateRepo(sampleRepos.appsody);
-            const res2 = await getTemplateRepos();
-            reposToTest = [...res2.body];
+    for (const [testName, test] of Object.entries(tests)) {
+        describe(testName, function() { // eslint-disable-line
+            let originalTemplateRepos;
+            const { testRepos } = test;
+            let templatesFromTestRepos;
+            before(async() => {
+                const res = await getTemplateRepos();
+                originalTemplateRepos = res.body;
+
+                await resetTemplateReposTo(testRepos);
+
+                const res2 = await getTemplates();
+                templatesFromTestRepos = res2.body;
+            });
+            after(async() => {
+                await resetTemplateReposTo(originalTemplateRepos);
+            });
+            it(`batch DISabling ${testRepos.length} repos returns 207 and sub-status 200 for each subrequest`, async function() {
+                const repoUrls = testRepos.map(repo => repo.url);
+                const res = await disableTemplateRepos(repoUrls);
+
+                res.should.have.status(207);
+                res.body.forEach(subResponse =>
+                    subResponse.status.should.equal(200)
+                );
+            });
+            it(`those repos are listed as DISabled`, async function() {
+                const disabledRepos = testRepos.map(repo => {
+                    return {
+                        ...repo,
+                        enabled: false,
+                    };
+                });
+
+                const res = await getTemplateRepos();
+
+                res.should.have.status(200);
+                res.body.should.have.deep.members(disabledRepos);
+            });
+            it(`those repos' templates DON'T appear in list of ENabled templates`, async function() {
+                const res = await getTemplates({ showEnabledOnly: true });
+                res.should.have.status(200);
+                res.body.should.not.have.deep.members(templatesFromTestRepos);
+            });
+
+            it(`batch ENabling repos ${testRepos.length} returns 207 and sub-status 200 for each subrequest`, async function() {
+                const repoUrls = testRepos.map(repo => repo.url);
+                const res = await enableTemplateRepos(repoUrls);
+
+                res.should.have.status(207);
+                res.body.forEach(subResponse =>
+                    subResponse.status.should.equal(200)
+                );
+            });
+            it(`those repos are listed as ENabled`, async function() {
+                const enabledRepos = testRepos.map(repo => {
+                    return {
+                        ...repo,
+                        enabled: true,
+                    };
+                });
+
+                const res = await getTemplateRepos();
+
+                res.should.have.status(200);
+                res.body.should.have.deep.members(enabledRepos);
+            });
+            it(`those repos' templates DO appear in list of ENabled templates`, async function() {
+                const res = await getTemplates({ showEnabledOnly: true });
+                res.should.have.status(200);
+                res.body.should.have.deep.members(templatesFromTestRepos);
+            });
         });
-        after(async function() {
-            await resetTemplateReposTo(originalTemplateRepos);
-        });
-        it(`batch enabling multiple template repos returns 207 and sub-status 200 for each subrequest`, async function() {
-            const repoUrls = reposToTest.map(repo => repo.url);
-            const res = await enableTemplateRepos(repoUrls);
-            res.should.have.status(207);
-            res.body.forEach(subResponse =>
-                subResponse.status.should.equal(200)
-            );
-        });
-        it(`those repos appear as enabled in list of template repos`, async function() {
-            const res = await getTemplateRepos();
-            res.should.have.status(200);
-            reposToTest.forEach(repo =>
-                res.body.should.deep.include({
-                    ...repo,
-                    enabled: true,
-                })
-            );
-        });
-        it(`batch disabling multiple template repos returns 207 and sub-status 200 for each subrequest`, async function() {
-            const repoUrls = reposToTest.map(repo => repo.url);
-            const res = await disableTemplateRepos(repoUrls);
-            res.should.have.status(207);
-            res.body[0].status.should.equal(200);
-        });
-        it(`those repos appear as disabled in list of template repos`, async function() {
-            const res = await getTemplateRepos();
-            res.should.have.status(200);
-            reposToTest.forEach(repo =>
-                res.body.should.deep.include({
-                    ...repo,
-                    enabled: false,
-                })
-            );
-        });
-        it(`templates from the disabled repos do not appear in list of enabled templates`, async function() {
-            const res = await getTemplates({ showEnabledOnly: true });
-            res.should.have.status(204);
-            // TODO: switch over to the below when we have 2 repos (so that 1 repo can still be enabled, so we return 200 rather than 204 No Content)
-            // res.should.have.status(200)
-            // res.body.should.not.include.deep.members(defaultTemplates);
-        });
-    });
+    }
 });

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -35,7 +35,7 @@ describe('Batch enabling repositories', function() {
     };
 
     for (const [testName, test] of Object.entries(tests)) {
-        describe(testName, function() { // eslint-disable-line
+        describe(testName, function() {
             let originalTemplateRepos;
             const { testRepos } = test;
             let templatesFromTestRepos;
@@ -51,7 +51,7 @@ describe('Batch enabling repositories', function() {
             after(async() => {
                 await resetTemplateReposTo(originalTemplateRepos);
             });
-            it(`batch DISabling ${testRepos.length} repos returns 207 and sub-status 200 for each subrequest`, async function() {
+            it(`returns 207 and sub-status 200 for each subrequest when batch disabling ${testRepos.length} repos`, async function() {
                 const repoUrls = testRepos.map(repo => repo.url);
                 const res = await disableTemplateRepos(repoUrls);
 
@@ -60,7 +60,7 @@ describe('Batch enabling repositories', function() {
                     subResponse.status.should.equal(200)
                 );
             });
-            it(`those repos are listed as DISabled`, async function() {
+            it(`lists those repos as disabled`, async function() {
                 const disabledRepos = testRepos.map(repo => {
                     return {
                         ...repo,
@@ -73,13 +73,13 @@ describe('Batch enabling repositories', function() {
                 res.should.have.status(200);
                 res.body.should.have.deep.members(disabledRepos);
             });
-            it(`those repos' templates DON'T appear in list of ENabled templates`, async function() {
+            it(`checks templates from the disabled repos do not appear in the list of enabled templates`, async function() {
                 const res = await getTemplates({ showEnabledOnly: true });
                 res.should.have.status(200);
                 res.body.should.not.have.deep.members(templatesFromTestRepos);
             });
 
-            it(`batch ENabling repos ${testRepos.length} returns 207 and sub-status 200 for each subrequest`, async function() {
+            it(`returns 207 and sub-status 200 for each subrequest when batch enabling ${testRepos.length} repos`, async function() {
                 const repoUrls = testRepos.map(repo => repo.url);
                 const res = await enableTemplateRepos(repoUrls);
 
@@ -88,7 +88,7 @@ describe('Batch enabling repositories', function() {
                     subResponse.status.should.equal(200)
                 );
             });
-            it(`those repos are listed as ENabled`, async function() {
+            it(`lists those repos as enabled`, async function() {
                 const enabledRepos = testRepos.map(repo => {
                     return {
                         ...repo,
@@ -101,7 +101,7 @@ describe('Batch enabling repositories', function() {
                 res.should.have.status(200);
                 res.body.should.have.deep.members(enabledRepos);
             });
-            it(`those repos' templates DO appear in list of ENabled templates`, async function() {
+            it(`checks templates from the enabled repos do not appear in the list of enabled templates`, async function() {
                 const res = await getTemplates({ showEnabledOnly: true });
                 res.should.have.status(200);
                 res.body.should.have.deep.members(templatesFromTestRepos);

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -16,7 +16,8 @@ const {
     getTemplateRepos,
     enableTemplateRepos,
     disableTemplateRepos,
-    resetTemplateReposTo,
+    setTemplateReposTo,
+    saveReposBeforeTestAndRestoreAfter,
 } = require('../../../modules/template.service');
 
 chai.should();
@@ -35,21 +36,15 @@ describe('Batch enabling repositories', function() {
     };
 
     for (const [testName, test] of Object.entries(tests)) {
-        describe(testName, function() {
-            let originalTemplateRepos;
+        describe(testName, function() { // eslint-disable-line no-loop-func
             const { testRepos } = test;
             let templatesFromTestRepos;
+            saveReposBeforeTestAndRestoreAfter();
             before(async() => {
-                const res = await getTemplateRepos();
-                originalTemplateRepos = res.body;
+                await setTemplateReposTo(testRepos);
 
-                await resetTemplateReposTo(testRepos);
-
-                const res2 = await getTemplates();
-                templatesFromTestRepos = res2.body;
-            });
-            after(async() => {
-                await resetTemplateReposTo(originalTemplateRepos);
+                const res = await getTemplates();
+                templatesFromTestRepos = res.body;
             });
             it(`returns 207 and sub-status 200 for each subrequest when batch disabling ${testRepos.length} repos`, async function() {
                 const repoUrls = testRepos.map(repo => repo.url);

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -25,8 +25,8 @@ const {
     getTemplateStyles,
     saveReposBeforeTestAndRestoreAfter,
     saveReposBeforeEachTestAndRestoreAfterEach,
-} = require('../modules/template.service');
-const { pathToApiSpec } = require('../config');
+} = require('../../../modules/template.service');
+const { pathToApiSpec } = require('../../../config');
 
 chai.should();
 chai.use(chaiResValidator(pathToApiSpec));

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -16,7 +16,7 @@ const path = require('path');
 const Templates = require('../../../src/pfe/portal/modules/Templates');
 const {
     styledTemplates,
-    defaultTemplates,
+    defaultCodewindTemplates,
     defaultRepoList,
     sampleRepos,
 } = require('../../modules/template.service');
@@ -108,10 +108,10 @@ describe('Templates.js', function() {
         });
         describe(`when we do refresh`, function() {
             describe('', function() {
-                it('returns the default templates', async function() {
+                it('returns the default Codewind templates', async function() {
                     const templateController = new Templates('');
                     const output = await templateController.getAllTemplates();
-                    output.should.deep.equal(defaultTemplates);
+                    output.should.deep.equal(defaultCodewindTemplates);
                 });
             });
             describe('and add an extra template repo', function() {
@@ -119,14 +119,14 @@ describe('Templates.js', function() {
                 before(() => {
                     templateController = new Templates('');
                     templateController.repositoryList = [
-                        sampleRepos.default,
+                        sampleRepos.codewind,
                         sampleRepos.appsody,
                     ];
                 });
                 it('returns more templates', async function() {
                     const output = await templateController.getAllTemplates();
-                    output.should.include.deep.members(defaultTemplates);
-                    (output.length).should.be.above(defaultTemplates.length);
+                    output.should.include.deep.members(defaultCodewindTemplates);
+                    (output.length).should.be.above(defaultCodewindTemplates.length);
                 });
             });
             describe('and add an extra bad template repo', function() {
@@ -134,13 +134,13 @@ describe('Templates.js', function() {
                 before(() => {
                     templateController = new Templates('');
                     templateController.repositoryList = [
-                        sampleRepos.default,
+                        sampleRepos.codewind,
                         { url: 'https://www.google.com/' },
                     ];
                 });
                 it('returns only the default templates', async function() {
                     const output = await templateController.getAllTemplates();
-                    output.should.deep.equal(defaultTemplates);
+                    output.should.deep.equal(defaultCodewindTemplates);
                 });
             });
         });
@@ -190,8 +190,8 @@ describe('Templates.js', function() {
     describe('getTemplatesFromRepo(repository)', function() {
         describe('(<validRepository>)', function() {
             it('returns the correct templates', async function() {
-                const output = await Templates.getTemplatesFromRepo(defaultRepoList[0]);
-                output.should.have.deep.members(defaultTemplates);
+                const output = await Templates.getTemplatesFromRepo(sampleRepos.codewind);
+                output.should.have.deep.members(defaultCodewindTemplates);
             });
         });
         describe('(<invalidRepository>)', function() {
@@ -232,10 +232,10 @@ describe('Templates.js', function() {
         });
         describe('(<defaultRepoList>)', function() {
             describe('when we have no providers', function() {
-                it('returns the default templates', async function() {
+                it('returns the default Codewind templates', async function() {
                     const templateController = new Templates('');
                     const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                    output.should.deep.equal(defaultTemplates);
+                    output.should.deep.equal(defaultCodewindTemplates);
                 });
             });
             describe(`when providers don't provide repo lists`, function() {
@@ -246,9 +246,9 @@ describe('Templates.js', function() {
                         getRepositories() { return 'should be array'; },
                     });
                 });
-                it('still returns the default templates (ignoring the invalid providers)', async function() {
+                it('still returns the default Codewind templates (ignoring the invalid providers)', async function() {
                     const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                    output.should.deep.equal(defaultTemplates);
+                    output.should.deep.equal(defaultCodewindTemplates);
                 });
             });
             describe('when providers list invalid repos', function() {
@@ -260,9 +260,9 @@ describe('Templates.js', function() {
                             getRepositories() { return ['should be object']; },
                         });
                     });
-                    it('still returns the default templates (ignoring the invalid repos)', async function() {
+                    it('still returns the default Codewind templates (ignoring the invalid repos)', async function() {
                         const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                        output.should.deep.equal(defaultTemplates);
+                        output.should.deep.equal(defaultCodewindTemplates);
                     });
                 });
                 describe('missing URL', function() {
@@ -275,9 +275,9 @@ describe('Templates.js', function() {
                             },
                         });
                     });
-                    it('still returns the default templates (ignoring the invalid repos)', async function() {
+                    it('still returns the default Codewind templates (ignoring the invalid repos)', async function() {
                         const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                        output.should.deep.equal(defaultTemplates);
+                        output.should.deep.equal(defaultCodewindTemplates);
                     });
                 });
                 describe('invalid URL', function() {
@@ -293,9 +293,9 @@ describe('Templates.js', function() {
                             },
                         });
                     });
-                    it('still returns the default templates (ignoring the invalid repos)', async function() {
+                    it('still returns the default Codewind templates (ignoring the invalid repos)', async function() {
                         const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                        output.should.deep.equal(defaultTemplates);
+                        output.should.deep.equal(defaultCodewindTemplates);
                     });
                 });
                 describe('duplicate URL', function() {
@@ -311,9 +311,9 @@ describe('Templates.js', function() {
                             },
                         });
                     });
-                    it('still returns the default templates (ignoring the invalid repos)', async function() {
+                    it('still returns the default Codewind templates (ignoring the invalid repos)', async function() {
                         const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                        output.should.deep.equal(defaultTemplates);
+                        output.should.deep.equal(defaultCodewindTemplates);
                     });
                 });
                 describe(`valid URL that doesn't provide JSON`, function() {
@@ -329,9 +329,9 @@ describe('Templates.js', function() {
                             },
                         });
                     });
-                    it('still returns the default templates (ignoring the invalid repos)', async function() {
+                    it('still returns the default Codewind templates (ignoring the invalid repos)', async function() {
                         const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                        output.should.deep.equal(defaultTemplates);
+                        output.should.deep.equal(defaultCodewindTemplates);
                     });
                 });
             });
@@ -348,10 +348,10 @@ describe('Templates.js', function() {
                         },
                     });
                 });
-                it(`returns the default templates and the provider's templates`, async function() {
+                it(`returns the default Codewind templates and the provider's templates`, async function() {
                     const output = await templateController.getTemplatesFromRepos(defaultRepoList);
-                    output.should.include.deep.members(defaultTemplates);
-                    (output.length).should.be.above(defaultTemplates.length);
+                    output.should.include.deep.members(defaultCodewindTemplates);
+                    (output.length).should.be.above(defaultCodewindTemplates.length);
                 });
             });
         });

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -182,7 +182,7 @@ describe('Templates.js', function() {
             },
         };
         for (const [testName, test] of Object.entries(tests)) {
-            describe(testName, function() { // eslint-disable-line
+            describe(testName, function() {
                 it(`returns the expected repos`, async function() {
                     const output = await Templates.getReposFromProviders(test.input);
                     output.should.deep.equal(test.output);
@@ -683,7 +683,7 @@ describe('Templates.js', function() {
                 },
             };
             for (const [testName, test] of Object.entries(tests)) {
-                describe(testName, function() { // eslint-disable-line
+                describe(testName, function() { // eslint-disable-line no-loop-func
                     it(`returns the expected operation info and correctly updates the repository file`, async function() {
                         const output = await templateController.batchUpdate(test.input);
                         output.should.deep.equal(test.output);
@@ -747,7 +747,7 @@ describe('Templates.js', function() {
                 },
             };
             for (const [testName, test] of Object.entries(tests)) {
-                describe(testName, function() { // eslint-disable-line
+                describe(testName, function() { // eslint-disable-line no-loop-func
                     it(`returns the expected operation info and correctly updates the repository file`, function() {
                         const output = templateController.performOperation(test.input);
                         output.should.deep.equal(test.output);
@@ -791,7 +791,7 @@ describe('Templates.js', function() {
                 },
             };
             for (const [testName, test] of Object.entries(tests)) {
-                describe(testName, function() { // eslint-disable-line
+                describe(testName, function() { // eslint-disable-line no-loop-func
                     it(`returns the expected operation info`, function() {
                         const output = templateController.performOperation(test.input);
                         output.should.deep.equal(test.output);

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -374,9 +374,14 @@ describe('Templates.js', function() {
             });
         });
         describe('(<uniqueString>, <validDesc>)', function() {
-            it('succeeds', function() {
+            it('succeeds', async function() {
                 const func = () => templateController.addRepository('unique string', 'description');
-                return func().should.not.be.rejected;
+                await (func().should.not.be.rejected);
+                templateController.repositoryList.should.deep.include({
+                    url: 'unique string',
+                    description: 'description',
+                    enabled: true,
+                });
             });
         });
     });
@@ -395,11 +400,11 @@ describe('Templates.js', function() {
         let templateController;
         before(() => {
             templateController = new Templates('');
-            templateController.repositoryList = [...mockRepoList];
+            templateController.repositoryList = [mockRepos.enabled, mockRepos.disabled];
         });
         it('returns only enabled repos', function() {
             const output = templateController.getEnabledRepositories();
-            output.should.deep.equal([mockRepos.enabled, mockRepos.noEnabledStatus]);
+            output.should.deep.equal([mockRepos.enabled]);
         });
     });
     describe('enableRepository(url)', function() {
@@ -410,10 +415,9 @@ describe('Templates.js', function() {
         });
         describe('(existing url)', function() {
             it('enables the correct repo', function() {
-                templateController.enableRepository('2');
+                templateController.enableRepository(mockRepos.disabled.url);
                 const expectedRepoDetails = {
-                    url: '2',
-                    description: '2',
+                    ...mockRepos.disabled,
                     enabled: true,
                 };
                 templateController.getRepositories().should.deep.include(expectedRepoDetails);

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -12,14 +12,16 @@ const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const fs = require('fs-extra');
 const path = require('path');
+const rewire = require('rewire');
 
-const Templates = require('../../../src/pfe/portal/modules/Templates');
+const Templates = rewire('../../../src/pfe/portal/modules/Templates');
 const {
     styledTemplates,
     defaultCodewindTemplates,
     defaultRepoList,
     sampleRepos,
 } = require('../../modules/template.service');
+const { suppressLogOutput } = require('../../modules/log.service');
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -48,6 +50,7 @@ const mockRepos = {
 const mockRepoList = Object.values(mockRepos);
 
 describe('Templates.js', function() {
+    suppressLogOutput(Templates);
     describe('getTemplateStyles() when Codewind is aware of:', function() {
         describe('Codewind and Appsody templates', function() {
             const sampleTemplateList = [


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Resolves https://github.com/eclipse/codewind/issues/251
Resolves https://github.com/eclipse/codewind/issues/253

The tests broke when the Appsody extension was integrated because:
- a minor bug that crept in while our tests weren't running on Jenkins. See fix: https://github.com/eclipse/codewind/pull/260/files#diff-395b0c2bf7f52e9b39e91bb2d4991d15R264
- these tests (which I wrote) needed updating as our default template repositories changed (e.g. when Appsody was integrated). I've reworked them a bit to make them less brittle in future.

