### PR TITLE
Adding 'name' parameter to POST /templates/repo

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1372,6 +1372,9 @@ components:
         projectType:
           type: string
           example: "docker"
+        source:
+          type: string
+          example: "Default Codewind Templates"
     TemplateRepo:
       type: object
       required:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1376,9 +1376,10 @@ components:
       type: object
       required:
         - url
-        - description
       properties:
         url:
+          type: string
+        name:
           type: string
         description:
           type: string

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -289,7 +289,11 @@ function fetchAllRepositoryDetails(repos) {
 
 async function fetchRepositoryDetails(repo) {
   let newRepo = {...repo}
-  await readRepoTemplatesJSON(newRepo);
+
+  // Only set the name or description of the repo if not given by the user
+  if (!(repo.name && repo.description)){
+    await readRepoTemplatesJSON(newRepo);
+  }
 
   if (repo.projectStyles) {
     return newRepo;
@@ -326,8 +330,7 @@ async function readRepoTemplatesJSON(repository) {
   try {
     const templateDetails = JSON.parse(res.body);
     for (const prop of ['name', 'description']) {
-      // Only set the name or description of the repo if not given by the user
-      if (templateDetails.hasOwnProperty(prop) && !repository[prop]) {
+      if (templateDetails.hasOwnProperty(prop)) {
         repository[prop] = templateDetails[prop];
       }
     }

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -326,6 +326,7 @@ async function readRepoTemplatesJSON(repository) {
   try {
     const templateDetails = JSON.parse(res.body);
     for (const prop of ['name', 'description']) {
+      // Only add the name or description if not set by the user on adding
       if (templateDetails.hasOwnProperty(prop) && !repository[prop]) {
         repository[prop] = templateDetails[prop];
       }

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -229,7 +229,7 @@ module.exports = class Templates {
   /**
    * Add a repository to the list of template repositories.
    */
-  async addRepository(repoUrl, repoDescription, isRepoProtected) {
+  async addRepository(repoUrl, repoDescription, repoName, isRepoProtected) {
     let url;
     try {
       url = new URL(repoUrl).href;
@@ -249,6 +249,7 @@ module.exports = class Templates {
     }
 
     let newRepo = {
+      name: repoName,
       url,
       description: repoDescription,
       enabled: true,
@@ -325,7 +326,7 @@ async function readRepoTemplatesJSON(repository) {
   try {
     const templateDetails = JSON.parse(res.body);
     for (const prop of ['name', 'description']) {
-      if (templateDetails.hasOwnProperty(prop)) {
+      if (templateDetails.hasOwnProperty(prop) && !repository[prop]) {
         repository[prop] = templateDetails[prop];
       }
     }

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -326,7 +326,7 @@ async function readRepoTemplatesJSON(repository) {
   try {
     const templateDetails = JSON.parse(res.body);
     for (const prop of ['name', 'description']) {
-      // Only add the name or description if not set by the user on adding
+      // Only set the name or description of the repo if not given by the user
       if (templateDetails.hasOwnProperty(prop) && !repository[prop]) {
         repository[prop] = templateDetails[prop];
       }

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -26,12 +26,14 @@ const DEFAULT_REPOSITORY_LIST = [
     enabled: true,
     protected: true,
     projectStyles: ['Codewind'],
+    name: 'Default templates',
   },
 ];
 
 const KABANERO_REPO = {
   url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/kabanero-index.json',
-  description: 'Kabanero Collections',
+  name: 'Kabanero Collections',
+  description: 'The default set of templates from Kabanero Collections',
   enabled: false,
   protected: true,
 };
@@ -370,9 +372,14 @@ async function getTemplatesFromRepo(repository) {
       url: summary.location,
       projectType: summary.projectType,
     };
+
     if (summary.projectStyle) {
       template.projectStyle = summary.projectStyle;
     }
+    if (repository.name) {
+      template.source = repository.name;
+    }
+
     return template;
   });
   return templates;

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -48,12 +48,18 @@ router.get('/api/v1/templates/repositories', sendRepositories);
 
 router.post('/api/v1/templates/repositories', validateReq, async (req, res, _next) => {
   const user = req.cw_user;
+  const repositoryName = req.sanitizeBody('name')
   const repositoryUrl = req.sanitizeBody('url');
   const repositoryDescription = req.sanitizeBody('description');
   const isRepoProtected = req.sanitizeBody('protected');
 
   try {
-    await user.templates.addRepository(repositoryUrl, repositoryDescription, isRepoProtected);
+    await user.templates.addRepository(
+      repositoryUrl,
+      repositoryDescription,
+      repositoryName,
+      isRepoProtected
+    );
   } catch (error) {
     log.error(error);
     const knownErrorCodes = ['INVALID_URL', 'DUPLICATE_URL', 'URL_DOES_NOT_POINT_TO_INDEX_JSON'];

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -18,6 +18,7 @@ const defaultCodewindTemplates = [
         language: 'go',
         url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
         projectType: 'docker',
+        source: 'Default templates',
     },
     {
         label: 'Lagom Java',
@@ -25,6 +26,7 @@ const defaultCodewindTemplates = [
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/lagomJavaTemplate',
         projectType: 'docker',
+        source: 'Default templates',
     },
     {
         label: 'Node.js Express',
@@ -32,6 +34,7 @@ const defaultCodewindTemplates = [
         language: 'nodejs',
         url: 'https://github.com/microclimate-dev2ops/nodeExpressTemplate',
         projectType: 'nodejs',
+        source: 'Default templates',
     },
     {
         label: 'Open Liberty',
@@ -39,6 +42,7 @@ const defaultCodewindTemplates = [
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/openLibertyTemplate',
         projectType: 'docker',
+        source: 'Default templates',
     },
     {
         label: 'Python',
@@ -46,6 +50,7 @@ const defaultCodewindTemplates = [
         language: 'python',
         url: 'https://github.com/microclimate-dev2ops/SVTPythonTemplate',
         projectType: 'docker',
+        source: 'Default templates',
     },
     {
         label: 'Spring Boot®',
@@ -53,6 +58,7 @@ const defaultCodewindTemplates = [
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/springJavaTemplate',
         projectType: 'spring',
+        source: 'Default templates',
     },
     {
         label: 'Swift',
@@ -60,6 +66,7 @@ const defaultCodewindTemplates = [
         language: 'swift',
         url: 'https://github.com/microclimate-dev2ops/swiftTemplate',
         projectType: 'swift',
+        source: 'Default templates',
     },
     {
         label: 'WebSphere Liberty MicroProfile®',
@@ -67,6 +74,7 @@ const defaultCodewindTemplates = [
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/javaMicroProfileTemplate',
         projectType: 'liberty',
+        source: 'Default templates',
     },
 ];
 
@@ -153,6 +161,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.java-microprofile.v0.2.11.templates.default.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
     {
         label: 'Appsody LoopBack 4 template',
@@ -161,6 +170,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.nodejs-loopback.v0.1.4.templates.scaffold.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
     {
         label: 'Appsody Node.js Express simple template',
@@ -169,6 +179,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.nodejs-express.v0.2.5.templates.simple.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
     {
         label: 'Appsody Node.js Express skaffold template',
@@ -177,6 +188,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.nodejs-express.v0.2.5.templates.skaffold.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
     {
         label: 'Appsody Node.js template',
@@ -185,6 +197,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.nodejs.v0.2.5.templates.simple.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
     {
         label: 'Appsody Spring Boot® default template',
@@ -193,6 +206,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.java-spring-boot2.v0.3.9.templates.default.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
     {
         label: 'Appsody Spring Boot® kotlin template',
@@ -201,6 +215,7 @@ const defaultKabaneroTemplates = [
         url: 'https://github.com/kabanero-io/collections/releases/download/v0.1.2/incubator.java-spring-boot2.v0.3.9.templates.kotlin.tar.gz',
         projectType: 'appsodyExtension',
         projectStyle: 'Appsody',
+        source: 'Kabanero Collections',
     },
 ];
 
@@ -216,6 +231,7 @@ const styledTemplates = {
         language: 'go',
         url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
         projectType: 'docker',
+        source: 'Default templates',
         // defaults to projectStyle 'Codewind'
     },
     appsody: {

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -231,7 +231,7 @@ const styledTemplates = {
 const sampleRepos = {
     codewind: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
-        description: 'Standard Codewind templates',
+        description: 'The default set of templates for new projects in Codewind.',
         enabled: true,
         protected: true,
         projectStyles: ['Codewind'],

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -1,4 +1,4 @@
-/*******************************************************************************
+ /*******************************************************************************
  * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -13,60 +13,60 @@ const reqService = require('./request.service');
 
 const defaultCodewindTemplates = [
     {
-        label: 'Go template',
+        label: 'Go',
         description: 'Sample microservice for simple go app',
         language: 'go',
         url: 'https://github.com/microclimate-dev2ops/microclimateGoTemplate',
         projectType: 'docker',
     },
     {
-        label: 'Java Lagom template',
-        description: 'Template for building Lagom Reactive microservice in Java',
+        label: 'Lagom Java',
+        description: 'Sample for building Lagom Reactive microservice in Java',
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/lagomJavaTemplate',
         projectType: 'docker',
     },
     {
-        label: 'Java MicroProfile template',
-        description: 'Cloud Microservice Starter for Java - MicroProfile / Java EE',
-        language: 'java',
-        url: 'https://github.com/microclimate-dev2ops/javaMicroProfileTemplate',
-        projectType: 'liberty',
-    },
-    {
-        label: 'Node.js template',
+        label: 'Node.js Express',
         description: 'Cloud-ready Node.js Express sample application',
         language: 'nodejs',
         url: 'https://github.com/microclimate-dev2ops/nodeExpressTemplate',
         projectType: 'nodejs',
     },
     {
-        label: 'Open Liberty template',
+        label: 'Open Liberty',
         description: 'Template for building an Open Liberty microservice in Java',
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/openLibertyTemplate',
         projectType: 'docker',
     },
     {
-        label: 'Python template',
+        label: 'Python',
         description: 'HelloWorld microservice written in python',
         language: 'python',
         url: 'https://github.com/microclimate-dev2ops/SVTPythonTemplate',
         projectType: 'docker',
     },
     {
-        label: 'Spring template',
-        description: 'Template for building a Spring microservice',
+        label: 'Spring Boot®',
+        description: 'Spring Boot® using IBM Java',
         language: 'java',
         url: 'https://github.com/microclimate-dev2ops/springJavaTemplate',
         projectType: 'spring',
     },
     {
-        label: 'Swift microservice template',
-        description: 'Template for building a Swift microservice',
+        label: 'Swift',
+        description: 'Sample for building a Swift microservice',
         language: 'swift',
         url: 'https://github.com/microclimate-dev2ops/swiftTemplate',
         projectType: 'swift',
+    },
+    {
+        label: 'WebSphere Liberty MicroProfile®',
+        description: 'Eclipse MicroProfile® on Websphere Liberty',
+        language: 'java',
+        url: 'https://github.com/microclimate-dev2ops/javaMicroProfileTemplate',
+        projectType: 'liberty',
     },
 ];
 
@@ -235,6 +235,7 @@ const sampleRepos = {
         enabled: true,
         protected: true,
         projectStyles: ['Codewind'],
+        name: 'Default templates',
     },
     appsody: {
         url: 'https://raw.githubusercontent.com/kabanero-io/codewind-appsody-templates/master/devfiles/index.json',

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -412,6 +412,20 @@ describe('Templates.js', function() {
                 });
             });
         });
+        describe('(<validUrl>, <NoDesc> <NoName>)', function() {
+            it('succeeds, and gets the name and description from templates.json', async function() {
+                const url = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json';
+                const func = () => templateController.addRepository(url);
+                await (func().should.not.be.rejected);
+                templateController.repositoryList.should.deep.include({
+                    url,
+                    name: 'Default templates',
+                    description: 'The default set of templates for new projects in Codewind.',
+                    enabled: true,
+                    projectStyles: ['Codewind'],
+                });
+            });
+        });
     });
     describe('deleteRepository(repoUrl)', function() {
         const mockRepoList = [sampleRepos.fromAppsodyExtension];

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -385,10 +385,11 @@ describe('Templates.js', function() {
         describe('(<validUrlPointingToIndexJson>, <validDesc>)', function() {
             it('succeeds', async function() {
                 const url = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json';
-                const func = () => templateController.addRepository(url, 'description');
+                const func = () => templateController.addRepository(url, 'description', 'name');
                 await (func().should.not.be.rejected);
                 templateController.repositoryList.should.deep.include({
                     url,
+                    name: 'name',
                     description: 'description',
                     enabled: true,
                     projectStyles: ['Codewind'],
@@ -399,10 +400,11 @@ describe('Templates.js', function() {
             it('succeeds', async function() {
                 const url = 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/aad4bafc14e1a295fb8e462c20fe8627248609a3/devfiles/index.json';
                 const isRepoProtected = false;
-                const func = () => templateController.addRepository(url, 'description', isRepoProtected);
+                const func = () => templateController.addRepository(url, 'description', 'name', isRepoProtected);
                 await (func().should.not.be.rejected);
                 templateController.repositoryList.should.deep.include({
                     url,
+                    name: 'name',
                     description: 'description',
                     enabled: true,
                     projectStyles: ['Codewind'],


### PR DESCRIPTION
Adds an extra parameter in the request body of `POST /templates/repo` for repo name (`name`), this will take precedence over the name read from the `templates.json` in the repo. 

Also makes `name` and `description` both optional parameters for this API, with the user description taking precedence too.

Updates templates.service to match new template descriptions, which had been changed without updating the tests.

Resolves https://github.com/eclipse/codewind/issues/586.

Latest Commit - adds source to each template endpoint (if a repo name exists) - #608, and updates the default repo list to have a name for the Kabenero repo - #609.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>