### PR TITLE
Update appsody extension to 0.5.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                         echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
                         mkdir -p ${SRC_DIR}/pfe/extensions
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.4.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.4.0.zip
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.5.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.5.0.zip
 
                         # BUILD IMAGES
                         # Uses a build file in each of the directories that we want to use

--- a/script/build.sh
+++ b/script/build.sh
@@ -58,7 +58,7 @@ cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
 mkdir -p ${SRC_DIR}/pfe/extensions
 rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.4.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.4.0.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.5.0.zip https://github.com/eclipse/codewind-appsody-extension/archive/0.5.0.zip
 
 # BUILD IMAGES
 # Uses a build file in each of the directories that we want to use


### PR DESCRIPTION
For development on master, we need to use the version of appsody we will eventually release, which is 0.5.0. I have created an appsody extension pre-release for 0.5.0.