### PR TITLE
Set PFE as the owner of deployed projects and add projectID label

### DIFF
--- a/src/pfe/file-watcher/idc/artifacts/run_kubernetes.sh
+++ b/src/pfe/file-watcher/idc/artifacts/run_kubernetes.sh
@@ -117,7 +117,7 @@ if [[ -z $serviceFile ]]; then
 fi
 
 # Add the necessary labels and serviceaccount to the chart
-/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $CONTAINER_NAME
+/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $CONTAINER_NAME $PROJECT_ID
 
 # Add the iterative-dev functionality to the chart
 /file-watcher/scripts/kubeScripts/add-iterdev-to-chart.sh $deploymentFile $PROJNAME "/home/default/artifacts/new_entrypoint.sh" $LOGFOLDER

--- a/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
+++ b/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
@@ -16,6 +16,7 @@ source /file-watcher/scripts/kubeScripts/kube-utils.sh
 deploymentFile=$1
 serviceFile=$2
 releaseName=$3
+projectID=$4
 
 function addOwnerReference() {
     local filename="$1"
@@ -39,6 +40,11 @@ yq w -i $serviceFile -- metadata.name $concatenatedReleaseName
 # Add the missing labels to the deployment
 yq w -i $deploymentFile -- metadata.labels.release $releaseName
 yq w -i $deploymentFile -- spec.template.metadata.labels.release $releaseName
+
+# Add the project ID label to the service and deployment
+yq w -i $serviceFile -- metadata.labels.projectID $projectID
+yq w -i $deploymentFile -- metadata.labels.projectID $projectID
+yq w -i $deploymentFile -- spec.template.metadata.labels.projectID $projectID
 
 # Add owner reference for deletion when workspace is deleted
 addOwnerReference $deploymentFile

--- a/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
+++ b/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
@@ -23,10 +23,13 @@ function addOwnerReference() {
     yq w -i $filename -- metadata.ownerReferences[+].apiVersion apps/v1
     yq w -i $filename -- metadata.ownerReferences[$index].blockOwnerDeletion true
     yq w -i $filename -- metadata.ownerReferences[$index].controller true
-    yq w -i $filename -- metadata.ownerReferences[$index].kind ReplicaSet
-    yq w -i $filename -- metadata.ownerReferences[$index].name $OWNER_REF_NAME
-    yq w -i $filename -- metadata.ownerReferences[$index].uid $OWNER_REF_UID
+    yq w -i $filename -- metadata.ownerReferences[$index].kind Deployment
+    yq w -i $filename -- metadata.ownerReferences[$index].name $PFE_NAME
+    yq w -i $filename -- metadata.ownerReferences[$index].uid $PFE_UID
 }
+
+export PFE_NAME=$( kubectl get deploy --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.name}' )
+export PFE_UID=$( kubectl get deploy --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.uid}' )
 
 # Set the name of the deployment and service to the release name
 concatenatedReleaseName=$(echo $releaseName | head -c 62 | sed 's/\-$//')

--- a/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
+++ b/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
@@ -24,13 +24,13 @@ function addOwnerReference() {
     yq w -i $filename -- metadata.ownerReferences[+].apiVersion apps/v1
     yq w -i $filename -- metadata.ownerReferences[$index].blockOwnerDeletion true
     yq w -i $filename -- metadata.ownerReferences[$index].controller true
-    yq w -i $filename -- metadata.ownerReferences[$index].kind Deployment
+    yq w -i $filename -- metadata.ownerReferences[$index].kind ReplicaSet
     yq w -i $filename -- metadata.ownerReferences[$index].name $PFE_NAME
     yq w -i $filename -- metadata.ownerReferences[$index].uid $PFE_UID
 }
 
-export PFE_NAME=$( kubectl get deploy --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.name}' )
-export PFE_UID=$( kubectl get deploy --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.uid}' )
+export PFE_NAME=$( kubectl get rs --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.name}' )
+export PFE_UID=$( kubectl get rs --selector=app=codewind-pfe,codewindWorkspace=$CHE_WORKSPACE_ID -o jsonpath='{.items[0].metadata.uid}' )
 
 # Set the name of the deployment and service to the release name
 concatenatedReleaseName=$(echo $releaseName | head -c 62 | sed 's/\-$//')

--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -138,7 +138,7 @@ function deployK8s() {
 	fi
 
 	# Add the necessary labels and serviceaccount to the chart
-	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project
+	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project $PROJECT_ID
 
 	# Push app container image to docker registry if one is set up
 	if [[ ! -z $DEPLOYMENT_REGISTRY ]]; then

--- a/src/pfe/file-watcher/scripts/spring-container.sh
+++ b/src/pfe/file-watcher/scripts/spring-container.sh
@@ -189,7 +189,7 @@ function deployK8() {
 	fi
 
 	# Add the necessary labels and serviceaccount to the chart
-	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project
+	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project $PROJECT_ID
 
 	# Add the iterative-dev functionality to the chart
 	/file-watcher/scripts/kubeScripts/add-iterdev-to-chart.sh $deploymentFile "$projectName" "/scripts/new_entrypoint.sh"

--- a/src/pfe/file-watcher/scripts/swift-container.sh
+++ b/src/pfe/file-watcher/scripts/swift-container.sh
@@ -156,7 +156,7 @@ function deployK8s() {
 	fi
 
 	# Add the necessary labels and serviceaccount to the chart
-	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project
+	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project $PROJECT_ID
 
 	# Push app container image to docker registry if one is set up
 	if [[ ! -z $DEPLOYMENT_REGISTRY ]]; then

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -1514,7 +1514,7 @@ async function containerBuildAndRun(event: string, buildInfo: BuildRequest, oper
             }
 
             // Add the missing labels to the chart
-            await processManager.spawnDetachedAsync(buildInfo.projectID, "bash", ["/file-watcher/scripts/kubeScripts/modify-helm-chart.sh", deploymentFile, serviceFile, buildInfo.containerName], {});
+            await processManager.spawnDetachedAsync(buildInfo.projectID, "bash", ["/file-watcher/scripts/kubeScripts/modify-helm-chart.sh", deploymentFile, serviceFile, buildInfo.containerName, buildInfo.projectID], {});
         }
         catch (err) {
             logger.logProjectError("Error modifying the chart to add the necessary labels", buildInfo.projectID);


### PR DESCRIPTION
- Makes the PFE deployment the owner of all deployed projects in Codewind, rather than the Che workspace
    - PFE and the Performance dashboard are still owned by the Che workspace
    - Has the same effect as before, when PFE goes down, so do the projects
- Adds a projectID label to the project deployments and services, so that the deployment and service can be easily retrieved from processes that don't have access to the helm release name