### PR TITLE
Move creation of temporary directory

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -68,6 +68,7 @@ module.exports = class User {
         logs: path.join(this.workspace, '/.logs/'),
         config: path.join(this.workspace, '/.config/'),
         extensions: path.join(this.workspace, '/.extensions/'),
+        temp: path.join(this.workspace, global.codewind.CODEWIND_TEMP_WORKSPACE),
       }
       await this.createDirectories();
       this.projectList = new ProjectList();

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -114,7 +114,6 @@ async function bindStart(req, res) {
 
   try {
     let tempDirName = path.join(global.codewind.CODEWIND_WORKSPACE, global.codewind.CODEWIND_TEMP_WORKSPACE);
-    await fs.mkdir(tempDirName);
     let dirName = path.join(newProject.workspace, newProject.name);
     await fs.mkdir(dirName);
     let tempProjPath = path.join(tempDirName, newProject.name);


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

The temporary directory (cw-temp) was being created as part of the bind so failed on the second project. I have moved the creation to the initialise function where we create other directories.