### PR TITLE
Revert back old readWorkspaceSettings function definition

### DIFF
--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -270,7 +270,7 @@ export default class Filewatcher {
      *  @property 400: Error when attempting to read the workspace settings file
      *
      */
-    readWorkspaceSettings: (newWorkspaceSettings: any) => Promise<any>;
+    readWorkspaceSettings: () => Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>;
 
     /**
      * @function

--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -274,13 +274,13 @@ export default class Filewatcher {
 
     /**
      * @function
-     * @description Read the workspace settings file and load the properties into cache if they're valid.
-     *
-     * @example await filewatcher.writeWorkspaceSettings();
+     * @description Write the provided workspace settings to the workspace settings file.
+     * @param newWorkspaceSettings  <Required | Object>: New workspace settings to write to the file
+     * @example await filewatcher.writeWorkspaceSettings(newWorkspaceSettings);
      *
      * @returns Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>
      * Response codes:
-     *  @property 200: Successfully received the request
+     *  @property 200: Successfully wrote the file
      *  @property 500: Error when attempting to write the workspace settings file
      *
      */

--- a/src/pfe/file-watcher/server/src/utils/utils.ts
+++ b/src/pfe/file-watcher/server/src/utils/utils.ts
@@ -70,9 +70,8 @@ let contents: any = {};
  * @returns Promise<any> - returns the file contents as JSON object.
  */
 export async function asyncWriteJSONFile(filePath: string, object: any): Promise<boolean> {
-    let contents: any = {};
     try {
-        contents = await fse.writeJSON(filePath, object, { spaces: 2 });
+        await fse.writeJSON(filePath, object, { spaces: 2 });
         return true;
     } catch (err) {
         logger.logError("Error writing file " + filePath);

--- a/src/pfe/file-watcher/server/src/utils/utils.ts
+++ b/src/pfe/file-watcher/server/src/utils/utils.ts
@@ -67,7 +67,7 @@ let contents: any = {};
  * @param file <Required | String> - The path to the file location.
  * @param object <Required | any> - The content to store
  *
- * @returns Promise<any> - returns the file contents as JSON object.
+ * @returns Promise<boolean> - returns true if the file successfully finished writing.
  */
 export async function asyncWriteJSONFile(filePath: string, object: any): Promise<boolean> {
     try {


### PR DESCRIPTION
### Description

The readWorkspaceSettings function definition was accidentally changed which caused a regression in our functional test suite. Reverting it back. Original commit https://github.com/eclipse/codewind/commit/60a98e94327fceae75f868a099295b7038077189#diff-1c61507dfacef770d56960208ce7b95fR273