### PR TITLE
Retrieve name and description for a template repository from `templates.json` in that repository.

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -279,17 +279,16 @@ function fetchAllRepositoryDetails(repos) {
 }
 
 async function fetchRepositoryDetails(repo) {
-  await readRepoTemplatesJSON(repo);
+  let newRepo = {...repo}
+  await readRepoTemplatesJSON(newRepo);
 
   if (repo.projectStyles) {
-    return repo;
+    return newRepo;
   }
 
   const templatesFromRepo = await getTemplatesFromRepo(repo);
-  return {
-    ...repo,
-    projectStyles: getTemplateStyles(templatesFromRepo),
-  };
+  newRepo.projectStyles = getTemplateStyles(templatesFromRepo);
+  return newRepo;
 }
 
 async function readRepoTemplatesJSON(repository) {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -865,7 +865,7 @@ describe('Templates.js', function() {
         });
     });
 
-    describe('addTemplateStylesToRepos(repos)', function() {
+    describe('fetchAllRepositoryDetails(repos)', function() {
         const tests = {
             '1 repo containing only Codewind templates': {
                 input: [sampleRepos.codewind],
@@ -893,7 +893,7 @@ describe('Templates.js', function() {
         for (const [testName, test] of Object.entries(tests)) {
             describe(testName, function() { // eslint-disable-line no-loop-func
                 it(`returns the expected operation info`, async function() {
-                    const output = await Templates.addTemplateStylesToRepos(test.input);
+                    const output = await Templates.fetchAllRepositoryDetails(test.input);
                     output.should.deep.equal(test.output);
                 });
             });


### PR DESCRIPTION
This PR adds the ability to retrieve the name and description for a template repository from a `templates.json` file at the same level as the repo `index.json`, if the `templates.json` file exists.

I've tested it via the `Template Source Manager` in the VSCode plugin and the details are loaded correct, I used my own repo here: https://raw.githubusercontent.com/hhellyer/codewind-templates-1/master/devfiles/index.json (which is just a clone of https://github.com/kabanero-io/codewind-templates with the `templates.json` file added in the right place.)
