### PR TITLE
Publish cumulative docker image from a release branch build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -241,6 +241,19 @@ pipeline {
                                 echo "Publishing $REGISTRY/$i:$TAG"
                                 ./script/publish.sh $i $REGISTRY $TAG
                             done
+
+                            if [[ $GIT_BRANCH =~ ^([0-9]+\\.[0-9]+) ]]; then
+                                IFS='.' # set '.' as delimiter
+                                read -ra TOKENS <<< "$GIT_BRANCH"    
+                                IFS=' ' # reset delimiter
+                                export TAG_CUMULATIVE=${TOKENS[0]}.${TOKENS[1]}
+
+                                for i in "${DOCKER_IMAGE_ARRAY[@]}"
+                                do
+                                    echo "Publishing $REGISTRY/$i:$TAG_CUMULATIVE"
+                                    ./script/publish.sh $i $REGISTRY $TAG_CUMULATIVE
+                                done
+                            fi
                         else
                             echo "Skip publishing docker images for $GIT_BRANCH branch"
                         fi


### PR DESCRIPTION
e.g.
publish 0.5 and 0.5.0 docker images from 0.5.0 branch build.

Fix the previous PR #481 