### PR TITLE
remove codewind project containers and networks in the beginning of ./run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,6 +53,8 @@ git config -f $GIT_CONFIG --add user.name "`git config --get user.name || echo '
 git config -f $GIT_CONFIG --add user.email "`git config --get user.email || echo 'codewind.user@localhost'`"
 
 DIR=`pwd`
+# Shutdown and cleanup.
+./stop.sh;
 
 # Setting the NOBUILD env var to true uses the current images.
 # Used in travis when we build and push the images with script/build.sh

--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ git config -f $GIT_CONFIG --add user.name "`git config --get user.name || echo '
 git config -f $GIT_CONFIG --add user.email "`git config --get user.email || echo 'codewind.user@localhost'`"
 
 DIR=`pwd`
-# Shutdown and cleanup.
+# Shutdown and cleanup to ensure the docker network gets recreated before attempting start
 ./stop.sh;
 
 # Setting the NOBUILD env var to true uses the current images.


### PR DESCRIPTION
For issue#https://github.com/eclipse/codewind/issues/611

If the `codewind_network` has already existed, but with a different `com.docker.network.bridge.host_binding_ipv4`.  It needs to be recreated to apply the change.

All  project containers need to be stopped before removing the `codewind_network`. 

Run `./stop.sh` without any options/flags in the beginning of ./run.sh to stop all running codewind containers and remove `codewind_network`