### PR TITLE
Backport to 0.5.0 - Stop streaming logs on close project

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -478,6 +478,9 @@ module.exports = class User {
   async closeProject(project) {
     let projectPath = path.join(this.directories.workspace, project.directory);
     let projectID = project.projectID;
+    // Stop streaming the logs files.
+    project.stopStreamingAllLogs();
+    
     if (await fs.pathExists(projectPath)) {
       try {
         await this.fw.closeProject(project);


### PR DESCRIPTION
### Description
Backport of https://github.com/eclipse/codewind/pull/696

It still needs to be tested as mentioned in https://github.com/eclipse/codewind/pull/696

Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>