### PR TITLE
[0.3.0] Fix buildah when using Dockerhub

### DIFF
--- a/src/pfe/file-watcher/scripts/constants.sh
+++ b/src/pfe/file-watcher/scripts/constants.sh
@@ -34,7 +34,7 @@ export MAVEN_BUILD_FAILED_MSG="Maven build stage failed for" # :NLS
 
 if [ "$IN_K8" == "true" ]; then
 	export IMAGE_COMMAND="buildah"
-	export BUILD_COMMAND="bud --layers"
+	export BUILD_COMMAND="bud --format docker --layers"
 else
 	export IMAGE_COMMAND="docker"
 	export BUILD_COMMAND="build"

--- a/src/pfe/file-watcher/server/src/utils/dockerutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/dockerutil.ts
@@ -382,10 +382,9 @@ const containerExec = function (options: any, container: any, projectID: string)
  */
 export async function buildImage(projectID: string, imageName: string, buildOptions: string[], pathOrURL: string, liveStream?: boolean, logFile?: string): Promise<ProcessResult> {
   // Construct the build command
-  const args: string[] = [];
+  let args: string[] = [];
   if (process.env.IN_K8) {
-    args[0] = "bud";
-    args[1] = "--layers";
+    args = ["bud", "--format", "docker", "--layers"];
   }
   else {
     args[0] = "build";


### PR DESCRIPTION
This PR updates Codewind to allow images to be pushed to DockerHub using `buildah`, due to the changes that have occurred in DockerHub since yesterday (see https://github.com/containers/buildah/issues/1826 and https://github.com/docker/hub-feedback/issues/1871)