### PR TITLE
Remove test artifacts from pom.xml

### DIFF
--- a/src/pfe/iterative-dev/pom.xml
+++ b/src/pfe/iterative-dev/pom.xml
@@ -57,7 +57,6 @@
 						<configuration>
 							<tasks>
 								<copy file="target/IDC.jar" todir="../file-watcher/idc/artifacts" overwrite="true"/>
-								<copy file="target/IDC.jar" todir="test/artifacts" overwrite="true"/>
 							</tasks>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## Description

Remove the test artifacts copy from the pom.xml. It currently always generates the IDC.jar and copies it over to the test artifacts directory.

Signed-off-by: ssh24 <sakib@ibm.com>