### PR TITLE
Allow the deployment registry to be set via the REST API.

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1218,8 +1218,12 @@ paths:
                     description: false if deployment registry was not set
                     example: false
     post:
-      summary: Test the specified Deployment Registry
-      description: The API also emits a socket event `deploymentRegistryStatus` with data `{deploymentRegistryTest ":" true, msg ":" message related to the socket for pass/failure}`
+      summary: Test or set the specified Deployment Registry
+      description: >
+        On test the API also emits a socket event `deploymentRegistryStatus` with data
+        `{deploymentRegistryTest ":" true, msg ":" message related to the socket for pass/failure}`
+        A set operation will set the registry without testing to allow the client to force save the
+        value.
       requestBody:
         content:
           application/json:
@@ -1230,6 +1234,11 @@ paths:
               properties:
                 deploymentRegistry:
                   type: string
+                operation:
+                  type: string
+                  enum:
+                    - test
+                    - set
       responses:
         200:
           description: Successfully completed

--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -270,7 +270,22 @@ export default class Filewatcher {
      *  @property 400: Error when attempting to read the workspace settings file
      *
      */
-    readWorkspaceSettings: () => Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>;
+    readWorkspaceSettings: (newWorkspaceSettings: any) => Promise<any>;
+
+    /**
+     * @function
+     * @description Read the workspace settings file and load the properties into cache if they're valid.
+     *
+     * @example await filewatcher.writeWorkspaceSettings();
+     *
+     * @returns Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>
+     * Response codes:
+     *  @property 200: Successfully received the request
+     *  @property 500: Error when attempting to write the workspace settings file
+     *
+     */
+    writeWorkspaceSettings: (newWorkspaceSettings: any) => Promise<any>;
+
 
     /**
      * @function
@@ -648,6 +663,7 @@ export default class Filewatcher {
         this.setLocale = locale.setLocale;
         this.setLoggingLevel = logger.setLoggingLevel;
         this.readWorkspaceSettings = workspaceSettings.readWorkspaceSettings;
+        this.writeWorkspaceSettings = workspaceSettings.writeWorkspaceSettings;
         this.testDeploymentRegistry = workspaceSettings.testDeploymentRegistry;
         this.registerListener = socket.registerListener;
         this.createProject = projectsController.createProject;

--- a/src/pfe/file-watcher/server/src/utils/utils.ts
+++ b/src/pfe/file-watcher/server/src/utils/utils.ts
@@ -62,6 +62,27 @@ let contents: any = {};
 
 /**
  * @function
+ * @description Write a JSON file asynchronously.
+ *
+ * @param file <Required | String> - The path to the file location.
+ * @param object <Required | any> - The content to store
+ *
+ * @returns Promise<any> - returns the file contents as JSON object.
+ */
+export async function asyncWriteJSONFile(filePath: string, object: any): Promise<boolean> {
+    let contents: any = {};
+    try {
+        contents = await fse.writeJSON(filePath, object, { spaces: 2 });
+        return true;
+    } catch (err) {
+        logger.logError("Error writing file " + filePath);
+        logger.logError(err);
+        return false;
+    }
+}
+
+/**
+ * @function
  * @description Check if the folder is a directory asynchronously.
  *
  * @param file <Required | String> - The path to the folder location.

--- a/src/pfe/file-watcher/server/src/utils/workspaceSettings.ts
+++ b/src/pfe/file-watcher/server/src/utils/workspaceSettings.ts
@@ -93,7 +93,25 @@ export async function readWorkspaceSettings(): Promise<IWorkspaceSettingsSuccess
 
    const workspaceSettingsCache = JSON.parse( await loadWorkspaceSettings(settingsFileContent) );
 
-    return { "statusCode": 200, "workspaceSettings": workspaceSettingsCache};
+   return { "statusCode": 200, "workspaceSettings": workspaceSettingsCache};
+}
+
+export async function writeWorkspaceSettings(newWorkspaceSettings: any): Promise<IWorkspaceSettingsSuccess | IWorkspaceSettingsFailure> {
+    const workspaceSettingsFile = constants.workspaceConstants.workspaceSettingsFile;
+    const workspaceSettingsInfo = await getWorkspaceSettingsInfo();
+    for (const setting in newWorkspaceSettings) {
+        workspaceSettingsInfo[setting] = newWorkspaceSettings[setting];
+    }
+    // Write the new settings and invalidate the cache.
+    const writeStatus = await utils.asyncWriteJSONFile(workspaceSettingsFile, workspaceSettingsInfo);
+    workspaceSettingsInfoCache = undefined;
+
+    if (writeStatus) {
+        return { "statusCode": 200 , workspaceSettings: workspaceSettingsInfo};
+    } else {
+        const msg = "Codewind encountered an error when trying to write the workspace settings file";
+        return { statusCode: 500 , msg };
+    }
 }
 
 /**

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -550,6 +550,21 @@ module.exports = class FileWatcher {
     }
   }
 
+  async writeWorkspaceSettings(workspaceSettings) {
+    let retval;
+    try{
+      retval = await filewatcher.writeWorkspaceSettings(workspaceSettings);
+      this.logFWReturnedMsg(retval);
+    } catch (err) {
+      log.error(err);
+    }
+    if (retval.statusCode != 200) {
+      throw new Error(`writeWorkspaceSettings ${retval.statusCode}`);
+    }
+    return retval;
+  }
+
+
   /**
    * Function to shutdown the user's projects
    */

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -656,6 +656,22 @@ module.exports = class User {
   }
 
   /**
+   * Function to write workspace settings
+   */
+  async writeWorkspaceSettings(workspaceSettings) {
+    let retval;
+    try{
+      log.info(`Writing workspace settings file.`);
+      retval = await this.fw.writeWorkspaceSettings(workspaceSettings);
+    } catch (err) {
+      log.error(`Error in writeWorkspaceSettings`);
+      log.error(err);
+    }
+    console.log(`writeWorkspaceSettings returning ${retval}`);
+    return retval;
+  }
+
+  /**
    * Function to get test deployment registry
    */
   async testDeploymentRegistry(deploymentRegistry) {

--- a/src/pfe/portal/routes/registry.route.js
+++ b/src/pfe/portal/routes/registry.route.js
@@ -11,6 +11,7 @@
 const express = require('express');
 const router = express.Router();
 const Logger = require('../modules/utils/Logger');
+const { validateReq } = require('../middleware/reqValidator');
 
 const log = new Logger(__filename);
 
@@ -35,21 +36,29 @@ router.get('/api/v1/registry', async function (req, res) {
 });
 
 /**
- * API Function to test Deployment Registry
+ * API Function to test and set the Deployment Registry
  */
-router.post('/api/v1/registry', async function (req, res) {
+router.post('/api/v1/registry', validateReq, async function (req, res) {
   let retval;
   try {
     let user = req.cw_user;
     log.debug(`POST /api/v1/registry called`);
     const deploymentRegistry = req.sanitizeBody('deploymentRegistry');
+    const operation = req.sanitizeBody('operation');
     if (!deploymentRegistry) {
       const msg = "Missing required parameter, deploymentRegistry is required to be provided.";
       const data = { "statusCode": 400, "deploymentRegistryTest": false, "msg": msg}
       res.status(400).send(data);
     }
-    log.debug(`Testing deployment registry: ${deploymentRegistry}`);
-    retval = await user.testDeploymentRegistry(deploymentRegistry);
+    // The validateReq middleware will throw an error if operation is not test or set,
+    // but it is optional and defaults to test.
+    if (operation === undefined || operation === 'test') {
+      log.debug(`Testing deployment registry: ${deploymentRegistry}`);
+      retval = await user.testDeploymentRegistry(deploymentRegistry);
+    } else if (operation === 'set') {
+      log.debug(`Setting deployment registry: ${deploymentRegistry}`);
+      retval = await user.writeWorkspaceSettings({deploymentRegistry});
+    }
     res.status(retval.statusCode).send(retval);
   } catch (error) {
     log.error(error);

--- a/test/src/API/registry.test.js
+++ b/test/src/API/registry.test.js
@@ -11,9 +11,10 @@
 
 const chai = require('chai');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const reqService = require('../../modules/request.service');
-const projectService = require('../../modules/project.service');
+const containerService = require('../../modules/container.service');
 const { ADMIN_COOKIE, testTimeout } = require('../../config');
 
 chai.should();
@@ -25,7 +26,12 @@ const getRegistryStatus = () => reqService.chai
 const testRegistry = () => reqService.chai
     .post('/api/v1/registry')
     .set('Cookie', ADMIN_COOKIE)
-    .send({ deploymentRegistry: 'someregistry' });
+    .send({ operation: 'test', deploymentRegistry: 'someregistry' });
+
+const setRegistry = (registry) => reqService.chai
+    .post('/api/v1/registry')
+    .set('Cookie', ADMIN_COOKIE)
+    .send({ operation: 'set', deploymentRegistry: registry });
 
 const getWatchList = () => reqService.chai
     .get('/api/v1/projects/watchlist')
@@ -47,56 +53,55 @@ async function putWatchStatus(projectID, projectWatchStateId) {
     await reqService.makeReqAndAwaitSocketMsg(req, 200, expectedSocketMsg);
 }
 
-describe.skip('Deployment Registry route tests', function() {
-    let workspace_location;
-    let workspace_settings_file;
-    let workspace_settings_file_bk;
+describe('Deployment Registry route tests', function() {
+    const workspace_settings_file = '/codewind-workspace/.config/settings.json';
+
     let projectID;
     let projectWatchStateId;
     const workspace_settings_file_content = { deploymentRegistry: 'someregistry' };
-    const workspace_settings_file_no_registry_content = { deploymentRegistryGarbage: 'someregistry' };
+    const workspace_settings_file_no_registry_content = { deploymentRegistryGarbage: 'garbagevalue' };
     
+    let restoreConfig = false;
+
+    before('Create a backup of any existing ${workspace_location}/.config/settings.json file and set the watch status', async function() {
+        this.timeout(testTimeout.med);
+
+        // Create backup of existing workspace settings file
+        if (await containerService.fileExists(workspace_settings_file)) {
+            await containerService.copyFrom(workspace_settings_file, path.join(os.tmpdir(), 'settings_bk.json'));
+            restoreConfig = true;
+        }
+
+        // Get the watch list for workspace config dir
+        const res = await getWatchList();
+        res.should.have.status(200);
+        const projectsWatchList = res.body.projects;
+        for (let i = 0; i < projectsWatchList.length; i++) {
+            if (projectsWatchList[i].pathToMonitor.includes('.config')) {
+                projectID = projectsWatchList[i].projectID;
+                projectWatchStateId = projectsWatchList[i].projectWatchStateId;
+            }
+        }
+
+        // Set the watch status for workspace config
+        await putWatchStatus(projectID, projectWatchStateId);
+    });
+
+    after('Restore ${workspace_location}/.config/settings_bk.json file', async function() {
+        this.timeout(testTimeout.med);
+
+        // Restore the workspace settings file backup if it exists
+        if (restoreConfig) {
+            await containerService.copyTo(path.join(os.tmpdir(), 'settings_bk.json'), workspace_settings_file);
+        }
+    });
+
     describe('GET /api/v1/registry', function() {
 
-        before('Create a backup of any existing ${workspace_location}/.config/settings.json file and set the watch status', async function() {
-            this.timeout(testTimeout.med);
-
-            workspace_location = await projectService.findWorkspaceLocation();
-            workspace_settings_file = path.join(workspace_location, '.config', 'settings.json');
-            workspace_settings_file_bk = path.join(workspace_location, '.config', 'settings_bk.json');
-
-            // Create backup of existing workspace settings file
-            if (fs.existsSync(workspace_settings_file)) {
-                fs.renameSync(workspace_settings_file, workspace_settings_file_bk);
-            }
-
-            // Get the watch list for workspace config dir
-            const res = await getWatchList();
-            res.should.have.status(200);
-            const projectsWatchList = res.body.projects;
-            for (let i = 0; i < projectsWatchList.length; i++) {
-                if (projectsWatchList[i].pathToMonitor.includes('.config')) {
-                    projectID = projectsWatchList[i].projectID;
-                    projectWatchStateId = projectsWatchList[i].projectWatchStateId;
-                }
-            }
-
-            // Set the watch status for workspace config
-            await putWatchStatus(projectID, projectWatchStateId);
-        });
-
-        after('Restore ${workspace_location}/.config/settings_bk.json file', async function() {
-            this.timeout(testTimeout.med);
-
-            // Restore the workspace settings file backup if it exists
-            if (fs.existsSync(workspace_settings_file) && fs.existsSync(workspace_settings_file_bk)) {
-                fs.renameSync(workspace_settings_file_bk, workspace_settings_file);
-            }
-        });
 
         it('should return false without ${workspace_location}/.config/settings.json', async function() {
             this.timeout(testTimeout.med);
-
+            await containerService.unlink(workspace_settings_file);
             const res = await getRegistryStatus();
             res.should.have.status(200);
             res.body.deploymentRegistry.should.equal(false);
@@ -106,21 +111,27 @@ describe.skip('Deployment Registry route tests', function() {
             this.timeout(testTimeout.med);
 
             const workspace_settings_file_content_json = JSON.stringify(workspace_settings_file_no_registry_content);
-            fs.writeFileSync(workspace_settings_file, workspace_settings_file_content_json, 'utf8');
+            const content_file = path.join(os.tmpdir(), 'no_registry.json');
+            fs.writeFileSync(content_file, workspace_settings_file_content_json, 'utf8');
+            await containerService.copyTo(content_file, workspace_settings_file);
+            fs.unlinkSync(content_file);
 
             const res = await getRegistryStatus();
             res.should.have.status(200);
             res.body.deploymentRegistry.should.equal(false);
         });
 
-        it('should return false with a bad JSON in ${workspace_location}/.config/settings.json', async function() {
+        it('should return false with bad JSON in ${workspace_location}/.config/settings.json', async function() {
             this.timeout(testTimeout.med);
 
-            const workspace_settings_file_content_json = '{"deploymentRegistryGarbage":"someregistry"';
-            fs.writeFileSync(workspace_settings_file, workspace_settings_file_content_json, 'utf8');
+            const bad_workspace_settings_file_content_json = '{"deploymentRegistryGarbage":"someregistry"';
+            const content_file = path.join(os.tmpdir(), 'bad_content.json');
+            fs.writeFileSync(content_file, bad_workspace_settings_file_content_json, 'utf8');
+            await containerService.copyTo(content_file, workspace_settings_file);
+            fs.unlinkSync(content_file);
 
             const res = await getRegistryStatus();
-            res.should.have.status(200);
+            res.should.have.status(500);
             res.body.deploymentRegistry.should.equal(false);
         });
 
@@ -128,7 +139,10 @@ describe.skip('Deployment Registry route tests', function() {
             this.timeout(testTimeout.med);
 
             const workspace_settings_file_content_json = JSON.stringify(workspace_settings_file_content);
-            fs.writeFileSync(workspace_settings_file, workspace_settings_file_content_json, 'utf8');
+            const content_file = path.join(os.tmpdir(), 'deploymentRegistry.json');
+            fs.writeFileSync(content_file, workspace_settings_file_content_json, 'utf8');
+            await containerService.copyTo(content_file, workspace_settings_file);
+            fs.unlinkSync(content_file);
 
             const res = await getRegistryStatus();
             res.should.have.status(200);
@@ -143,6 +157,21 @@ describe.skip('Deployment Registry route tests', function() {
             const res = await testRegistry();
             res.should.have.status(500);
             res.body.deploymentRegistryTest.should.equal(false);
+        });
+
+        it('should set the registry to the specified value', async function() {
+            this.timeout(testTimeout.med);
+
+            const newRegistry = 'localhost:5000';
+            const setRes = await setRegistry(newRegistry);
+            setRes.should.have.status(200);
+
+            const statusRes = await getRegistryStatus();
+            statusRes.should.have.status(200);
+            statusRes.body.deploymentRegistry.should.equal(true);
+
+            const settings = await containerService.readJson(workspace_settings_file);
+            settings.deploymentRegistry.should.equal(newRegistry);
         });
     });
 });


### PR DESCRIPTION
Add the ability to set the deployment registry via the rest API.
Add a 'set' operation to api/v1/registry to support that.
Update the Open API docs to reflect the change.
Update and re-enable the registry tests.

This is for Issue #557 