### PR TITLE
Add a readiness endpoint

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -19,6 +19,13 @@ info:
   # - name: admin
   #   description: Operations available only to authenticated admins
 paths:
+  /ready:
+    get:
+      summary: Return true when codewind is ready to accept requests
+      responses:
+        200:
+          description: Status of codewind as a boolean
+
   /api/v1/environment:
     get:
       summary: Get information on the current environment

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -17,6 +17,7 @@ main().catch(err => console.dir(err));
 // Wrap everything in an async function so we can use
 // await to serialize initialisation.
 async function main() {
+  let ready = false;
 
   // Set the umask for file creation.
   process.umask(0o002);
@@ -194,6 +195,7 @@ async function main() {
 
   app.get('/', (req, res) => { res.sendStatus(200); });
   app.get('/health', (req, res) => { res.sendStatus(200); });
+  app.get('/ready', (req, res) => { res.status(200).send(ready); });
   app.use(securityMiddleware);
 
   // Default, single user implementation
@@ -205,6 +207,9 @@ async function main() {
   );
   userList.add(user);
   setRoutes();
+  // We have finished initialising the user, any projects and routes so we are ready now
+  ready = true;
+
 
   /**
    * Function to set up express routes for codewind portal. All external APIs


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

This PR adds a ready endpoint that will return true once the user and any existing projects have been initialised.