### PR TITLE
Add new Templates to Lifecycle Tests

### DIFF
--- a/test/config/index.js
+++ b/test/config/index.js
@@ -76,6 +76,22 @@ const templateOptions = {
         language: 'swift',
         metricsAvailable: true,
     },
+    go: {
+        name: 'goTemplate',
+        url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
+        language: 'go',
+        metricsAvailable: false,
+    },
+    lagom: {
+        name: 'javaLagomTemplate',
+        url: 'https://github.com/microclimate-dev2ops/lagomJavaTemplate',
+        language: 'java',
+    },
+    openliberty: {
+        name: 'openLibertyTenplate',
+        url: 'https://github.com/microclimate-dev2ops/openLibertyTemplate',
+        language: 'java',
+    },
 };
 
 


### PR DESCRIPTION
As per #347 

- Go, Lagom and Open Liberty templates added to Lifecycle tests
- Project creation loop unrolled to try and prevent timeouts and to improve readability of test logs
- Relies on changes in #374 in order to create Open Liberty projects