### PR TITLE
Stop streaming logs on close project

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -479,6 +479,9 @@ module.exports = class User {
   async closeProject(project) {
     let projectPath = path.join(this.directories.workspace, project.directory);
     let projectID = project.projectID;
+    // Stop streaming the logs files.
+    project.stopStreamingAllLogs();
+    
     if (await fs.pathExists(projectPath)) {
       try {
         await this.fw.closeProject(project);


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Added call to stop streaming logs when closing projects.