### PR TITLE
[0.5.0]fix issue#688

### DIFF
--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/DockerUtils.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/DockerUtils.java
@@ -31,12 +31,13 @@ public class DockerUtils {
 		boolean isPresent = false;
 
 		String imageCommand = context.getImageCommand();
+		String imagesFormatString = context.getImagesFormatString();
 		
-		ProcessRunner pr = TaskUtils.runCmd(imageCommand + " images --format \"{{.Repository}}\"", context, false);
+		ProcessRunner pr = TaskUtils.runCmd(imageCommand + " images --format " + imagesFormatString, context, false);
 
 		Thread.sleep(1000);
 		for (String str : pr.getReceived().split("\\r?\\n")) {
-			if (str != null && str.equals(context.getImageName())) {
+			if (str != null && str.contains(context.getImageName())) {
 				isPresent = true;
 				Logger.info("----");
 				Logger.info("Container Image already present: " + str);

--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
@@ -58,6 +58,8 @@ public class IDCContext {
 	private final boolean isWin;
 
 	private final String imageCommand;
+
+	private final String imagesFormatString;
 	
 	public IDCContext(String rootPassword, String localWorkspaceOrigin, String containerName, String projectID, String logName, String deploymentRegistry, String startMode, String debugPort) throws IOException {
 
@@ -149,6 +151,14 @@ public class IDCContext {
 		else {
 			this.imageCommand = "docker";
 		}
+
+		if (this.isK8s) {
+			this.imagesFormatString = "\"{{.Name}}\"";
+		}
+		else {
+			this.imagesFormatString = "\"{{.Repository}}\"";
+		}
+
 	}
 
 	public DBMap getAppDb() {
@@ -358,5 +368,9 @@ public class IDCContext {
 
 	public String getImageCommand() {
 		return this.imageCommand;
+	}
+
+	public String getImagesFormatString() {
+		return this.imagesFormatString;
 	}
 }

--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
@@ -152,6 +152,8 @@ public class IDCContext {
 			this.imageCommand = "docker";
 		}
 
+		// for buildah on K8, the format is Name
+		// for docker on local, the format is Repository
 		if (this.isK8s) {
 			this.imagesFormatString = "\"{{.Name}}\"";
 		}


### PR DESCRIPTION
Fix the issue caused by buildah on K8, since the images listed format has changed from `{{.Repository}}` to `{{.Name}}`

And also the project image name listed by buildah is `localhost/<projectImageName>`, so when we check the existence of the project by checking the image name , we should use `contains` instead of `equals`