### PR TITLE
Always add the remote route

### DIFF
--- a/src/pfe/portal/routes/projects/index.js
+++ b/src/pfe/portal/routes/projects/index.js
@@ -27,12 +27,8 @@ const router = express.Router();
   require('./internal.route'),
   require('./binding.route'),
   require('./fileChanges.route'),
+  require('./remoteBind.route')
 ]
   .forEach((subRouter) => router.use(subRouter));
-
-// Enable remote bind in remote mode only.
-if (global.codewind.REMOTE_MODE) {
-  router.use(require('./remoteBind.route'));
-}
 
 module.exports = router;

--- a/src/pfe/portal/routes/projects/index.js
+++ b/src/pfe/portal/routes/projects/index.js
@@ -27,7 +27,7 @@ const router = express.Router();
   require('./internal.route'),
   require('./binding.route'),
   require('./fileChanges.route'),
-  require('./remoteBind.route')
+  require('./remoteBind.route'),
 ]
   .forEach((subRouter) => router.use(subRouter));
 


### PR DESCRIPTION
The new remote route was only being added when the REMOTE flag was set which worked when using run.sh but not if you use the cwctl to start the images. Thanks @jopit for tracking down the problem.