### PR TITLE
GET templates/repositories also returns project styles

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -935,12 +935,7 @@ paths:
               schema:
                 type: array
                 items:
-                  type: object
-                  properties:
-                    url:
-                      type: string
-                    description:
-                      type: string
+                  $ref: '#/components/schemas/TemplateRepo'
         400:
           description: Bad request
     delete:
@@ -955,7 +950,7 @@ paths:
                 - url
               properties:
                 url:
-                    type: string
+                  type: string
       responses:
         200:
           description: Returns all the templates repositories that Codewind will use to find templates
@@ -1378,11 +1373,17 @@ components:
       required:
         - url
         - description
+        - projectStyles
       properties:
         url:
           type: string
         description:
           type: string
+        projectStyles:
+          type: array
+          items:
+            type: string
+          example: ['Codewind', 'Appsody']
         enabled:
           type: boolean
     TemplateRepoSetting:

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -73,10 +73,9 @@ router.delete('/api/v1/templates/repositories', validateReq, async (req, res, _n
   await sendRepositories(req, res, _next);
 });
 
-async function sendRepositories(req, res, _next) {
+function sendRepositories(req, res, _next) {
   const user = req.cw_user;
   const templatesController = user.templates;
-  await templatesController.updateRepoListWithReposFromProviders();
   const repositoryList = templatesController.getRepositories();
   res.status(200).json(repositoryList);
 }
@@ -95,7 +94,7 @@ router.patch('/api/v1/batch/templates/repositories', validateReq, async (req, re
 router.get('/api/v1/templates/styles', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
   const templateController = user.templates;
-  const styles = await templateController.getTemplateStyles();
+  const styles = await templateController.getAllTemplateStyles();
   res.status(200).json(styles);
 });
 

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  ******************************************************************************/
-const { ADMIN_COOKIE } = require('../config');
+const { ADMIN_COOKIE, testTimeout } = require('../config');
 const reqService = require('./request.service');
 
 const defaultCodewindTemplates = [
@@ -175,22 +175,26 @@ const sampleRepos = {
         description: 'Standard Codewind templates.',
         enabled: true,
         protected: true,
+        projectStyles: ['Codewind'],
     },
     anotherCodewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json',
         description: 'Additional Codewind templates.',
         enabled: true,
+        projectStyles: ['Codewind'],
     },
     appsody: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-appsody-templates/master/devfiles/index.json',
         description: 'Appsody extension for Codewind',
         enabled: true,
+        projectStyles: ['Appsody'],
     },
     fromAppsodyExtension: {
-        description: '*appsodyhub',
         url: 'https://github.com/appsody/stacks/releases/latest/download/incubator-index.json',
+        description: 'Appsody Stacks - appsodyhub',
         enabled: true,
         protected: true,
+        projectStyles: ['Appsody'],
     },
 };
 const defaultRepoList = [
@@ -287,12 +291,12 @@ async function getTemplateStyles() {
 function saveReposBeforeTestAndRestoreAfter() {
     let originalTemplateRepos;
     before(async function() {
-        this.timeout(5000);
+        this.timeout(testTimeout.short);
         const res = await getTemplateRepos();
         originalTemplateRepos = res.body;
     });
     after(async function() {
-        this.timeout(5000);
+        this.timeout(testTimeout.short);
         await setTemplateReposTo(originalTemplateRepos);
     });
 }
@@ -300,12 +304,12 @@ function saveReposBeforeTestAndRestoreAfter() {
 function saveReposBeforeEachTestAndRestoreAfterEach() {
     let originalTemplateRepos;
     beforeEach(async function() {
-        this.timeout(5000);
+        this.timeout(testTimeout.short);
         const res = await getTemplateRepos();
         originalTemplateRepos = res.body;
     });
     afterEach(async function() {
-        this.timeout(5000);
+        this.timeout(testTimeout.short);
         await setTemplateReposTo(originalTemplateRepos);
     });
 }

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -34,8 +34,12 @@ chai.use(chaiResValidator(pathToApiSpec));
 
 describe('Template API tests', function() {
     saveReposBeforeTestAndRestoreAfter();
-    before(async() => {
-        await setTemplateReposTo([{ ...sampleRepos.codewind }]);
+    before(async function() {
+        this.timeout(10000);
+        await setTemplateReposTo([
+            { ...sampleRepos.codewind },
+            { ...sampleRepos.fromAppsodyExtension },
+        ]);
     });
     describe('GET /api/v1/templates', function() {
         describe('?projectStyle=', function() {
@@ -100,10 +104,21 @@ describe('Template API tests', function() {
         });
     });
 
+    describe('GET /api/v1/templates/repositories', function() {
+        it('should return 200 and a list of available template repositories', async function() {
+            this.timeout(10000);
+            const res = await getTemplateRepos();
+
+            res.should.have.status(200).and.satisfyApiSpec;
+            res.body.should.have.deep.members(defaultRepoList);
+        });
+    });
+
     describe('POST /api/v1/templates/repositories', function() {
         describe('when trying to add a repository with', function() {
             describe('an invalid url', function() {
                 it('should return 400', async function() {
+                    this.timeout(10000);
                     const res = await addTemplateRepo({
                         url: '/invalid/url',
                         description: 'Invalid url.',
@@ -113,6 +128,7 @@ describe('Template API tests', function() {
             });
             describe('a duplicate url', function() {
                 it('should return 400', async function() {
+                    this.timeout(10000);
                     // Arrange
                     const res = await getTemplateRepos();
                     const originalTemplateRepos = res.body;
@@ -128,6 +144,7 @@ describe('Template API tests', function() {
             });
             describe('a valid url that does not point to an index.json', function() {
                 it('should return 400', async function() {
+                    this.timeout(10000);
                     const res = await addTemplateRepo({
                         url: validUrlNotPointingToIndexJson,
                         description: 'valid url that does not point to an index.json',
@@ -138,7 +155,7 @@ describe('Template API tests', function() {
         });
     });
 
-    describe('GET|POST|DELETE /api/v1/templates/repositories', function() {
+    describe('DELETE|POST /api/v1/templates/repositories', function() {
         const repoToDelete = sampleRepos.codewind;
         const repoToAdd = sampleRepos.anotherCodewind;
         let originalTemplateRepos;
@@ -151,14 +168,9 @@ describe('Template API tests', function() {
             const res2 = await getTemplates();
             originalNumTemplates = res2.body.length;
         });
-        after(async() => {
-            await setTemplateReposTo(originalTemplateRepos);
-        });
-        it('GET should return a list of available template repositories', async function() {
+        after(async function() {
             this.timeout(10000);
-            const res = await getTemplateRepos();
-            res.should.have.status(200).and.satisfyApiSpec;
-            res.body.should.have.deep.members(defaultRepoList);
+            await setTemplateReposTo(originalTemplateRepos);
         });
         // Test deleting repos
         it('DELETE should remove a template repository', async function() {
@@ -175,6 +187,7 @@ describe('Template API tests', function() {
         });
         // Test adding repos
         it('POST should re-add the deleted template repository', async function() {
+            this.timeout(10000);
             const res = await addTemplateRepo(repoToDelete);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.deep.include(repoToDelete);
@@ -187,6 +200,7 @@ describe('Template API tests', function() {
             res.body.length.should.equal(originalNumTemplates);
         });
         it('POST should add a 2nd template repository', async function() {
+            this.timeout(10000);
             const res = await addTemplateRepo(repoToAdd);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.deep.include(repoToAdd);


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

resolves #179 

`GET templates/repositories` now also returns the styles of the template projects contained in the repo, i.e.:
```js
[
  {
    "url": "https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json",
    "description": "Standard Codewind templates.",
    "enabled": true,
    "projectStyles": [
      "Codewind"
    ],
    "protected": true
  },
  {
    "url": "https://github.com/appsody/stacks/releases/latest/download/incubator-index.json",
    "description": "Appsody Stacks - appsodyhub",
    "enabled": true,
    "projectStyles": [
      "Appsody"
    ],
    "protected": true
  }
]
```