### PR TITLE
Increase bodyParser upload size

### DIFF
--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -275,7 +275,10 @@ async function main() {
       }
     });
 
-    app.use(bodyParser.json());
+    app.use(bodyParser.json({
+      limit: '1mb'
+    }));
+
     app.use(bodyParser.urlencoded({
       extended: false
     }));


### PR DESCRIPTION
## Problem : 

Hybrid :  Large numbers of files in a new Liberty project could not be pushed or cleared resulting in : 

```
[07/10/19 08:42:03 /portal/middleware/errorHandler.js] [ERROR] { error:
   { name: 'PayloadTooLargeError',
     message: 'request entity too large' } }
```

## Solution : 

Increase the size limit from 100KB to 1MB

## Testing : 

After changing size,  all project files (including the target folder) were uploaded / removed successfully.


Signed-off-by: mark-cornaia <mark.cornaia@uk.ibm.com>