### PR TITLE
Prevent app state from changing from unknown to stopped on first time creation

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -797,7 +797,6 @@ export async function getContainerName(projectInfo: ProjectInfo): Promise<string
     const projectLocation: string = projectInfo.location;
 
     const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-    logger.logInfo("typeof projectHandler.getContainerName is " + typeof projectHandler.getContainerName);
     if (projectHandler && projectHandler.hasOwnProperty("getContainerName") && typeof projectHandler.getContainerName === "function") {
         return projectHandler.getContainerName(projectID, projectLocation);
     }


### PR DESCRIPTION

Signed-off-by: Stephanie <stephanie.cao@ibm.com>
For issue https://github.com/eclipse/codewind/issues/831
provent app state from changing from unknown to stopped on first time creation

Also removes an unnecessary debug log message. 


![image](https://user-images.githubusercontent.com/22285490/67515182-2a69fa00-f66c-11e9-8002-e449e0467a4d.png)
