### PR TITLE
Add ability to enable/disable template repos from extensions

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -24,6 +24,7 @@ const DEFAULT_REPOSITORY_LIST = [
     url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
     description: 'Standard Codewind templates.',
     enabled: true,
+    protected: true,
   },
 ];
 module.exports = class Templates {
@@ -44,6 +45,7 @@ module.exports = class Templates {
         this.repositoryList = list;
         this.needsRefresh = true;
       } else {
+        await this.updateRepoListWithReposFromProviders();
         await this.writeRepositoryList();
       }
     } catch (err) {
@@ -61,26 +63,39 @@ module.exports = class Templates {
     return templates;
   }
 
-  getEnabledTemplates() {
+  async getEnabledTemplates() {
+    await this.updateRepoListWithReposFromProviders();
     return this.getTemplatesFromRepos(this.getEnabledRepositories());
   }
 
-  getAllTemplates() {
+  async getAllTemplates() {
     if (!this.needsRefresh) {
       return this.projectTemplates;
     }
+    await this.updateRepoListWithReposFromProviders();
     return this.getTemplatesFromRepos(this.repositoryList);
   }
 
-  async getTemplatesFromRepos(repositoryList) {
+  async updateRepoListWithReposFromProviders() {
     const providers = Object.values(this.providers);
     const providedRepos = await getReposFromProviders(providers);
-    // Avoid processing duplicate repos
-    const extraRepos = providedRepos.filter(repo =>
-      !repositoryList.find(repo2 => repo2.url === repo.url)
-    );
-    const repos = repositoryList.concat(extraRepos);
 
+    const extraRepos = providedRepos.filter(repo =>
+      !this.repositoryList.find(repo2 => repo2.url === repo.url)
+    );
+
+    // TODO: should we remove repos we previously saved, that are no longer provided by the extension?
+    if (extraRepos.length > 0) {
+      extraRepos.forEach(repo => {
+        repo.enabled = true;
+        repo.protected = true;
+      });
+      this.repositoryList = this.repositoryList.concat(extraRepos);
+      await this.writeRepositoryList();
+    }
+  }
+
+  async getTemplatesFromRepos(repos) {
     let newProjectTemplates = [];
     await Promise.all(repos.map(async(repo) => {
       try {

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -84,7 +84,6 @@ module.exports = class Templates {
       !this.repositoryList.find(repo2 => repo2.url === repo.url)
     );
 
-    // TODO: should we remove repos we previously saved, that are no longer provided by the extension?
     if (extraRepos.length > 0) {
       extraRepos.forEach(repo => {
         repo.enabled = true;

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -209,7 +209,7 @@ module.exports = class Templates {
   /**
    * Add a repository to the list of template repositories.
    */
-  async addRepository(repoUrl, repoDescription) {
+  async addRepository(repoUrl, repoDescription, isRepoProtected) {
     let url;
     try {
       url = new URL(repoUrl).href;
@@ -232,6 +232,7 @@ module.exports = class Templates {
       url,
       description: repoDescription,
       enabled: true,
+      protected: isRepoProtected,
     }
     this.repositoryList.push(newRepo);
     this.needsRefresh = true;

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -232,8 +232,11 @@ module.exports = class Templates {
       url,
       description: repoDescription,
       enabled: true,
-      protected: isRepoProtected,
     }
+    if (isRepoProtected) {
+      newRepo.protected = isRepoProtected;
+    }
+
     this.repositoryList.push(newRepo);
     this.needsRefresh = true;
     await this.writeRepositoryList();

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -62,19 +62,21 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
     }
     throw error;
   }
-  sendRepositories(req, res, _next);
+  await sendRepositories(req, res, _next);
 });
 
 router.delete('/api/v1/templates/repositories', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
   const repositoryUrl = req.sanitizeBody('url');
   await user.templates.deleteRepository(repositoryUrl);
-  sendRepositories(req, res, _next);
+  await sendRepositories(req, res, _next);
 });
 
-function sendRepositories(req, res, _next) {
+async function sendRepositories(req, res, _next) {
   const user = req.cw_user;
-  const repositoryList = user.templates.getRepositories();
+  const templatesController = user.templates;
+  await templatesController.updateRepoListWithReposFromProviders();
+  const repositoryList = templatesController.getRepositories();
   res.status(200).json(repositoryList);
 }
 

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -50,9 +50,10 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
   const user = req.cw_user;
   const repositoryUrl = req.sanitizeBody('url');
   const repositoryDescription = req.sanitizeBody('description');
+  const isRepoProtected = req.sanitizeBody('protected');
 
   try {
-    await user.templates.addRepository(repositoryUrl, repositoryDescription);
+    await user.templates.addRepository(repositoryUrl, repositoryDescription, isRepoProtected);
   } catch (error) {
     log.error(error);
     const knownErrorCodes = ['INVALID_URL', 'DUPLICATE_URL', 'URL_DOES_NOT_POINT_TO_INDEX_JSON'];

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -174,8 +174,7 @@ const sampleRepos = {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
         description: 'Standard Codewind templates.',
         enabled: true,
-        // TODO:
-        // protected: true,
+        protected: true,
     },
     anotherCodewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json',
@@ -208,11 +207,11 @@ async function getTemplateRepos() {
     return res;
 }
 
-async function addTemplateRepo({ url, description }) {
+async function addTemplateRepo(repo) {
     const res = await reqService.chai
         .post('/api/v1/templates/repositories')
         .set('Cookie', ADMIN_COOKIE)
-        .send({ url, description });
+        .send(repo);
     return res;
 }
 

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -174,6 +174,8 @@ const sampleRepos = {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
         description: 'Standard Codewind templates.',
         enabled: true,
+        // TODO:
+        // protected: true,
     },
     anotherCodewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json',
@@ -185,8 +187,18 @@ const sampleRepos = {
         description: 'Appsody extension for Codewind',
         enabled: true,
     },
+    fromAppsodyExtension: {
+        description: '*appsodyhub',
+        url: 'https://github.com/appsody/stacks/releases/latest/download/incubator-index.json',
+        enabled: true,
+        protected: true,
+    },
 };
-const defaultRepoList = [sampleRepos.codewind];
+const defaultRepoList = [
+    sampleRepos.codewind,
+    sampleRepos.fromAppsodyExtension,
+];
+
 const validUrlNotPointingToIndexJson = 'https://support.oneskyapp.com/hc/en-us/article_attachments/202761627/example_1.json';
 
 async function getTemplateRepos() {

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -286,11 +286,13 @@ async function getTemplateStyles() {
 
 function saveReposBeforeTestAndRestoreAfter() {
     let originalTemplateRepos;
-    before(async() => {
+    before(async function() {
+        this.timeout(5000);
         const res = await getTemplateRepos();
         originalTemplateRepos = res.body;
     });
-    after(async() => {
+    after(async function() {
+        this.timeout(5000);
         await setTemplateReposTo(originalTemplateRepos);
     });
 }

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -40,7 +40,8 @@ describe('Batch enabling repositories', function() {
             const { testRepos } = test;
             let templatesFromTestRepos;
             saveReposBeforeTestAndRestoreAfter();
-            before(async() => {
+            before(async function() {
+                this.timeout(10000);
                 await setTemplateReposTo(testRepos);
 
                 const res = await getTemplates();
@@ -69,6 +70,7 @@ describe('Batch enabling repositories', function() {
                 res.body.should.have.deep.members(disabledRepos);
             });
             it(`checks templates from the disabled repos do not appear in the list of enabled templates`, async function() {
+                this.timeout(10000);
                 const res = await getTemplates({ showEnabledOnly: true });
                 res.should.have.status(204);
             });
@@ -96,6 +98,7 @@ describe('Batch enabling repositories', function() {
                 res.body.should.have.deep.members(enabledRepos);
             });
             it(`checks templates from the enabled repos do appear in the list of enabled templates`, async function() {
+                this.timeout(10000);
                 const res = await getTemplates({ showEnabledOnly: true });
                 res.should.have.status(200);
                 res.body.should.have.deep.members(templatesFromTestRepos);

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -27,12 +27,12 @@ describe('Batch enabling repositories', function() {
         '1 repo': {
             testRepos: [{ ...sampleRepos.codewind }],
         },
-        'multiple repos': {
-            testRepos: [
-                { ...sampleRepos.codewind },
-                { ...sampleRepos.appsody },
-            ],
-        },
+        // 'multiple repos': {
+        //     testRepos: [
+        //         { ...sampleRepos.appsody },
+        //         { ...sampleRepos.fromAppsodyExtension },
+        //     ],
+        // },
     };
 
     for (const [testName, test] of Object.entries(tests)) {

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -25,14 +25,14 @@ chai.should();
 describe('Batch enabling repositories', function() {
     const tests = {
         '1 repo': {
-            testRepos: [{ ...sampleRepos.codewind }],
+            testRepos: [{ ...sampleRepos.fromAppsodyExtension }],
         },
-        // 'multiple repos': {
-        //     testRepos: [
-        //         { ...sampleRepos.appsody },
-        //         { ...sampleRepos.fromAppsodyExtension },
-        //     ],
-        // },
+        'multiple repos': {
+            testRepos: [
+                { ...sampleRepos.codewind },
+                { ...sampleRepos.fromAppsodyExtension },
+            ],
+        },
     };
 
     for (const [testName, test] of Object.entries(tests)) {
@@ -70,8 +70,7 @@ describe('Batch enabling repositories', function() {
             });
             it(`checks templates from the disabled repos do not appear in the list of enabled templates`, async function() {
                 const res = await getTemplates({ showEnabledOnly: true });
-                res.should.have.status(200);
-                res.body.should.not.have.deep.members(templatesFromTestRepos);
+                res.should.have.status(204);
             });
 
             it(`returns 207 and sub-status 200 for each subrequest when batch enabling ${testRepos.length} repos`, async function() {
@@ -96,7 +95,7 @@ describe('Batch enabling repositories', function() {
                 res.should.have.status(200);
                 res.body.should.have.deep.members(enabledRepos);
             });
-            it(`checks templates from the enabled repos do not appear in the list of enabled templates`, async function() {
+            it(`checks templates from the enabled repos do appear in the list of enabled templates`, async function() {
                 const res = await getTemplates({ showEnabledOnly: true });
                 res.should.have.status(200);
                 res.body.should.have.deep.members(templatesFromTestRepos);

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -41,6 +41,7 @@ describe('Template API tests', function() {
         describe('?projectStyle=', function() {
             describe('empty', function() {
                 it('should return a list of all available templates', async function() {
+                    this.timeout(10000);
                     const res = await getTemplates();
                     res.should.have.status(200).and.satisfyApiSpec;
                     res.body.length.should.equal(defaultTemplates.length);
@@ -48,6 +49,7 @@ describe('Template API tests', function() {
             });
             describe('Codewind', function() {
                 it('should return only Codewind templates', async function() {
+                    this.timeout(10000);
                     const res = await getTemplates({ projectStyle: 'Codewind' });
                     res.should.have.status(200).and.satisfyApiSpec;
                     res.body.forEach(template => {
@@ -60,6 +62,7 @@ describe('Template API tests', function() {
             for (const projectStyle of ['Appsody']) {
                 describe(projectStyle, function() {
                     it(`should return only ${projectStyle} templates`, async function() {
+                        this.timeout(10000);
                         const res = await getTemplates({ projectStyle });
                         res.should.have.status(200).and.satisfyApiSpec;
                         res.body.forEach(template =>
@@ -70,6 +73,7 @@ describe('Template API tests', function() {
             }
             describe('unknownStyle', function() {
                 it('should return 204', async function() {
+                    this.timeout(10000);
                     const res = await getTemplates({ projectStyle: 'unknownStyle' });
                     res.should.have.status(204);
                     res.body.should.be.empty;
@@ -79,6 +83,7 @@ describe('Template API tests', function() {
         describe('?showEnabledOnly=', function() {
             describe('false', function() {
                 it('should return all templates (from enabled and disabled repos)', async function() {
+                    this.timeout(10000);
                     const res = await getTemplates({ showEnabledOnly: false });
                     res.should.have.status(200).and.satisfyApiSpec;
                     res.body.length.should.equal(defaultTemplates.length);
@@ -86,6 +91,7 @@ describe('Template API tests', function() {
             });
             describe('true', function() {
                 it('should return only templates from enabled repos', async function() {
+                    this.timeout(10000);
                     const res = await getTemplates({ showEnabledOnly: true });
                     res.should.have.status(200).and.satisfyApiSpec;
                     res.body.length.should.equal(defaultTemplates.length);
@@ -149,6 +155,7 @@ describe('Template API tests', function() {
             await setTemplateReposTo(originalTemplateRepos);
         });
         it('GET should return a list of available template repositories', async function() {
+            this.timeout(10000);
             const res = await getTemplateRepos();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.have.deep.members(defaultRepoList);
@@ -161,6 +168,7 @@ describe('Template API tests', function() {
             res.body.length.should.equal(originalTemplateRepos.length - 1);
         });
         it('GET /api/v1/templates should return fewer templates', async function() {
+            this.timeout(10000);
             const res = await getTemplates();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.length.should.be.below(originalNumTemplates);
@@ -173,6 +181,7 @@ describe('Template API tests', function() {
             res.body.length.should.equal(originalTemplateRepos.length);
         });
         it('should return the original list of available templates', async function() {
+            this.timeout(10000);
             const res = await getTemplates();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.length.should.equal(originalNumTemplates);
@@ -183,7 +192,8 @@ describe('Template API tests', function() {
             res.body.should.deep.include(repoToAdd);
             res.body.length.should.equal(originalTemplateRepos.length + 1);
         });
-        it('should return longer list of available templates', async function() {
+        it('should return a longer list of available templates', async function() {
+            this.timeout(10000);
             const res = await getTemplates();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.length.should.be.above(originalNumTemplates);
@@ -268,6 +278,7 @@ describe('Template API tests', function() {
     });
     describe('GET /api/v1/templates/styles', function() {
         it('should return a list of available template styles', async function() {
+            this.timeout(10000);
             const res = await getTemplateStyles();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.have.members(['Codewind', 'Appsody']);

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -137,7 +137,8 @@ describe('Template API tests', function() {
         const repoToAdd = sampleRepos.anotherCodewind;
         let originalTemplateRepos;
         let originalNumTemplates;
-        before(async() => {
+        before(async function() {
+            this.timeout(10000);
             const res = await getTemplateRepos();
             originalTemplateRepos = res.body;
 

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -189,7 +189,7 @@ describe('Template API tests', function() {
         });
     });
     describe('PATCH /api/v1/batch/templates/repositories', function() {
-        const existingRepoUrl = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json';
+        const existingRepoUrl = sampleRepos.fromAppsodyExtension.url;
         const tests = {
             'enable an existing repo': {
                 input: [{

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -185,27 +185,6 @@ describe('Templates.js', function() {
                         },
                     },
                 },
-                // TODO: reject these:
-                // 'provider provides array of objects with invalid URLs': {
-                //     provider: {
-                //         getRepositories() {
-                //             return [{
-                //                 description: 'invalid URL',
-                //                 url: 'invalid',
-                //             }];
-                //         },
-                //     },
-                // },
-                // 'provider provides a repo with URL that doesn't provide JSON': {
-                //     provider: {
-                //         getRepositories() {
-                //             return [{
-                //                 url: 'https://www.google.com/',
-                //                 description: 'URL that doesn't provide JSON',
-                //             }];
-                //         },
-                //     },
-                // },
                 'provider provides a duplicate repo': {
                     provider: {
                         getRepositories() {
@@ -828,12 +807,10 @@ describe('Templates.js', function() {
                         templateController.addProvider('empty obj', {});
 
                         templateController.providers.should.deep.equal(originalProviders);
-                        // TODO: check this doesn't update repository_list.json
                     });
                 });
             });
         });
-        // TODO: check valid providers do update repository_list.json
     });
 
     describe('filterTemplatesByStyle(templates, projectStyle)', function() {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -18,7 +18,6 @@ const Templates = rewire('../../../src/pfe/portal/modules/Templates');
 const {
     styledTemplates,
     defaultCodewindTemplates,
-    defaultRepoList,
     sampleRepos,
     validUrlNotPointingToIndexJson,
 } = require('../../modules/template.service');


### PR DESCRIPTION
- `GET templates/repositories` now includes repos from the Appsody extension
- `PATCH batch/templates/repositories` can enable/disable those repos
- When the Appsody repo is disabled, `GET templates` lists all templates, including Appsody templates. This is by prior design. `GET templates?showEnabledOnly=true` will exclude the Appsody repos are disabled

Also: added a `protected: true` field to the default Codewind template repo, and repos from providers (e.g. the Appsody extension). You can see it in the `repository_list.json`, or by calling - `GET templates/repositories`