### PR TITLE
Fix problems with autobuild setting and affected APIs

### DIFF
--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -317,6 +317,7 @@ export default class Filewatcher {
      *  @property startMode <Optional | String>: An optional start mode for the application.
      *  @property contextroot <Optional | String>: An optional context root path for the application.
      *  @property ignoredPaths <Optional | String[]>: An optional string array of relative file paths or regex for files want to be ignored for changes.
+     *  @property build <Optional | Boolean>: An optional boolean to indicate if the project should be built
      *
      * @example await filewatcher.createProject(req)
      * ```json

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -224,7 +224,8 @@ module.exports = class FileWatcher {
       location: project.projectPath(false),
       applicationPort: project.applicationPort,
       settings: settingsFileContents,
-      language: project.language 
+      language: project.language,
+      build: project.autoBuild
     };
 
     log.info(`Calling createProject() for project ${project.name} ${JSON.stringify(projectAction)}`);

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -291,7 +291,7 @@ module.exports = class User {
       for (let i = 0; i < projectArray.length; i++) {
         let project = projectArray[i];
         // Don't request build if autoBuild is false
-        if (project.isOpen() && project.autoBuild) {
+        if (project.isOpen()) {
           this.buildAndRunProject(project);
         }
       }


### PR DESCRIPTION
This PR fixes https://github.com/eclipse/codewind/issues/54 so that a project with autobuild set to false will behave as expected. 

The solution was to always call createProject on Turbine even when autobuild is false so that Turbine will set up project metadata and log directories but then only create a build operation when the flag is set to true.  This fixes problems with the capabilities/logs/build apis not working on projects that hadn't been built. problems were particularly encountered when restarting Codewind with a project having autobuild false. I have a clean run of the portal API tests and 4 failures on the Turbine unit tests but these also occurred on master branch. 