### PR TITLE
{WIP} Enable remote mode by default.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,6 @@ pipeline {
                         export TAG
                         export WORKSPACE_DIRECTORY=$PWD/codewind-workspace;
                         export HOST_OS=$(uname);
-                        export REMOTE_MODE;
                         export HOST_HOME=$HOME
                         export ARCH=$(uname -m);
                         # Select the right images for this architecture.
@@ -151,7 +150,6 @@ pipeline {
                             # Reset so we don't get conflicts
                             unset REPOSITORY;
                             unset WORKSPACE_DIRECTORY;
-                            unset REMOTE_MODE;
                             printf "\n\n${GREEN}SUCCESSFULLY STARTED CONTAINERS $RESET\n";
                             printf "\nCurrent running codewind containers\n";
                             docker ps --filter name=codewind

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -1,5 +1,0 @@
-version: "2"
-services:
-  codewind-pfe:
-    volumes:
-      - ${WORKSPACE_DIRECTORY}:/codewind-workspace

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,6 @@ services:
       - HOST_OS=${HOST_OS}
       - CODEWIND_VERSION=${TAG}
       - PERFORMANCE_CONTAINER=codewind-performance${PLATFORM}:${TAG}
-      - REMOTE_MODE=${REMOTE_MODE}
       - HOST_HOME=${HOST_HOME}
       - HOST_MAVEN_OPTS=${HOST_MAVEN_OPTS}
     depends_on:
@@ -20,6 +19,7 @@ services:
       - "127.0.0.1:34000-35000:9090"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - cw-workspace:/codewind-workspace
     networks:
       - network
 
@@ -34,3 +34,6 @@ services:
 
 networks:
   network:
+
+volumes:
+  cw-workspace:

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -79,32 +79,6 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         let isProjectBuildRequired = false;
 
         try {
-            // TODO - We should merge the two loops but we never want to stop
-            // this one early.
-            // Check if we are in remote mode, while that mode is experimental and non-default.
-            if (process.env["REMOTE_MODE"] == "true") {
-                for (const event of eventArray) {
-                    // TODO - Check for modify and delete events.
-                    const filePath = path.join(projectInfo.location, event.path);
-                    // console.log(`handling project event, event.hasOwnProperty("content")=${event.hasOwnProperty("content")}, filePath=${filePath}:`);
-                    // console.dir(event);
-                    if (event.type == "DELETE") {
-                        if (event.directory) {
-                            await rmdir(filePath);
-                        } else {
-                            await unlink(filePath);
-                        }
-                    } else if (event.type == "MODIFY") {
-                        const content = event.content;
-                        try {
-                            await ensureDir(path.dirname(filePath));
-                            await writeFile(filePath, content, { encoding: "utf8" });
-                        } catch (err) {
-                            logger.logProjectError(`Codewind was unable to update file ${filePath}`, projectID);
-                        }
-                    }
-                }
-            }
             for (let i = 0; i < eventArrayLength; i++) {
                 if (isSettingFileChanged && isProjectBuildRequired) {
                     // Once we have all the necessary flags, dont process any more events

--- a/src/pfe/portal/routes/projects/index.js
+++ b/src/pfe/portal/routes/projects/index.js
@@ -27,12 +27,8 @@ const router = express.Router();
   require('./internal.route'),
   require('./binding.route'),
   require('./fileChanges.route'),
+  require('./remoteBind.route'),
 ]
   .forEach((subRouter) => router.use(subRouter));
-
-// Enable remote bind in remote mode only.
-if (global.codewind.REMOTE_MODE) {
-  router.use(require('./remoteBind.route'));
-}
 
 module.exports = router;

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -132,7 +132,6 @@ async function main() {
     // Workspace location *inside* the our container.
     // Volume is mounted from WORKSPACE_DIRECTORY in docker-compose.yaml.
     CODEWIND_WORKSPACE: '/codewind-workspace/',
-    REMOTE_MODE: (process.env.REMOTE_MODE == 'true') || false,
   };
 
   // find if running in kubernetes and build up a whitelist of allowed origins

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,6 @@ RED='\033[0;31m'
 BLUE='\033[0;36m'
 RESET='\033[0m'
 DEVMODE=false
-REMOTE_MODE=false
 
 printf "\n\n${BLUE}Running 'start.sh' to start codewind. $RESET\n";
 
@@ -24,7 +23,6 @@ while [ "$#" -gt 0 ]; do
   case $1 in
     -t|--tag) TAG="$2"; shift 2;;
     --dev) DEVMODE=true; shift 1;;
-    --remote) REMOTE_MODE=true; shift 1;;
     *) shift 1;;
   esac
 done
@@ -48,13 +46,7 @@ git config -f $GIT_CONFIG --add user.email "`git config --get user.email || echo
 
 
 # Set docker-compose file
-if [ "$REMOTE_MODE" = true ]; then
-  printf "\nRemote mode is enabled\n";
-  DOCKER_COMPOSE_FILE="docker-compose.yaml"
-else
-  printf "\nDefault Local mode is enabled\n";
-  DOCKER_COMPOSE_FILE="docker-compose.yaml -f docker-compose-local.yaml"
-fi
+DOCKER_COMPOSE_FILE="docker-compose.yaml"
 
 if [ "$DEVMODE" = true ]; then
   printf "\nDev mode is enabled\n";
@@ -136,7 +128,6 @@ export TAG
 export WORKSPACE_DIRECTORY=$PWD/codewind-workspace;
 # Export HOST_OS for fix to Maven failing on Windows only as host
 export HOST_OS=$(uname);
-export REMOTE_MODE;
 export HOST_HOME=$HOME
 
 export ARCH=$(uname -m);
@@ -157,7 +148,6 @@ if [ $? -eq 0 ]; then
     # Reset so we don't get conflicts
     unset REPOSITORY;
     unset WORKSPACE_DIRECTORY;
-    unset REMOTE_MODE;
     printf "\n\n${GREEN}SUCCESSFULLY STARTED CONTAINERS $RESET\n";
     printf "\nCurrent running codewind containers\n";
     docker ps --filter name=codewind

--- a/test/src/API/projects/creation/remote-bind.test.js
+++ b/test/src/API/projects/creation/remote-bind.test.js
@@ -9,11 +9,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 
-// Skip this test if remote mode isn't enabled.
-if (process.env['REMOTE_MODE'] !== 'true') {
-    return;
-}
-
 const chai = require('chai');
 const path = require('path');
 const fs = require('fs-extra');


### PR DESCRIPTION
Remove the remote mode flag and enable the function by default.
Start codewind using a docker volume for codewind-workspace instead of a bind mount from the host OS.

Marked WIP so we can synchronise with changes to the installer and the editor plugins.