### PR TITLE
Environment API - Make Tekton Dashboard URL be dynamic

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -35,7 +35,7 @@ paths:
                   - socket_namespace
                   - codewind_version
                   - os_platform
-                  - tekton_dashboard_url
+                  - tekton_dashboard
                 properties:
                   running_in_k8s:
                     type: boolean
@@ -53,9 +53,19 @@ paths:
                     type: string
                     example: 'Linux'
                   tekton_dashboard_url:
-                    type: string
-                    example: '9.20.195.90.nip.io'
-                    description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string. May also be 'not-installed' or an error message."
+                    type: object
+                    properties:
+                      status:
+                        type: boolean
+                      message:
+                        type: string
+                      url:
+                        type: string
+                    example:
+                      status: true
+                      message: ''
+                      url: '9.20.195.90.nip.io'
+                    description: "An object containing the Ingress URL of Tekton dashboard. If the dashboard is configured and available status=true, if not available then status=false along with a message providing more information."
                   workspace_location:
                     type: string
                     example: '/home/user/codewind-workspace'

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -55,7 +55,7 @@ paths:
                   tekton_dashboard_url:
                     type: string
                     example: '9.20.195.90.nip.io'
-                    description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string. May also be 'error' or 'not-installed'."
+                    description: "Ingress URL of Tekton dashboard if it's available. On local Codewind, it is the empty string. May also be 'not-installed' or an error message."
                   workspace_location:
                     type: string
                     example: '/home/user/codewind-workspace'

--- a/src/pfe/portal/modules/TektonUtils.js
+++ b/src/pfe/portal/modules/TektonUtils.js
@@ -16,9 +16,9 @@ const cwUtils = require('./utils/sharedFunctions');
 const Logger = require('./utils/Logger');
 
 const ERR_TEKTON_SERVICE_NOT_INSTALLED = "not-installed";
-const ERR_TEKTON_NO_DASHBOARD_LIST = "unable to obtain a list of dashboards";
-const ERR_TEKTON_NO_DASHBOARD = "unable to find a dashboard";
-const ERR_TEKTON_NO_DASHBOARD_URL = "unable to read dashboard URL"
+const ERR_TEKTON_NO_DASHBOARD_LIST = "no-dashboard-list";
+const ERR_TEKTON_NO_DASHBOARD = "no-dashboard";
+const ERR_TEKTON_NO_DASHBOARD_URL = "no-dashboard-url"
 
 const log = new Logger(__filename);
 
@@ -105,28 +105,28 @@ async function getTektonDashboardUrl() {
   try {
     const tektonAPIService = await getTektonAPIService();
     if (!tektonAPIService) {
-      return ERR_TEKTON_SERVICE_NOT_INSTALLED;
+      return {status: false, message: ERR_TEKTON_SERVICE_NOT_INSTALLED, url: ''};
     }
 
     tektonDashList = await getTektonDashboardList(tektonAPIService);
     if (!tektonDashList) {
-      return ERR_TEKTON_NO_DASHBOARD_LIST;
+      return {status: false, message: ERR_TEKTON_NO_DASHBOARD_LIST, url: ''};
     }
 
   } catch (err) {
     log.error(`Error getting Dashboard list: ${err}`);
-    return ERR_TEKTON_NO_DASHBOARD;
+    return {status: false, message: ERR_TEKTON_NO_DASHBOARD, url: ''};
   }
 
   if (tektonDashList && tektonDashList.length > 0 && tektonDashList[0].url) {
     tektonDashboardURL = tektonDashList[0].url;
   } else {
-    log.error(`Unable to find a URL`);
-    return ERR_TEKTON_NO_DASHBOARD_URL;
+    log.error(`Unable to find a Tekton dashboard URL`);
+    return {status:false, message: ERR_TEKTON_NO_DASHBOARD_URL, url: ''};
   }
 
   log.info(`Tekton DashboardURL = ${tektonDashboardURL}`);
-  return tektonDashboardURL;
+  return {status: true, message:'', url: tektonDashboardURL};
 }
 
 module.exports.getTektonDashboardUrl = getTektonDashboardUrl;

