### PR TITLE
Fix setLoggingLevel call to catch unhandled promise

### DIFF
--- a/src/pfe/file-watcher/server/test/unit-test/tests/logger.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/logger.module.test.ts
@@ -539,7 +539,9 @@ export function loggerTestModule(): void {
             it(combo + " => msg: " + msg + ", level: " + level, async() => {
                 try {
                     await logger.setLoggingLevel(level);
-                } catch (err) {}
+                } catch (err) {
+                    // an error here is expected when setting invalid level - we verify that in the line below by reading the turbine logs
+                }
                 const turbineLogContent = await getTurbineLogContent(turbineLogPath, regex);
                 expect(turbineLogContent).to.equal(expectedResult);
             }).timeout(10000);


### PR DESCRIPTION
### Description

The unit test calls setLoggingLevel function but does not enacapsulate it with try and catch block. This PR fixes this and avoids logging unhandled promise warnings in the log.

```
 combinational testing of setLoggingLevel function
        ✓ combo1 => msg: The current log level is, level: info (1002ms)
[07/10/19 16:16:35 Turbine] [ERROR] [File Name: /Users/sakib@ibm.com/workspace/dev/projects/codewind/src/pfe/file-watcher/server/src/utils/logger.ts | Function Name: setLoggingLevel | Line Number: 11] wronglevel is not a valid value, the following log levels are available {"error":"error","warn":"warn","info":"info","debug":"debug","trace":"trace"}
        ✓ combo2 => msg: is not a valid value, the following log levels are available, level: wronglevel (1005ms)

```

Related to https://github.com/eclipse/codewind/issues/627

Signed-off-by: ssh24 <sakib@ibm.com>

