### PR TITLE
Enable remote mode in development via --remote flag to run.sh

### DIFF
--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -1,5 +1,0 @@
-version: "2"
-services:
-  codewind-pfe:
-    volumes:
-      - ${WORKSPACE_DIRECTORY}:/codewind-workspace

--- a/docker-compose-remote.yaml
+++ b/docker-compose-remote.yaml
@@ -1,0 +1,4 @@
+version: "2"
+
+volumes:
+  cw-workspace:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       - "127.0.0.1:34000-35000:9090"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ${WORKSPACE_VOLUME}:/codewind-workspace
     networks:
       - network
 

--- a/run.sh
+++ b/run.sh
@@ -18,12 +18,14 @@ RESET='\033[0m'
 
 # Developer-mode option for running with appmetrics, see start.sh
 DEVMODE=''
+REMOTE_MODE=''
 
 printf "\n\n${BLUE}Running 'run.sh' to build and start codewind. $RESET\n";
 
 while [ "$#" -gt 0 ]; do
   case $1 in
     --dev) DEVMODE='--dev'; shift 1;;
+    --remote) REMOTE_MODE=--remote; shift 1;;
     *) shift 1;;
   esac
 done
@@ -75,4 +77,4 @@ fi
 cd $DIR/
 
 # Start codewind
-./start.sh $DEVMODE --tag latest
+./start.sh $REMOTE_MODE $DEVMODE --tag latest

--- a/start.sh
+++ b/start.sh
@@ -50,10 +50,10 @@ git config -f $GIT_CONFIG --add user.email "`git config --get user.email || echo
 # Set docker-compose file
 if [ "$REMOTE_MODE" = true ]; then
   printf "\nRemote mode is enabled\n";
-  DOCKER_COMPOSE_FILE="docker-compose.yaml"
+  DOCKER_COMPOSE_FILE="docker-compose.yaml -f docker-compose-remote.yaml"
 else
   printf "\nDefault Local mode is enabled\n";
-  DOCKER_COMPOSE_FILE="docker-compose.yaml -f docker-compose-local.yaml"
+  DOCKER_COMPOSE_FILE="docker-compose.yaml"
 fi
 
 if [ "$DEVMODE" = true ]; then
@@ -134,6 +134,11 @@ printf "\n\n${BLUE}RUNNING DOCKER-COMPOSE IN: $PWD $RESET\n";
 export REPOSITORY='';
 export TAG
 export WORKSPACE_DIRECTORY=$PWD/codewind-workspace;
+if [ "$REMOTE_MODE" = true ]; then
+  export WORKSPACE_VOLUME=cw-workspace
+else
+  export WORKSPACE_VOLUME="$WORKSPACE_DIRECTORY"
+fi
 # Export HOST_OS for fix to Maven failing on Windows only as host
 export HOST_OS=$(uname);
 export REMOTE_MODE;


### PR DESCRIPTION
Enable remote mode when using run.sh via --remote flag.
Use a docker volume for persitent storage in remote mode.