### PR TITLE
Always do initial build of project

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -290,8 +290,8 @@ module.exports = class User {
       let projectArray = this.projectList.getAsArray();
       for (let i = 0; i < projectArray.length; i++) {
         let project = projectArray[i];
-        // Don't request build if autoBuild is false
-        if (project.isOpen() && project.autoBuild) {
+        // Don't request build if project is closed
+        if (project.isOpen()) {
           this.buildAndRunProject(project);
         }
       }

--- a/src/pfe/portal/routes/projects/binding.route.js
+++ b/src/pfe/portal/routes/projects/binding.route.js
@@ -109,10 +109,7 @@ router.post('/api/v1/projects/bind', validateReq, async function (req, res) {
     }
 
     newProject = await user.createProject(projectDetails);
-    let msg = `Project ${newProject.name} (${newProject.projectID}) opened.`;
-    if (autoBuild) {
-      msg += ' Will build and run.';
-    }
+    let msg = `Project ${newProject.name} (${newProject.projectID}) opened and build requested`;
     res.status(202).send(newProject);
     log.info(msg);
   } catch (err) {
@@ -126,9 +123,7 @@ router.post('/api/v1/projects/bind', validateReq, async function (req, res) {
   }
 
   try {
-    if (newProject.autoBuild) {
-      await user.buildAndRunProject(newProject);
-    }
+    await user.buildAndRunProject(newProject);
     user.uiSocket.emit('projectBind', { status: 'success', ...newProject });
     log.info(`Successfully created project - name: ${newProject.name}, ID: ${newProject.projectID}`);
   } catch (err) {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

As discussed in https://github.com/eclipse/codewind/issues/54, when a project is created or bound, codewind will always do an initial build and run (regardless of the autobuild setting).  This fixes all issues with existing APIs that were broken if a project had not been built 9logs, capabilities etc).  The same will happen on a restart, all projects will be built and run. 

Tests have been run cleanly.