### PR TITLE
Skip registry test until we have projects to watch

### DIFF
--- a/test/src/API/registry.test.js
+++ b/test/src/API/registry.test.js
@@ -53,14 +53,16 @@ async function putWatchStatus(projectID, projectWatchStateId) {
     await reqService.makeReqAndAwaitSocketMsg(req, 200, expectedSocketMsg);
 }
 
-describe('Deployment Registry route tests', function() {
+// Skipped because we have no projects to watch, resulting in an error in the before block
+// (Due to feeding a `projectID` of `undefined` to line 94: `await putWatchStatus(projectID, projectWatchStateId);`)
+describe.skip('Deployment Registry route tests', function() {
     const workspace_settings_file = '/codewind-workspace/.config/settings.json';
 
     let projectID;
     let projectWatchStateId;
     const workspace_settings_file_content = { deploymentRegistry: 'someregistry' };
     const workspace_settings_file_no_registry_content = { deploymentRegistryGarbage: 'garbagevalue' };
-    
+
     let restoreConfig = false;
 
     before('Create a backup of any existing ${workspace_location}/.config/settings.json file and set the watch status', async function() {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Having no projects to watch means we error in the `before` block, because we feed a `projectID` of `undefined` to line 94: `await putWatchStatus(projectID, projectWatchStateId);`

Skipping the whole test for now