### PR TITLE
Fix Turbine Test - Circular Dependency on Modules

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/Project.ts
+++ b/src/pfe/file-watcher/server/src/projects/Project.ts
@@ -34,6 +34,7 @@ export interface ProjectInfo {
     language?: string;
     isHttps?: boolean;
     appBaseURL?: string;
+    odoAppName?: string;
 }
 
 export interface ProjectMetadata {

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -1908,7 +1908,7 @@ async function getPODInfoAndSendToPortal(operation: Operation, event: string = "
         status: "failed"
     };
 
-    const projectInfo = operation.projectInfo;
+    let projectInfo = operation.projectInfo;
     const projectLocation = projectInfo.location;
     const projectID = projectInfo.projectID;
     const projectName = projectInfo.projectName;
@@ -1934,6 +1934,12 @@ async function getPODInfoAndSendToPortal(operation: Operation, event: string = "
         logger.logProjectInfo(`The container was started successfully for application ` + projectLocation, projectID, projectName);
 
         logger.logProjectInfo("The project location for " + projectID + " is " + projectLocation, projectID, projectName);
+
+        if (projectInfo.projectType == "odo") {
+            // this if loop is  used to get the odo app name to set the odo app name in the project info file and reload it back
+            await setOdoAppName(projectInfo);
+            projectInfo = await getProjectInfo(projectInfo.projectID);
+        }
 
         const containerInfo = await kubeutil.getApplicationContainerInfo(projectInfo, operation);
         projectEvent.status = "success";

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -401,10 +401,12 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
 
                     logger.logProjectInfo("The project location for " + operation.projectInfo.projectID + " is " + projectLocation, projectID, projectName);
 
+                    // this if loop is used to get the odo app name and set the odo app name in the project info file and reload it back
                     if (operation.projectInfo.projectType == "odo") {
-                        // this if loop is  used to get the odo app name to set the odo app name in the project info file and reload it back
-                        await setOdoAppName(operation.projectInfo);
-                        operation.projectInfo = await getProjectInfo(operation.projectInfo.projectID);
+                        if (!operation.projectInfo.odoAppName) {
+                            await getAndSaveOdoAppName(operation.projectInfo);
+                            operation.projectInfo = await getProjectInfo(operation.projectInfo.projectID);
+                        }
                     }
 
                     const containerInfo = await kubeutil.getApplicationContainerInfo(operation.projectInfo, operation);
@@ -838,10 +840,12 @@ export async function getContainerInfo(projectInfo: ProjectInfo, forceRefresh: b
         const operation = new Operation("general", projectInfo);
         operation.containerName = containerName;
 
+        // this if loop is used to get the odo app name and set the odo app name in the project info file and reload it back
         if (projectInfo.projectType == "odo") {
-            // this if loop is  used to get the odo app name to set the odo app name in the project info file and reload it back
-            await setOdoAppName(projectInfo);
-            projectInfo = await getProjectInfo(projectInfo.projectID);
+            if (!projectInfo.odoAppName) {
+                await getAndSaveOdoAppName(projectInfo);
+                projectInfo = await getProjectInfo(projectInfo.projectID);
+            }
         }
 
         containerInfo = await kubeutil.getApplicationContainerInfo(projectInfo, operation);
@@ -957,10 +961,12 @@ export async function isContainerActive(projectID: string, handler: any): Promis
         const containerName = await getContainerName(projectInfo);
         let containerState = undefined;
         if (process.env.IN_K8 === "true") {
+            // this if loop is used to get the odo app name and set the odo app name in the project info file and reload it back
             if (projectInfo.projectType == "odo") {
-                // this if loop is  used to get the odo app name to set the odo app name in the project info file and reload it back
-                await setOdoAppName(projectInfo);
-                projectInfo = await getProjectInfo(projectInfo.projectID);
+                if (!projectInfo.odoAppName) {
+                    await getAndSaveOdoAppName(projectInfo);
+                    projectInfo = await getProjectInfo(projectInfo.projectID);
+                }
             }
             containerState = await kubeutil.isContainerActive(containerName, projectInfo);
         } else {
@@ -988,17 +994,17 @@ export async function isContainerActive(projectID: string, handler: any): Promis
 
 /**
  * @function
- * @description Set the ODO app name and save it to the project info file.
+ * @description Get the ODO app name and save it to the project info file.
  *
  * @param projectInfo <Required | ProjectInfo> - The metadata information for a project.
  *
  * @returns Promsie<void>
  */
-export async function setOdoAppName(projectInfo: ProjectInfo): Promise<void> {
+export async function getAndSaveOdoAppName(projectInfo: ProjectInfo): Promise<void> {
     const projectID = projectInfo.projectID;
 
     const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-    const appName = await projectHandler.getAppName(projectID);
+    const appName = projectHandler.hasOwnProperty("getAppName") ? await projectHandler.getAppName(projectID) : undefined;
 
     projectInfo.odoAppName = appName;
 
@@ -1935,10 +1941,12 @@ async function getPODInfoAndSendToPortal(operation: Operation, event: string = "
 
         logger.logProjectInfo("The project location for " + projectID + " is " + projectLocation, projectID, projectName);
 
+        // this if loop is used to get the odo app name and set the odo app name in the project info file and reload it back
         if (projectInfo.projectType == "odo") {
-            // this if loop is  used to get the odo app name to set the odo app name in the project info file and reload it back
-            await setOdoAppName(projectInfo);
-            projectInfo = await getProjectInfo(projectInfo.projectID);
+            if (!projectInfo.odoAppName) {
+                await getAndSaveOdoAppName(projectInfo);
+                projectInfo = await getProjectInfo(projectInfo.projectID);
+            }
         }
 
         const containerInfo = await kubeutil.getApplicationContainerInfo(projectInfo, operation);

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -948,7 +948,7 @@ export async function getAllProjectInfo(handler: any): Promise<void> {
  */
 export async function isContainerActive(projectID: string, handler: any): Promise<void> {
     try {
-        const projectInfo = await getProjectInfo(projectID);
+        let projectInfo = await getProjectInfo(projectID);
         if (!projectInfo) {
             handler({ error: await locale.getTranslation("projectUtil.projectInfoError") });
             return;
@@ -957,6 +957,11 @@ export async function isContainerActive(projectID: string, handler: any): Promis
         const containerName = await getContainerName(projectInfo);
         let containerState = undefined;
         if (process.env.IN_K8 === "true") {
+            if (projectInfo.projectType == "odo") {
+                // this if loop is  used to get the odo app name to set the odo app name in the project info file and reload it back
+                await setOdoAppName(projectInfo);
+                projectInfo = await getProjectInfo(projectInfo.projectID);
+            }
             containerState = await kubeutil.isContainerActive(containerName, projectInfo);
         } else {
             containerState = await dockerutil.isContainerActive(containerName);

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -206,9 +206,7 @@ export async function isContainerActive(containerName: string, projectInfo?: Pro
         let releaseLabel = "release=" + containerName;
         if (projectInfo.projectType == "odo") {
             const componentName = path.basename(projectInfo.location);
-            const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-            const appName = await projectHandler.getAppName(projectInfo.projectID);
-            releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + appName;
+            releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.appName;
         }
         let containerState = {state: ContainerStates.containerNotFound};
         // We are getting the list of pods by the release label

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -69,9 +69,7 @@ export async function getApplicationContainerInfo(projectInfo: ProjectInfo, oper
     let releaseLabel = "release=" + releaseName;
     if (projectInfo.projectType == "odo") {
         const componentName = path.basename(projectInfo.location);
-        const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-        const appName = await projectHandler.getAppName(projectID);
-        releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + appName;
+        releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.odoAppName;
     }
     const projectName = path.basename(projectLocation);
 

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -206,7 +206,7 @@ export async function isContainerActive(containerName: string, projectInfo?: Pro
         let releaseLabel = "release=" + containerName;
         if (projectInfo.projectType == "odo") {
             const componentName = path.basename(projectInfo.location);
-            releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.appName;
+            releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.odoAppName;
         }
         let containerState = {state: ContainerStates.containerNotFound};
         // We are getting the list of pods by the release label


### PR DESCRIPTION
### Description

There was circular dependency introduced from https://github.com/eclipse/codewind/pull/601. This PR extracts the logic to set app name into the project info metadata and use that where needed and avoid circular dependencies.

Related to issue #613 