### PR TITLE
Remove path check to fix disable project

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -462,32 +462,29 @@ module.exports = class User {
    * @param project, the project to close
    */
   async closeProject(project) {
-    let projectPath = path.join(this.directories.workspace, project.directory);
     let projectID = project.projectID;
     // Stop streaming the logs files.
     project.stopStreamingAllLogs();
     
-    if (await fs.pathExists(projectPath)) {
-      try {
-        await this.fw.closeProject(project);
-      } catch (err) {
-        // IF FW not up we can simply update the state and emit event
-        if (err instanceof FilewatcherError && err.code == 'CONNECTION_FAILED') {
-          let projectUpdate = {
-            projectID: projectID,
-            ports: '',
-            buildStatus: 'unknown',
-            appStatus: 'unknown',
-            state: Project.STATES.closed
-          }
-          // Set the container key to '' as the container has stopped.
-          const containerKey = (global.codewind.RUNNING_IN_K8S ? 'podName' : 'containerId');
-          projectUpdate[containerKey] = '';
-          let updatedProject = await this.user.projectList.updateProject(projectUpdate);
-          this.user.uiSocket.emit('projectClosed', {...updatedProject, status: 'success'});
-          log.debug('project ' + projectID + ' successfully closed');
-        } else throw err;
-      }
+    try {
+      await this.fw.closeProject(project);
+    } catch (err) {
+      // IF FW not up we can simply update the state and emit event
+      if (err instanceof FilewatcherError && err.code == 'CONNECTION_FAILED') {
+        let projectUpdate = {
+          projectID: projectID,
+          ports: '',
+          buildStatus: 'unknown',
+          appStatus: 'unknown',
+          state: Project.STATES.closed
+        }
+        // Set the container key to '' as the container has stopped.
+        const containerKey = (global.codewind.RUNNING_IN_K8S ? 'podName' : 'containerId');
+        projectUpdate[containerKey] = '';
+        let updatedProject = await this.user.projectList.updateProject(projectUpdate);
+        this.user.uiSocket.emit('projectClosed', {...updatedProject, status: 'success'});
+        log.debug('project ' + projectID + ' successfully closed');
+      } else throw err;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

We don't actually need the check for projectPath before we attempt to close a project so removing that check.