### PR TITLE
Change GET /api/v1/project-types

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -321,7 +321,7 @@ pipeline {
               # Docker system prune
               echo "Docker system prune ..."
               docker system df
-              docker system prune -a -f
+              docker system prune -a -f --volumes
               docker builder prune -a -f
               docker system df
               df -lh

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1360,9 +1360,7 @@ components:
       type: object
       required:
         - id
-        - version
         - label
-        - description
       properties:
         id:
           type: string

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1374,7 +1374,6 @@ components:
       description: Descriptor for subtypes of a project type
       type: object
       required:
-        - prompt
         - items
       properties:
         prompt:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1021,7 +1021,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/ProjectType'
+                  $ref: '#/components/schemas/ProjectTypeDescriptor'
         204:
           description: No templates found
 
@@ -1344,6 +1344,48 @@ components:
     ProjectType:
       description: the build type for the project. Built-in types are 'liberty', 'spring', 'swift', 'nodejs', and 'docker'.
       type: string
+    ProjectTypeDescriptor:
+      description: Descriptor of a project type, including possible subtypes
+      type: object
+      required:
+        - projectType
+        - projectSubtypes
+      properties:
+        projectType:
+          $ref: '#/components/schemas/ProjectType'
+        projectSubtypes:
+          $ref: '#/components/schemas/ProjectSubtypesDescriptor'
+    ProjectSubtype:
+      description: A project subtype defined by a project extension
+      type: object
+      required:
+        - id
+        - version
+        - label
+        - description
+      properties:
+        id:
+          type: string
+        version:
+          type: string
+        label:
+          type: string
+        description:
+          type: string
+    ProjectSubtypesDescriptor:
+      description: Descriptor for subtypes of a project type
+      type: object
+      required:
+        - prompt
+        - items
+      properties:
+        prompt:
+          description: A prompt for user to select a subtype
+          type: string
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectSubtype'
     testRunTime:
       description: The time of a load-test run, whose format is yyyymmddHHMMss
       type: number

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1376,8 +1376,8 @@ components:
       required:
         - items
       properties:
-        prompt:
-          description: A prompt for user to select a subtype
+        label:
+          description: A name label to refer to the subtype
           type: string
         items:
           type: array

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -32,7 +32,6 @@ async function initSubtypes(extension, templates, language) {
   // simple case, not an extension project type
   if (!extension) {
     return {
-      prompt: 'Select the language that best fits your project',
       items: [ toSubtype(language) ]
     };
   }

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -24,7 +24,7 @@ function sanitizeProjectType(array, type) {
   const sanitized = {
     projectType: String(type.projectType),
     projectSubtypes: {
-      prompt: String(type.projectSubtypes.prompt),
+      label: String(type.projectSubtypes.label),
       items: []
     }
   };

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -15,15 +15,59 @@ const Logger = require('../modules/utils/Logger');
 const router = express.Router();
 const log = new Logger(__filename);
 
+function toSubtype(language) {
+  return {
+    id: language,
+    label: language
+  };
+}
+
+function addLanguage(projectType, language) {
+  if (!projectType.projectSubtypes.items.find(item => item.id == language))
+    projectType.projectSubtypes.items.push(toSubtype(language));
+}
+
+async function initSubtypes(extension, language) {
+  
+  if (extension) {
+    // todo
+  }
+  
+  return {
+    prompt: 'Select the language that best fits your project',
+    items: [ toSubtype(language) ]
+  };
+}
+
 /**
  * API function to returns a list of supported project types
  * @return JSON array with the list of supported project types
  */
 router.get('/api/v1/project-types', async (req, res) => {
   const user = req.cw_user;
+  const projectTypes = {};
   try {
-    const validProjectTypes = await user.projectTypes();
-    res.status(200).send(validProjectTypes);
+    const templates = await user.templates.getEnabledTemplates();
+    for (const template of templates) {
+      
+      const projectType = template.projectType;
+      const extension = user.extensionList.getExtensionForProjectType(projectType)
+      
+      // seen this type before
+      if (projectTypes[projectType]) {
+        if (!extension)
+          addLanguage(projectTypes[projectType], template.language);
+      }
+      // initialize a new entry
+      else {
+        projectTypes[projectType] = {
+          projectType: projectType,
+          projectSubtypes: await initSubtypes(extension, template.language)
+        };
+      }
+    }
+
+    res.status(200).send(Object.values(projectTypes));
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -37,7 +37,6 @@ async function initSubtypes(extension, templates, language) {
   }
 
   const subtypes = {
-    prompt: '',
     items: []
   };
 

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -15,51 +15,54 @@ const Logger = require('../modules/utils/Logger');
 const router = express.Router();
 const log = new Logger(__filename);
 
-function toSubtype(language) {
-  return {
-    id: language,
-    label: language
+function sanitizeProjectType(array, type) {
+
+  // doesn't even have the expected fields, no-op return
+  if (!type.projectType || !type.projectSubtypes || !Array.isArray(type.projectSubtypes.items))
+    return array;
+
+  const sanitized = {
+    projectType: String(type.projectType),
+    projectSubtypes: {
+      prompt: String(type.projectSubtypes.prompt),
+      items: []
+    }
   };
+
+  for (const item of type.projectSubtypes.items) {
+    if (!item.id)
+      continue;
+    sanitized.projectSubtypes.items.push({
+      id: String(item.id),
+      version: String(item.version),
+      label: String(item.label || item.id),
+      description: String(item.description)
+    });
+  }
+
+  if (sanitized.projectSubtypes.items.length > 0)
+    array.push(sanitized);
+
+  return array
+}
+
+async function getProjectTypes(provider) {
+  
+  const projectTypes = [];
+
+  // get projectTypes from extension provider
+  if (provider && typeof provider.getProjectTypes == 'function') {
+    const types = await provider.getProjectTypes();
+    if (Array.isArray(types))
+      types.reduce(sanitizeProjectType, projectTypes);
+  }
+
+  return projectTypes;
 }
 
 function addLanguage(projectType, language) {
   if (!projectType.projectSubtypes.items.find(item => item.id == language))
-    projectType.projectSubtypes.items.push(toSubtype(language));
-}
-
-async function initSubtypes(extension, templates, language) {
-  
-  // simple case, not an extension project type
-  if (!extension) {
-    return {
-      items: [ toSubtype(language) ]
-    };
-  }
-
-  const subtypes = {
-    items: []
-  };
-
-  // get subtypes from extension provider
-  const provider = templates.providers[extension.name];
-  if (provider && typeof provider.getSubtypes == 'function') {
-    const temp = await provider.getSubtypes();
-    subtypes.prompt = temp.prompt;
-    if (Array.isArray(temp.items)) {
-      for (const item of temp.items) {
-        if (!item.id)
-          continue;
-        subtypes.items.push({
-          id: item.id,
-          version: item.version, 
-          label: item.label || item.id,
-          description: item.description
-        });
-      }
-    }
-  }
-
-  return subtypes;
+    projectType.projectSubtypes.items.push({ id: language, label: language });
 }
 
 /**
@@ -68,7 +71,8 @@ async function initSubtypes(extension, templates, language) {
  */
 router.get('/api/v1/project-types', async (req, res) => {
   const user = req.cw_user;
-  const projectTypes = {};
+  const projectTypes = [];
+  const seenProjectTypes = {};
   try {
     const templates = await user.templates.getEnabledTemplates();
     for (const template of templates) {
@@ -76,21 +80,32 @@ router.get('/api/v1/project-types', async (req, res) => {
       const projectType = template.projectType;
       const extension = user.extensionList.getExtensionForProjectType(projectType)
       
-      // seen this type before
-      if (projectTypes[projectType]) {
-        if (!extension)
-          addLanguage(projectTypes[projectType], template.language);
+      if (extension) {
+        // only need to get project types from extension once
+        if (seenProjectTypes[projectType])
+          continue;
+        const types = await getProjectTypes(user.templates.providers[extension.name]);
+        projectTypes.push(...types);
+        seenProjectTypes[projectType] = true;
       }
-      // initialize a new entry
       else {
-        projectTypes[projectType] = {
-          projectType: projectType,
-          projectSubtypes: await initSubtypes(extension, user.templates, template.language)
-        };
+        // initialize a new entry
+        if (!seenProjectTypes[projectType]) {
+          const type = {
+            projectType: projectType,
+            projectSubtypes: {
+              items: []
+            }
+          };
+          projectTypes.push(type);
+          seenProjectTypes[projectType] = type;
+        }
+        
+        addLanguage(seenProjectTypes[projectType], template.language);
       }
     }
 
-    res.status(200).send(Object.values(projectTypes));
+    res.status(200).send(projectTypes);
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -61,8 +61,11 @@ async function getProjectTypes(provider) {
 }
 
 function addLanguage(projectType, language) {
-  if (!projectType.projectSubtypes.items.find(item => item.id == language))
+  if (!projectType.projectSubtypes.items.find(item => item.id == language)) {
+    // label is mainly for extension project types to supply custom labels for subtypes
+    // for Codewind the label for the language is just the language itself
     projectType.projectSubtypes.items.push({ id: language, label: language });
+  }
 }
 
 /**

--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -29,7 +29,7 @@ describe('Project Types API tests', function() {
         res.body.should.be.an('array');
         res.body.map((item) => {
             return item.projectType;
-        }).should.have.members([
+        }).should.include.members([
             'liberty',
             'nodejs',
             'spring',

--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -9,10 +9,12 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 const chai = require('chai');
+const chaiResValidator = require('chai-openapi-response-validator');
 
 const reqService = require('../../modules/request.service');
-const { ADMIN_COOKIE } = require('../../config');
+const { ADMIN_COOKIE, pathToApiSpec } = require('../../config');
 
+chai.use(chaiResValidator(pathToApiSpec));
 chai.should();
 
 describe('Project Types API tests', function() {
@@ -22,10 +24,12 @@ describe('Project Types API tests', function() {
             .get('/api/v1/project-types')
             .set('Cookie', ADMIN_COOKIE);
 
-        res.should.have.status(200);
+        res.should.have.status(200).and.satisfyApiSpec;
         res.should.have.ownProperty('body');
         res.body.should.be.an('array');
-        res.body.should.have.members([
+        res.body.map((item) => {
+            return item.projectType;
+        }).should.have.members([
             'liberty',
             'nodejs',
             'spring',

--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -20,7 +20,7 @@ chai.should();
 describe('Project Types API tests', function() {
 
     it('should return expected list of project types', async function() {
-        this.timeout(5000);
+        this.timeout(10000);
         const res = await reqService.chai
             .get('/api/v1/project-types')
             .set('Cookie', ADMIN_COOKIE);


### PR DESCRIPTION
For: https://github.com/eclipse/codewind/issues/292

Related PR: https://github.com/eclipse/codewind-appsody-extension/pull/30 

Sample output:

```json

  {
    "projectType": "appsodyExtension",
    "projectSubtypes": {
      "label": "Appsody stack",
      "items": [
        {
          "id": "appsodyhub/java-microprofile",
          "version": "0.2.14",
          "label": "Appsody java-microprofile",
          "description": "Eclipse MicroProfile on Open Liberty & OpenJ9 using Maven"
        }
      ]
    }
  },
  {
    "projectType": "docker",
    "projectSubtypes": {
      "items": [
        {
          "id": "go",
          "label": "go"
        },
        {
          "id": "java",
          "label": "java"
        },
        {
          "id": "python",
          "label": "python"
        }
      ]
    }
  }
]
```