### PR TITLE
Allow developers to set appsody extension version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,8 @@ We welcome submitting issues and contributions.
 2. [Contributing](CONTRIBUTING.md)
 3. [View the API documentation](https://eclipse.github.io/codewind/)
 
+## Setting Appsody Codewind extension version
+Use the environment variable `APPSODY_EXT_VERSION` to set the specific Appsody Codewind extension to download. For example, before executing `run.sh` set `APPSODY_EXT_VERSION=0.5.0` to download the 0.5.0 release. To skip the download, set `APPSODY_EXT_VERSION=none` and the existing Appsody extension in `codewind-workspace/.extensions` will be used. If an invalid version is used, the download will be skipped.
+
 ## License
 [EPL 2.0](https://www.eclipse.org/legal/epl-2.0/)

--- a/run.sh
+++ b/run.sh
@@ -63,7 +63,7 @@ else
   # Build the docker images
   printf "\n\n${BLUE}BUILDING DOCKER IMAGES${RESET}\n\n";
 
-  ./script/build.sh;
+  ./script/build.sh $DEVMODE;
 
   if [ $? -ne 0 ]; then
     printf "\n${RED}FAILED TO BUILD\nExiting. $RESET";

--- a/run.sh
+++ b/run.sh
@@ -63,7 +63,7 @@ else
   # Build the docker images
   printf "\n\n${BLUE}BUILDING DOCKER IMAGES${RESET}\n\n";
 
-  ./script/build.sh $DEVMODE;
+  ./script/build.sh;
 
   if [ $? -ne 0 ]; then
     printf "\n${RED}FAILED TO BUILD\nExiting. $RESET";

--- a/script/build.sh
+++ b/script/build.sh
@@ -26,14 +26,6 @@ PERFORMANCE=performance;
 ARCH=`uname -m`;
 TAG=latest;
 REGISTRY=eclipse
-DEVMODE=false
-
-while [ "$#" -gt 0 ]; do
-  case $1 in
-    --dev) DEVMODE=true; shift 1;;
-    *) shift 1;;
-  esac
-done
 
 # On intel, uname -m returns "x86_64", but the convention for our docker images is "amd64"
 if [ "$ARCH" == "x86_64" ]; then
@@ -67,23 +59,22 @@ cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 mkdir -p ${SRC_DIR}/pfe/extensions
 rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 
-DEFAULT_APPSODY_EXT_VERSION="0.5.0"
+DOWNLOAD_APPSODY_EXT_VERSION="0.5.0"
 
-if [ "$DEVMODE" == "true" ]; then
-  if [ "$APPSODY_EXT_VERSION" == "none" ]; then 
+# - If APPSODY_EXT_VERSION=none, skip the download
+# - If APPSODY_EXT_VERSION is not set, set to the default version (same as running without --dev)
+# - If value is set for APPSODY_EXT_VERSION, attempt to download it (no error if invalid)
+if [ "$APPSODY_EXT_VERSION" == "none" ]; then
+  DOWNLOAD_APPSODY_EXT_VERSION="none"
+elif [ ! -z "$APPSODY_EXT_VERSION" ]; then 
+  DOWNLOAD_APPSODY_EXT_VERSION=$APPSODY_EXT_VERSION
+fi
+
+if [ "$DOWNLOAD_APPSODY_EXT_VERSION" == "none" ]; then 
     echo -e "\n+++   SKIPPING APPSODY EXTENSION DOWNLOAD DUE TO ENV VARIABLE APPSODY_EXT_VERSION=none +++\n";
   else
-    if [ -z "$APPSODY_EXT_VERSION" ]; then 
-      APPSODY_EXT_VERSION=$DEFAULT_APPSODY_EXT_VERSION
-    fi
-
-    echo -e "\n+++   DOWNLOADING APPSODY EXTENSION: ${APPSODY_EXT_VERSION}  +++\n";
-    curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-${APPSODY_EXT_VERSION}.zip https://github.com/eclipse/codewind-appsody-extension/archive/${APPSODY_EXT_VERSION}.zip
-  fi
-else
-  # If devmode is not set, download the approved version
-  echo -e "\n+++   DOWNLOADING DEFAULT APPSODY EXTENSION: ${DEFAULT_APPSODY_EXT_VERSION}  +++\n";
-  curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-${DEFAULT_APPSODY_EXT_VERSION}.zip https://github.com/eclipse/codewind-appsody-extension/archive/${DEFAULT_APPSODY_EXT_VERSION}.zip
+    echo -e "\n+++   DOWNLOADING DEFAULT APPSODY EXTENSION: ${DOWNLOAD_APPSODY_EXT_VERSION}  +++\n";
+    curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-${DOWNLOAD_APPSODY_EXT_VERSION}.zip https://github.com/eclipse/codewind-appsody-extension/archive/${DOWNLOAD_APPSODY_EXT_VERSION}.zip
 fi
 
 # BUILD IMAGES

--- a/script/build.sh
+++ b/script/build.sh
@@ -62,7 +62,7 @@ rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 DOWNLOAD_APPSODY_EXT_VERSION="0.5.0"
 
 # - If APPSODY_EXT_VERSION=none, skip the download
-# - If APPSODY_EXT_VERSION is not set, set to the default version (same as running without --dev)
+# - If APPSODY_EXT_VERSION is not set, set to the default version
 # - If value is set for APPSODY_EXT_VERSION, attempt to download it (no error if invalid)
 if [ "$APPSODY_EXT_VERSION" == "none" ]; then
   DOWNLOAD_APPSODY_EXT_VERSION="none"


### PR DESCRIPTION
Sometimes, we want to modify the appsody extension and not have it overwritten on a ./run.sh call.

If APPSODY_EXT_VERSION is unset, then the default will be downloaded
If APPSODY_EXT_VERSION is set, it will attempt to download that version. No checks are in place for invalid URLs, since this is for developers only. The name of the zip is displayed in the console in case they want to diagnose

An env variable is used, as that is what the IDE uses to specify which version of codewind to use. They use CW_TAGS, so we follow a similar approach.