--- a/src/pfe/portal/routes/environment.route.js
+++ b/src/pfe/portal/routes/environment.route.js
@@ -34,7 +34,7 @@ router.get('/api/v1/environment', async (req, res) => {
       tektonDashboardUrl = await tektonDashboardUrlPromise;
     }
   } else {
-    tektonDashboardUrl = TektonUtils.ERR_TEKTON_SERVICE_NOT_INSTALLED;
+    tektonDashboardUrl = '';
   }
 
   try {

--- a/src/pfe/portal/routes/environment.route.js
+++ b/src/pfe/portal/routes/environment.route.js
@@ -34,7 +34,7 @@ router.get('/api/v1/environment', async (req, res) => {
       tektonDashboardUrl = await tektonDashboardUrlPromise;
     }
   } else {
-    tektonDashboardUrl = '';
+    tektonDashboardUrl = {status:false, message: TektonUtils.ERR_TEKTON_SERVICE_NOT_INSTALLED, url: ''};
   }
 
   try {
@@ -45,7 +45,7 @@ router.get('/api/v1/environment', async (req, res) => {
       codewind_version: process.env.CODEWIND_VERSION,
       workspace_location: process.env.HOST_WORKSPACE_DIRECTORY,
       os_platform: process.env.HOST_OS || 'Linux',
-      tekton_dashboard_url: tektonDashboardUrl
+      tekton_dashboard: tektonDashboardUrl
     }
     res.status(200).send(envData);
   } catch (err) {

--- a/src/pfe/portal/routes/environment.route.js
+++ b/src/pfe/portal/routes/environment.route.js
@@ -15,26 +15,18 @@ const Logger = require('../modules/utils/Logger');
 const router = express.Router();
 const log = new Logger(__filename);
 
-let tektonDashboardUrl;
-let tektonDashboardUrlPromise;
-
 /**
  * API Function to provide codewind runtime information to the UI
  */
 router.get('/api/v1/environment', async (req, res) => {
 
+  let tektonDashboard;
   if (global.codewind.RUNNING_IN_K8S) {
-    if (!tektonDashboardUrl) {
-      // just await on this promise if it exists so we only call getTektonDashboardUrl once
-      if (!tektonDashboardUrlPromise) {
-        tektonDashboardUrlPromise = TektonUtils.getTektonDashboardUrl().then((tektonUrl) => {
-          return tektonUrl;
-        });
-      }
-      tektonDashboardUrl = await tektonDashboardUrlPromise;
-    }
+    tektonDashboard = await TektonUtils.getTektonDashboardUrl().then((tekton) => {
+      return tekton;
+    });
   } else {
-    tektonDashboardUrl = {status:false, message: TektonUtils.ERR_TEKTON_SERVICE_NOT_INSTALLED, url: ''};
+    tektonDashboard = {status:false, message: TektonUtils.ERR_TEKTON_SERVICE_NOT_INSTALLED, url: ''};
   }
 
   try {
@@ -45,7 +37,7 @@ router.get('/api/v1/environment', async (req, res) => {
       codewind_version: process.env.CODEWIND_VERSION,
       workspace_location: process.env.HOST_WORKSPACE_DIRECTORY,
       os_platform: process.env.HOST_OS || 'Linux',
-      tekton_dashboard: tektonDashboardUrl
+      tekton_dashboard: tektonDashboard
     }
     res.status(200).send(envData);
   } catch (err) {


### PR DESCRIPTION
# PROBLEM

Codewind can not get to Tekton Dashboard if Tekton installed after Codewind install
Issue : https://github.com/eclipse/codewind/issues/309

# SOLUTION

This PR changes the behaviour of the environment API such that the URL is determined each time the Environment API is accessed.   This provides a more dynamic view of the dashboard ensuring if the dashboard becomes unavailable the status provided to the IDE plugins can be monitored. 

Ran tests : 

  Environment API tests
    ✓ should return expected environment properties (41ms)

  1 passing (50ms)