### PR TITLE
Safe guard LOCAL_WORKSPACE to default when REMOTE_MODE is false

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -50,12 +50,13 @@ if (process.env.IN_K8) {
 }
 
 const KUBE_NAMESPACE = process.env.KUBE_NAMESPACE || "default";
+const REMOTE_MODE = (process.env.REMOTE_MODE) || false;
 
 const containerInfoMap = new Map();
 
 export const containerInfoForceRefreshMap = new Map();
 
-export const LOCAL_WORKSPACE = "/codewind-workspace";
+export const LOCAL_WORKSPACE = REMOTE_MODE ? "/codewind-workspace" : process.env.NODE_ENV === "test" ? process.env.HOST_WORKSPACE_DIRECTORY : (process.argv[2] ? process.argv[2] : process.env.HOST_WORKSPACE_DIRECTORY);
 
 const projectList: Array<string> = [];
 
@@ -164,7 +165,6 @@ export async function containerCreate(operation: Operation, script: string, comm
     const projectInfo = await projectsController.updateProjectInfo(projectID, keyValuePair);
     logger.logTrace("The projectInfo has been updated for deploymentRegistry: " + JSON.stringify(projectInfo));
 
-    const REMOTE_MODE = (process.env.REMOTE_MODE) || false;
     logger.logTrace("Running with --remote=" + REMOTE_MODE);
 
     let args = [projectLocation, LOCAL_WORKSPACE, operation.projectInfo.projectID, command,

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -56,7 +56,7 @@ const containerInfoMap = new Map();
 
 export const containerInfoForceRefreshMap = new Map();
 
-export const LOCAL_WORKSPACE = REMOTE_MODE ? "/codewind-workspace" : process.env.NODE_ENV === "test" ? process.env.HOST_WORKSPACE_DIRECTORY : (process.argv[2] ? process.argv[2] : process.env.HOST_WORKSPACE_DIRECTORY);
+export const LOCAL_WORKSPACE = REMOTE_MODE === "true" ? "/codewind-workspace" : (process.env.NODE_ENV === "test" ? process.env.HOST_WORKSPACE_DIRECTORY : (process.argv[2] ? process.argv[2] : process.env.HOST_WORKSPACE_DIRECTORY));
 
 const projectList: Array<string> = [];
 


### PR DESCRIPTION
### Description

With hybrid change landed, appsody and probably other projects rely on `LOCAL_WORKSPACE` in here https://github.com/eclipse/codewind/blob/abe12b535cd345a5e677af066d0e38dd7d3ca754/src/pfe/file-watcher/server/src/projects/projectUtil.ts#L58 so for non-remote cases we should have safeguard to the default value.

Related to https://github.com/eclipse/codewind/issues/683

```
[16/10/19 15:43:55 knpy] [INFO] Emitting event 
 message: projectCreation
 data: {
  "operationId": "8d86cb6c98b95e6273ddda7b131032e2",
  "projectID": "b0890320-f02b-11e9-be7a-397ed8cd80da",
  "isHttps": false,
  "status": "success",
  "host": "172.19.0.4",
  "ports": {
    "exposedPort": "32784",
    "internalPort": "8080"
  },
  "containerId": "d739527d9d4e8b1b9bbaf3662de50b217c59bff16c3bac46001e3e94b37961c0",
  "logs": {
    "build": {
      "origin": "workspace",
      "files": []
    },
    "app": {
      "origin": "workspace",
      "files": [
        "/codewind-workspace/.logs/knpy-b0890320-f02b-11e9-be7a-397ed8cd80da/appsody.log"
      ]
    }
  }
}
[16/10/19 15:43:55 knpy] [TRACE] {"/file-watcher/fwdata/projects/b0890320-f02b-11e9-be7a-397ed8cd80da/b0890320-f02b-11e9-be7a-397ed8cd80da.json":"{\"projectID\":\"b0890320-f02b-11e9-be7a-397ed8cd80da\",\"projectType\":\"appsodyExtension\",\"location\":\"/codewind-workspace/knpy\",\"autoBuildEnabled\":true,\"startMode\":\"run\",\"appPorts\":[\"8080\"],\"extensionID\":\"/codewind-workspace/.extensions/codewind-appsody-extension\",\"language\":\"python\",\"isHttps\":false,\"buildRequest\":false,\"sentProjectInfo\":true}"}
[16/10/19 15:43:56 FileWatcher.js] [DEBUG] Portal's event listener: projectStatusChanged
[16/10/19 15:43:56 FileWatcher.js] [DEBUG] Portal's event listener: {"projectID":"b0890320-f02b-11e9-be7a-397ed8cd80da","appStatus":"started","detailedAppStatus":" "}
[16/10/19 15:43:56 FileWatcher.js] [DEBUG] projectStatusChanged: started (project b0890320-f02b-11e9-be7a-397ed8cd80da)
[16/10/19 15:43:56 FileWatcher.js] [TRACE] projectStatusChanged: started (project: {
  "projectID": "b0890320-f02b-11e9-be7a-397ed8cd80da",
  "appStatus": "started",
  "detailedAppStatus": " "
})
[16/10/19 15:43:56 ProjectList.js] [INFO] Project knpy started (project ID: b0890320-f02b-11e9-be7a-397ed8cd80da)
[16/10/19 15:43:56 knpy] [INFO] pingInTransitApplications: Application state for project b0890320-f02b-11e9-be7a-397ed8cd80da has changed from starting to started
[16/10/19 15:43:56 knpy] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "b0890320-f02b-11e9-be7a-397ed8cd80da",
  "appStatus": "started",
  "detailedAppStatus": " "
}
```
![Screen Shot 2019-10-16 at 11 44 26 AM](https://user-images.githubusercontent.com/15173354/66935699-741e6900-f00a-11e9-8431-1d7b595bfdac.png)


Signed-off-by: ssh24 <sakib@ibm.com>