### PR TITLE
Change default host ip to 127.0.0.1 for codewind_network

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,3 +37,5 @@ services:
 
 networks:
   network:
+    driver_opts:
+          com.docker.network.bridge.host_binding_ipv4: "127.0.0.1"


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

For issue https://github.com/eclipse/codewind/issues/611
Change the default container host ip from `0.0.0.0` to `127.0.0.1` for codewind_network

Tested the port binding is fixed, plus we do not want the app to be exposed externally. 

```
CONTAINER ID        IMAGE                                                     COMMAND                  CREATED             STATUS              PORTS                                                  NAMES
e2a0a29dcb2b        cw-nodetestproject-0ad407f0-f9b7-11e9-819c-e9a52ed790d8   "docker-entrypoint.s…"   18 seconds ago      Up 17 seconds       127.0.0.1:32769->3000/tcp, 127.0.0.1:32768->9229/tcp   cw-nodetestproject-0ad407f0-f9b7-11e9-819c-e9a52ed790d8
```