### PR TITLE
Port Include new container id in restart event to 0.3.1

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -1898,6 +1898,9 @@ export async function restartProject(operation: Operation, startMode: string, ev
                         internalPort: containerInfo.internalPort
                     }
                 };
+                if (containerInfo.containerId) {
+                    data.containerId = containerInfo.containerId;
+                }
                 if (containerInfo.exposedDebugPort) {
                     data.ports.exposedDebugPort = containerInfo.exposedDebugPort;
                 }
@@ -1962,6 +1965,9 @@ export async function restartProject(operation: Operation, startMode: string, ev
                         internalPort: containerInfo.internalPort
                     }
                 };
+                if (containerInfo.containerId) {
+                    data.containerId = containerInfo.containerId;
+                }
                 if (containerInfo.exposedDebugPort) {
                     data.ports.exposedDebugPort = containerInfo.exposedDebugPort;
                 }


### PR DESCRIPTION
Port of https://github.com/eclipse/codewind/pull/318/files

Tests done: verified that you can shell into the container after restarting various appsody projects into debug mode.