### PR TITLE
Fix unit test microprofile validate tests env variable

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -194,7 +194,6 @@ export async function validate(operation: Operation): Promise<void> {
  * @returns Promise<any>
  */
 export async function logBuildEvent(projectInfo: ProjectInfo, msg: String, isError: boolean): Promise<any> {
-    if (process.env.NODE_ENV === "test") return;
     // have the message match the Maven format
     const msgLabel = isError ? "ERROR" : "INFO";
     const fullMsg = `\n[${msgLabel}] ${msg}`;
@@ -215,11 +214,14 @@ export async function logBuildEvent(projectInfo: ProjectInfo, msg: String, isErr
 
     logger.logProjectInfo(`Writing to build log at ${buildLog} :\n\t${fullMsg}`, projectInfo.projectID);
 
-    fs.appendFile(buildLogPath, fullMsg, (err) => {
-        if (err) {
-            logger.logProjectError("File system error writing to build log: " + err, projectInfo.projectID);
-        }
-    });
+    // if the build log path is defined, only then we write it
+    if (buildLogPath) {
+        fs.appendFile(buildLogPath, fullMsg, (err) => {
+            if (err) {
+                logger.logProjectError("File system error writing to build log: " + err, projectInfo.projectID);
+            }
+        });
+    }
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -194,7 +194,7 @@ export async function validate(operation: Operation): Promise<void> {
  * @returns Promise<any>
  */
 export async function logBuildEvent(projectInfo: ProjectInfo, msg: String, isError: boolean): Promise<any> {
-    if (process.env.HIDE_PFE_LOG === "y") return;
+    if (process.env.NODE_ENV === "test") return;
     // have the message match the Maven format
     const msgLabel = isError ? "ERROR" : "INFO";
     const fullMsg = `\n[${msgLabel}] ${msg}`;


### PR DESCRIPTION
## Description 

There was a mismatch of env variable for the microprofile validate tests. This PR switches it from `HIDE_PFE_LOG` to `NODE_ENV` to make sure the logs are consistent and the error is caught.

See comment https://github.com/eclipse/codewind/issues/396#issuecomment-539533985

**Unit test**
![Screen Shot 2019-10-08 at 12 39 03 PM](https://user-images.githubusercontent.com/15173354/66415194-0dc19700-e9c9-11e9-95d6-15ba094a54ea.png)

**Microprofile functional test**
![Screen Shot 2019-10-08 at 12 38 08 PM](https://user-images.githubusercontent.com/15173354/66415206-1619d200-e9c9-11e9-92ef-935a51735d83.png)

Signed-off-by: ssh24 <sakib@ibm.com>