### PR TITLE
fix locOnDisk variable

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -62,6 +62,10 @@ module.exports = class Project {
     if (args.gitURL) this.gitURL = args.gitURL;
     if (args.validate) this.validate = args.validate;
     if (args.extension) this.extension = args.extension;
+
+    // locOnDisk is used by the UI and needs to match what it sees.
+    this.locOnDisk = `${global.codewind.CODEWIND_WORKSPACE}${this.directory}`;
+
     if (args.locOnDisk) this.locOnDisk = args.locOnDisk;
     
     // Project status information

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -65,8 +65,6 @@ module.exports = class Project {
 
     // locOnDisk is used by the UI and needs to match what it sees.
     this.locOnDisk = `${global.codewind.CODEWIND_WORKSPACE}${this.directory}`;
-
-    if (args.locOnDisk) this.locOnDisk = args.locOnDisk;
     
     // Project status information
     this.host = args.host || '';


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

The locOnDisk variable had been changed ready for an upcoming merge but it shouldn't have been.  Reverting back to the old setting.  this should fix https://github.com/eclipse/codewind/issues/734