### PR TITLE
Fix circular dependency between projectUtil and dockerUtil modules

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -1436,7 +1436,9 @@ async function containerBuildAndRun(event: string, buildInfo: BuildRequest, oper
         await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, buildInfo.projectID, BuildState.inProgress, "buildscripts.buildImage");
         try {
             logger.logProjectInfo("Build container image", buildInfo.projectID);
-            await dockerutil.buildImage(buildInfo.projectID, buildInfo.containerName, [], buildInfo.projectLocation, true, dockerBuildLog);
+            const projectInfo = await getProjectInfo(buildInfo.projectID);
+            const language = projectInfo.language;
+            await dockerutil.buildImage(buildInfo.projectID, language, buildInfo.containerName, [], buildInfo.projectLocation, true, dockerBuildLog);
             const imageLastBuild = Date.now();
             logger.logProjectInfo("Container image build stage complete.", buildInfo.projectID);
             await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, buildInfo.projectID, BuildState.inProgress, "buildscripts.containerBuildSuccess", imageLastBuild.toString());
@@ -1499,7 +1501,9 @@ async function containerBuildAndRun(event: string, buildInfo: BuildRequest, oper
         await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, buildInfo.projectID, BuildState.inProgress, "buildscripts.buildImage");
         try {
             logger.logProjectInfo("Build container image", buildInfo.projectID);
-            await dockerutil.buildImage(buildInfo.projectID, buildInfo.containerName, [], buildInfo.projectLocation, true, dockerBuildLog);
+            const projectInfo = await getProjectInfo(buildInfo.projectID);
+            const language = projectInfo.language;
+            await dockerutil.buildImage(buildInfo.projectID, language, buildInfo.containerName, [], buildInfo.projectLocation, true, dockerBuildLog);
             logger.logProjectInfo("Container image build stage complete.", buildInfo.projectID);
             const imageLastBuild = Date.now();
             await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, buildInfo.projectID, BuildState.success, " ", imageLastBuild.toString());

--- a/src/pfe/file-watcher/server/src/utils/dockerutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/dockerutil.ts
@@ -17,7 +17,6 @@ import * as processManager from "./processManager";
 import { ProcessResult } from "./processManager";
 import * as logger from "./logger";
 import { ContainerStates } from "../projects/constants";
-import * as projectUtil from "../projects/projectUtil";
 import { Stream } from "stream";
 import { BuildRequest, ProjectInfo } from "../projects/Project";
 import { StartModes } from "../projects/constants";
@@ -381,20 +380,15 @@ const containerExec = function (options: any, container: any, projectID: string)
  *
  * @returns Promise<ProcessResult>
  */
-export async function buildImage(projectID: string, imageName: string, buildOptions: string[], pathOrURL: string, liveStream?: boolean, logFile?: string): Promise<ProcessResult> {
+export async function buildImage(projectID: string, projectLanguage: string, imageName: string, buildOptions: string[], pathOrURL: string, liveStream?: boolean, logFile?: string): Promise<ProcessResult> {
 
   // Construct the build command.
   let args: string[] = [];
 
   if (process.env.IN_K8) {
     args = ["bud", "--format", "docker"];
-
-    // Retrieve the language of the project type that's being built
-    const projectInfo = await projectUtil.getProjectInfo(projectID);
-    const language = projectInfo.language;
-
     // Don't use layer caching on Java projects due to caching issues with buildah and the pom.xml: https://github.com/eclipse/codewind/issues/344
-    if (language !== "java") {
+    if (projectLanguage !== "java") {
       args.push("--layers");
     }
   }


### PR DESCRIPTION
## Description

Read comment https://github.com/eclipse/codewind/issues/355#issuecomment-527896867

```
  232 passing (23s)

-----------------------------|----------|----------|----------|----------|-------------------|
File                         |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------------------|----------|----------|----------|----------|-------------------|
All files                    |    41.59 |    33.13 |    51.85 |     41.3 |                   |
 src                         |      100 |      100 |      100 |      100 |                   |
  index.ts                   |      100 |      100 |      100 |      100 |                   |
 src/controllers             |    29.64 |    19.29 |    44.57 |    29.91 |                   |
  projectEventsController.ts |    14.09 |     4.05 |        0 |    14.19 |... 69,270,271,273 |
  projectStatusController.ts |    53.02 |    31.09 |    62.96 |    53.56 |... 58,659,660,661 |
  projectsController.ts      |    21.26 |    12.65 |    42.11 |    21.45 |... 1152,1153,1154 |
 src/extensions              |    87.27 |    66.67 |      100 |    86.79 |                   |
  projectExtensions.ts       |    87.27 |    66.67 |      100 |    86.79 |... 46,58,59,71,72 |
 src/projects                |    44.35 |    40.26 |    51.02 |    43.68 |                   |
  DockerProject.ts           |    71.43 |      100 |       50 |    71.43 |     88,89,106,167 |
  LibertyValidator.ts        |    93.48 |    88.46 |      100 |    93.48 |       120,123,236 |
  ShellExtensionProject.ts   |    68.57 |    18.75 |    47.06 |    68.57 |... 67,269,281,307 |
  SpringValidator.ts         |    81.82 |       75 |      100 |    85.71 |          78,90,91 |
  Validator.ts               |    96.05 |    83.33 |      100 |    95.89 |       137,138,156 |
  actions.ts                 |    63.39 |    55.22 |       50 |    63.39 |... 27,332,334,336 |
  constants.ts               |      100 |       90 |      100 |      100 |             13,16 |
  libertyProject.ts          |     87.3 |    61.11 |    54.55 |    88.14 |... 23,325,335,357 |
  logHelper.ts               |    88.46 |      100 |       50 |       88 |       179,189,211 |
  nodejsProject.ts           |    73.68 |       50 |    55.56 |    72.97 |... 98,156,171,184 |
  operation.ts               |      100 |      100 |      100 |      100 |                   |
  projectSpecifications.ts   |    66.11 |    61.07 |       90 |    66.22 |... 80,730,731,732 |
  projectUtil.ts             |    16.53 |    17.08 |       25 |    16.47 |... 2023,2026,2027 |
  springProject.ts           |    91.89 |      100 |       50 |    91.43 |       157,171,181 |
  swiftProject.ts            |    56.25 |      100 |    57.14 |    56.25 |... 0,73,85,97,109 |
 src/utils                   |    48.61 |    44.56 |    60.78 |    49.17 |                   |
  dockerutil.ts              |    18.03 |    22.22 |       20 |    17.82 |... 05,606,607,627 |
  kubeutil.ts                |    23.47 |       25 |    33.33 |    23.91 |... 05,306,322,326 |
  locale.ts                  |    89.83 |    72.22 |      100 |    91.23 |... 65,177,179,190 |
  logger.ts                  |    86.59 |    72.22 |      100 |       88 |... 95,300,353,387 |
  processManager.ts          |    58.21 |       60 |    53.85 |    58.46 |... 66,167,168,187 |
  socket.ts                  |    42.86 |      100 |      100 |       50 |          35,44,45 |
  utils.ts                   |      100 |      100 |      100 |      100 |                   |
  workspaceSettings.ts       |    68.66 |    83.33 |      100 |    69.23 |... 76,277,278,282 |
-----------------------------|----------|----------|----------|----------|-------------------|

> file-watcher@1.0.1 unit:cleanup /Users/sakib@ibm.com/workspace/dev/projects/codewind/src/pfe/file-watcher/server
> ./test/scripts/unit_cleanup.sh

Removing test projects... 

Removing test log directory... 
```

Signed-off-by: ssh24 <sakib@ibm.com>