### PR TITLE
Enable Appsody projects to be created in PFE under a mounted-workspace directory

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${WORKSPACE_VOLUME}:/codewind-workspace
+      - ${WORKSPACE_DIRECTORY}:/mounted-workspace
     networks:
       - network
 

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -152,7 +152,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
     // create log storing directory for the project
     logger.logInfo("Creating project logs directory");
     const dirName = await logHelper.getLogDir(projectID, projectName);
-    await logHelper.createLogDir(dirName, constants.projectConstants.projectsLogDir);
+    const logDirectory = await logHelper.createLogDir(dirName, constants.projectConstants.projectsLogDir);
 
     let projInfo: ProjectInfo;
     try {
@@ -356,8 +356,6 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
     logger.logProjectInfo("operationId: " + operation.operationId, projectID, projectName);
 
     // set default docker build log for initial project creation
-    const projectLogDir = await logHelper.getLogDir(projectID, projectName);
-    const logDirectory = path.resolve(projectLocation + "/../.logs/" + projectLogDir);
     const logFilePath = path.join(logDirectory, logHelper.buildLogs.dockerBuild + logHelper.logExtension);
 
 

--- a/src/pfe/file-watcher/server/src/projects/logHelper.ts
+++ b/src/pfe/file-watcher/server/src/projects/logHelper.ts
@@ -153,8 +153,8 @@ export async function getLogFilesFromContainer(projectID: string, containerName:
  *
  * @returns Promise<void>
  */
-export async function createLogDir(dirName: string, logPath: string): Promise<void> {
-    if (!dirName || !logPath) return;
+export async function createLogDir(dirName: string, logPath: string): Promise<string> {
+    if (!dirName || !logPath) return undefined;
 
     const folderpath = path.join(logPath, dirName);
 
@@ -164,7 +164,7 @@ export async function createLogDir(dirName: string, logPath: string): Promise<vo
     } else {
         logger.logInfo("Log directory found at: " + folderpath + "\nSkipping directory creation.");
     }
-    return;
+    return folderpath;
 }
 
 /**

--- a/src/pfe/file-watcher/server/test/unit-test/tests/logHelper.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/logHelper.module.test.ts
@@ -131,7 +131,7 @@ export function logHelperTestModule(): void {
             expect(fs.statSync(dirPath)).to.exist;
 
             const createReturn = await logHelper.createLogDir(dirName, process.cwd());
-            expect(createReturn).to.be.undefined;
+            expect(createReturn).to.equal(path.join(process.cwd(), dirName));
 
             try {
                 fs.rmdirSync(dirPath);

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -189,7 +189,8 @@ module.exports = class Project {
   projectPath(inPortal) {
     // this.workspace will include the user directory if we are in multi-user.
     // Codewind workspace is hardcoded in filewatcherDeployment.js
-    return (inPortal ? this.workspace + this.directory :  `/codewind-workspace/${this.directory}` );
+    // return (inPortal ? this.workspace + this.directory :  `/codewind-workspace/${this.directory}` );
+    return join(this.workspace, this.directory);
   }
 
   /**

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -186,7 +186,7 @@ module.exports = class Project {
    * @arg inPortal true if we want the location in the portal container (with username)
    * @return the path to the project directory.
    */
-  projectPath(inPortal) {
+  projectPath(_) {
     // this.workspace will include the user directory if we are in multi-user.
     // Codewind workspace is hardcoded in filewatcherDeployment.js
     // return (inPortal ? this.workspace + this.directory :  `/codewind-workspace/${this.directory}` );

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -175,10 +175,10 @@ module.exports = class User {
           const projFile = await fs.readJson(file);
           // should now have a project name
           const projName = projFile.name;
-          let settingsFilePath = path.join(this.directories.workspace, projName, '.cw-settings');
+          let settingsFilePath = path.join(projFile.workspace, projName, '.cw-settings');
           const settFileExists = await fs.pathExists(settingsFilePath);
           const settFile = settFileExists ? await fs.readJson(settingsFilePath) : {};
-          let project = new Project({ ...projFile, ...settFile }, this.directories.workspace);
+          let project = new Project({ ...projFile, ...settFile }, projFile.workspace);
           this.projectList.addProject(project);
         } catch (err) {
           // Corrupt project inf file
@@ -307,7 +307,7 @@ module.exports = class User {
    * @param projectJson, the project to add to the projectList
    */
   async createProject(projectJson) {
-    let project = new Project(projectJson, this.directories.workspace);
+    let project = new Project(projectJson, projectJson.workspace);
     this.projectList.addProject(project);
     // If checkIfMetricsAvailable errors, it should not break project creation
     // try {

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -238,7 +238,8 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
           
           let projectRoot = getProjectSourceRoot(project);
           // need to delete from the build container as well
-          if (!global.codewind.RUNNING_IN_K8S && project.projectType != 'docker') {
+          if (!global.codewind.RUNNING_IN_K8S && project.projectType != 'docker' &&
+            (!project.extension || !project.extension.config.needsMount)) {
             await Promise.all(
               filesToDelete.map(file => cwUtils.deleteFile(project, projectRoot, file))
             )

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -93,7 +93,7 @@ async function bindStart(req, res) {
       let extension = user.extensionList.getExtensionForProjectType(projectType);
       if (extension) {
         projectDetails.extension = extension;
-        if (extension.config.needsMount)
+        if (extension.config.needsMount && !global.codewind.RUNNING_IN_K8S)
           projectDetails.workspace = global.codewind.MOUNTED_WORKSPACE;
       }
     }

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -134,6 +134,8 @@ async function main() {
     CODEWIND_WORKSPACE: '/codewind-workspace/',
     CODEWIND_TEMP_WORKSPACE: '/cw-temp/',
     REMOTE_MODE: (process.env.REMOTE_MODE == 'true') || false,
+    // temporary mounted workspace directory retained for projects that still require it
+    MOUNTED_WORKSPACE: '/mounted-workspace'
   };
 
   // find if running in kubernetes and build up a whitelist of allowed origins


### PR DESCRIPTION
Part of #717 

- This PR introduces back a mounted workspace area, now under `/mounted-workspace` in PFE
- PFE syncs/creates regular projects under `/codewind-workspace` (not a mount point) as before
- Appsody extension will specify a `needsMount` flag (https://github.com/eclipse/codewind-appsody-extension/pull/47), this makes PFE syncs/creates the project under '/mounted-workspace`

Related CLI PR https://github.com/eclipse/codewind-installer/pull/159