### PR TITLE
Send socket msg when state changes to enabled on creation

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -369,6 +369,7 @@ async function bindEnd(req, res) {
       state: Project.STATES.open,
       startMode: 'run' // always use 'run' mode for new or recently re-opened projects
     }
+    user.uiSocket.emit('projectStatusChanged', updatedProject);
     await user.projectList.updateProject(updatedProject);
     await user.buildAndRunProject(project);
     res.status(200).send(project);


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

When we create a project now, the state is set to closed until the files are ready to be built. We then set the state to open and request build and I have added a socket msg to update the ui with the state changed.
