### PR TITLE
Increase payload size limit

### DIFF
--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -278,7 +278,7 @@ async function main() {
       }
     });
 
-    app.use(bodyParser.json());
+    app.use(bodyParser.json({limit: '1mb'}));
     app.use(bodyParser.urlencoded({
       extended: false
     }));


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

We have seen failures in the uploading of files due to the payload limit in our middleware so I'm increasing the payload limit to 1mb