### PR TITLE
Builds should fail if Turbine unit tests fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
                             echo "+++   TURBINE UNIT TESTS COMPLETED SUCCESSFULLY   +++";
                         else
                             echo "+++   TURBINE UNIT TESTS FAILED   +++";
-                            exit 12;
+                            exit 1;
                         fi
                         '''
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,12 @@ pipeline {
                         # Run the unit test suite
                         echo "Started running Turbine Unit Test Suite"
                         npm run unit:test
+                        if [ $? -eq 0 ]; then
+                            echo "+++   TURBINE UNIT TESTS COMPLETED SUCCESSFULLY   +++";
+                        else
+                            echo "+++   TURBINE UNIT TESTS FAILED   +++";
+                            exit 12;
+                        fi
                         '''
                     }
                 }

--- a/src/pfe/file-watcher/server/package.json
+++ b/src/pfe/file-watcher/server/package.json
@@ -14,7 +14,7 @@
     "test": "npm run unit:test && npm run functional:test",
     "unit:setup": "./test/scripts/unit_setup.sh",
     "unit:cleanup": "./test/scripts/unit_cleanup.sh",
-    "unit:test": "npm run unit:setup ; NODE_ENV=test HIDE_PFE_LOG=y CW_LOCALES_DIR=$(pwd)/src/utils/locales/ CW_WORKSPACE=$(pwd)/test/resources CW_PROJECTDATA_DIR=$(pwd)/test/resources/ nyc mocha test/unit-test/unit.test.ts ; npm run unit:cleanup",
+    "unit:test": "npm run unit:setup && NODE_ENV=test HIDE_PFE_LOG=y CW_LOCALES_DIR=$(pwd)/src/utils/locales/ CW_WORKSPACE=$(pwd)/test/resources CW_PROJECTDATA_DIR=$(pwd)/test/resources/ nyc mocha test/unit-test/unit.test.ts && npm run unit:cleanup",
     "unit:test:xml": "npm run unit:setup ; NODE_ENV=test HIDE_PFE_LOG=y CW_LOCALES_DIR=$(pwd)/src/utils/locales/  CW_WORKSPACE=$(pwd)/test/resources CW_PROJECTDATA_DIR=$(pwd)/test/resources/ nyc mocha test/unit-test/unit.test.ts --colors --reporter mocha-jenkins-reporter ; npm run unit:cleanup",
     "functional:test": "NODE_ENV=test nyc mocha test/functional-test/functional.test.ts",
     "functional:test:xml": "NODE_ENV=test nyc mocha test/functional-test/functional.test.ts --colors --reporter mocha-jenkins-reporter",

--- a/src/pfe/file-watcher/server/package.json
+++ b/src/pfe/file-watcher/server/package.json
@@ -15,7 +15,7 @@
     "unit:setup": "./test/scripts/unit_setup.sh",
     "unit:cleanup": "./test/scripts/unit_cleanup.sh",
     "unit:test": "npm run unit:setup && NODE_ENV=test HIDE_PFE_LOG=y CW_LOCALES_DIR=$(pwd)/src/utils/locales/ CW_WORKSPACE=$(pwd)/test/resources CW_PROJECTDATA_DIR=$(pwd)/test/resources/ nyc mocha test/unit-test/unit.test.ts && npm run unit:cleanup",
-    "unit:test:xml": "npm run unit:setup ; NODE_ENV=test HIDE_PFE_LOG=y CW_LOCALES_DIR=$(pwd)/src/utils/locales/  CW_WORKSPACE=$(pwd)/test/resources CW_PROJECTDATA_DIR=$(pwd)/test/resources/ nyc mocha test/unit-test/unit.test.ts --colors --reporter mocha-jenkins-reporter ; npm run unit:cleanup",
+    "unit:test:xml": "npm run unit:setup && NODE_ENV=test HIDE_PFE_LOG=y CW_LOCALES_DIR=$(pwd)/src/utils/locales/  CW_WORKSPACE=$(pwd)/test/resources CW_PROJECTDATA_DIR=$(pwd)/test/resources/ nyc mocha test/unit-test/unit.test.ts --colors --reporter mocha-jenkins-reporter && npm run unit:cleanup",
     "functional:test": "NODE_ENV=test nyc mocha test/functional-test/functional.test.ts",
     "functional:test:xml": "NODE_ENV=test nyc mocha test/functional-test/functional.test.ts --colors --reporter mocha-jenkins-reporter",
     "coverage": "nyc report",


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/916
The Jenkins PR builds should fail if there's a unit test failure.

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>