### PR TITLE
Move LICENSE & NOTICE.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,10 @@ package-lock.json
 src/performance/webclient/build/
 test/test-results.xml
 test/tmp.json
-src/performance/LICENSE.md
+src/performance/LICENSE
 src/performance/NOTICE.md
-src/pfe/portal/LICENSE.md
+src/pfe/portal/LICENSE
 src/pfe/portal/NOTICE.md
 src/initialize/NOTICE.md
-src/initialize/LICENSE/LICENSE.md
+src/initialize/LICENSE/LICENSE
 src/initialize/LICENSE/NOTICE.md

--- a/src/performance/Dockerfile_x86_64
+++ b/src/performance/Dockerfile_x86_64
@@ -22,29 +22,29 @@ COPY . .
 
 
 ##############################################
-# Build the performance dashboard (Codewind) 
+# Build the performance dashboard (Codewind)
 ##############################################
 
 WORKDIR /usr/src/app/dashboard
 
-# Install nodeJS dependancies
+# Install nodeJS dependencies
 RUN npm install
 
-# Build React webapp 
+# Build React webapp
 RUN npm run build
 
 
 ############################################################
-# We now have a built ui, begin setup of a new runtime image 
+# We now have a built ui, begin setup of a new runtime image
 ############################################################
 
 FROM node:10-alpine
 
-# Copy our license files into the new image
-COPY LICENSE NOTICE.md /
-
 # Create app directory
 WORKDIR /usr/src/app
+
+# Copy our license files into the new image
+COPY LICENSE NOTICE.md ./
 
 # Install performance server
 COPY package*.json server.js ./

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -146,8 +146,8 @@ COPY --from=codewind-pfe-portal /portal /portal
 
 # Copy the license files to the root directory
 # to satisfy requirement from legal
-COPY /portal/LICENSE /LICENSE
-COPY /portal/NOTICE.md /LICENSE
+COPY /portal/LICENSE /
+COPY /portal/NOTICE.md /
 
 WORKDIR /portal
 ARG NODE_ENV


### PR DESCRIPTION
## Problem

Command `docker exec -it codewind-performance cat LICENSE` does not display license issue :  https://github.com/eclipse/codewind/issues/737

## Solution

1. License file moved into container WORKDIR. 
2. Added LICENSE file to .gitignore list for each component /src/ subdirectory as we only need the ROOT version
3. Fixed a problem in the PFE container where running `docker exec -it codewind-pfe cat LICENSE` would return the Notice.md file which was overwriting LICENSE during build.


## Validation: 

### Performance : 
```
➜  ~ docker exec -it codewind-performance more LICENSE
Eclipse Public License - v 2.0

    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
```
```
➜  ~ docker exec -it codewind-performance more NOTICE.md
# Notices for Codewind

This content is produced and maintained by the Eclipse Codewind project.

 * Project home: https://www.eclipse.org/codewind/
```

### PFE : 

```
➜  ~ docker exec -it codewind-pfe more LICENSE
Eclipse Public License - v 2.0

    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
```

```
➜  ~  docker exec -it codewind-pfe more NOTICE.md  
# Notices for Codewind

This content is produced and maintained by the Eclipse Codewind project.

 * Project home: https://www.eclipse.org/codewind/

## Trademarks
```






Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>