### PR TITLE
Add the PFE reference ID to projects

### DIFF
--- a/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
+++ b/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
@@ -30,8 +30,9 @@ function addOwnerReference() {
     yq w -i $filename -- metadata.ownerReferences[$index].uid $ownerRefUID
 }
 
-ownerReferenceName=$( kubectl get po --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.ownerReferences[0].name}' )
-ownerReferenceUID=$( kubectl get po --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.ownerReferences[0].uid}' )
+# Get the UID of the Codewind replicaset
+ownerReferenceName=$( kubectl get replicaset --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.name}' )
+ownerReferenceUID=$( kubectl get replicaset --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.uid}' )
 
 # Set the name of the deployment and service to the release name
 concatenatedReleaseName=$(echo $releaseName | head -c 62 | sed 's/\-$//')


### PR DESCRIPTION
Updates the `modify-helm-chart.sh` script to mark all of the projects deployed by PFE as owned by PFE, so that the Kube garbage collector cleans them up.

A follow-up PR to codewind-che-plugin will remove the now old environment variable from the PFE deployment.

To test, create a Che workspace with the following [devfile](https://raw.githubusercontent.com/johnmcollier/devfiles/master/codewind/codewind.yaml) and verify that deployed projects are removed when the workspace is deleted.