### PR TITLE
re enable tests at PR time

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
                 }
             }
         }  
-        /*
+        
         stage('Run Codewind test suite') {            
                 steps {
                     withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]){
@@ -197,7 +197,7 @@ pipeline {
                 }
             }
         } 
-        */ 
+         
         
         stage('Publish Docker images') {
 


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

Re enable the logic in the Jenkins file to get the tests running again