### PR TITLE
[master]fix issue#688

### DIFF
--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/DockerUtils.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/DockerUtils.java
@@ -31,12 +31,13 @@ public class DockerUtils {
 		boolean isPresent = false;
 
 		String imageCommand = context.getImageCommand();
+		String imagesFormatString = context.getImagesFormatString();
 		
-		ProcessRunner pr = TaskUtils.runCmd(imageCommand + " images --format \"{{.Repository}}\"", context, false);
+		ProcessRunner pr = TaskUtils.runCmd(imageCommand + " images --format " + imagesFormatString, context, false);
 
 		Thread.sleep(1000);
 		for (String str : pr.getReceived().split("\\r?\\n")) {
-			if (str != null && str.equals(context.getImageName())) {
+			if (str != null && str.contains(context.getImageName())) {
 				isPresent = true;
 				Logger.info("----");
 				Logger.info("Container Image already present: " + str);

--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
@@ -152,6 +152,8 @@ public class IDCContext {
 			this.imageCommand = "docker";
 		}
 
+		// for buildah on K8, the format is Name
+		// for docker on local, the format is Repository
 		if (this.isK8s) {
 			this.imagesFormatString = "\"{{.Name}}\"";
 		}

--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDCContext.java
@@ -35,8 +35,6 @@ public class IDCContext {
 
 	private final String rootPassword;
 
-	private String turbineSync;
-
 	private final String localWorkspaceOrigin;
 
 	private final String deploymentRegistry;
@@ -60,9 +58,10 @@ public class IDCContext {
 	private final boolean isWin;
 
 	private final String imageCommand;
+
+	private final String imagesFormatString;
 	
-	public IDCContext(String rootPassword, String localWorkspaceOrigin, String containerName, String projectID, String logName, String deploymentRegistry, 
-	String startMode, String debugPort, String turbineSync) throws IOException {
+	public IDCContext(String rootPassword, String localWorkspaceOrigin, String containerName, String projectID, String logName, String deploymentRegistry, String startMode, String debugPort) throws IOException {
 
 		this.rootPassword = rootPassword;
 
@@ -123,11 +122,6 @@ public class IDCContext {
 			appDb.put(Constants.DB_DEBUG_PORT, this.debugPort);
 		}
 
-		this.turbineSync = turbineSync;
-		if (this.turbineSync != null) {
-			appDb.put(Constants.DB_TURBINE_SYNC, this.turbineSync);
-		}
-
 		this.artifactsDirectory = getArtifactsFromInstallDir();
 
 		this.appDirectory = new File(System.getProperty("user.dir"));
@@ -157,6 +151,14 @@ public class IDCContext {
 		else {
 			this.imageCommand = "docker";
 		}
+
+		if (this.isK8s) {
+			this.imagesFormatString = "\"{{.Name}}\"";
+		}
+		else {
+			this.imagesFormatString = "\"{{.Repository}}\"";
+		}
+
 	}
 
 	public DBMap getAppDb() {
@@ -181,14 +183,6 @@ public class IDCContext {
 
 	public DBMap getGlobalDb() {
 		return globalDb;
-	}
-
-	public String getTurbineSync() {
-		if (appDb.get(Constants.DB_TURBINE_SYNC) != null) {
-			return appDb.get(Constants.DB_TURBINE_SYNC);
-		} else {
-			return "false";
-		}
 	}
 
 	public String getContainerName() {
@@ -374,5 +368,9 @@ public class IDCContext {
 
 	public String getImageCommand() {
 		return this.imageCommand;
+	}
+
+	public String getImagesFormatString() {
+		return this.imagesFormatString;
 	}
 }


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

porting over changes from https://github.com/eclipse/codewind/pull/706


Fix the issue caused by buildah on K8, since the images listed format has changed from {{.Repository}} to {{.Name}}

And also the project image name listed by buildah is localhost/<projectImageName>, so when we check the existence of the project by checking the image name , we should use contains instead of equals