### PR TITLE
Add back dev mode to PFE

### DIFF
--- a/src/pfe/portal/package.json
+++ b/src/pfe/portal/package.json
@@ -5,8 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "./npm-start.sh",
-    "prod": "node --inspect=0.0.0.0:9777 server.js",
-    "dev": "node --inspect=0.0.0.0:9777 server.js",
+    "prod": "node server.js",
+    "dev": "nodemon server.js",
     "coverage": "nyc node server.js",
     "local": "node server.js --local",
     "eslint": "eslint ."


### PR DESCRIPTION
### Description

This PR adds back the dev mode option to PFE which was taken out with the hybrid changes. https://github.com/eclipse/codewind/issues/695

Signed-off-by: ssh24 <sakib@ibm.com>