### PR TITLE
Fix streaming of separate log files

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -564,6 +564,75 @@ paths:
         500:
           description: if error occurred
 
+  /api/v1/projects/{id}/logs/{type}/{name}:
+    post:
+      summary: Start streaming one log for a given project
+      description: >
+        This requests that the specified log for a project starts streaming.
+        Logs are sent over socket.io via the 'log-update' event. When a log is enabled
+        for streaming its current content is sent in one or more 'log-update' events and
+        then any further updates are sent via further 'log-update' events as they occur.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+        - in: path
+          name: type
+          schema:
+            type: string
+            enum: ['app', 'build']
+          required: true
+          description: type of log
+        - in: path
+          name: name
+          schema:
+            type: string
+          required: true
+          description: name of log
+      responses:
+        200:
+          description: if the log stream was successfully enabled
+        404:
+          description: if the project or the specified log were not found
+        500:
+          description: if an error occurred
+    delete:
+      summary: Stop streaming one log for a given project
+      description: >
+        This requests that streaming stops for the specified log.
+        If the log stream is re-enabled later then the log will be sent from the beginning.
+        again.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+        - in: path
+          name: type
+          schema:
+            type: string
+            enum: ['app', 'build']
+          required: true
+          description: type of log
+        - in: path
+          name: name
+          schema:
+            type: string
+          required: true
+          description: name of log
+      responses:
+        200:
+          description: if the log stream was successfully stopped
+        404:
+          description: if the project with id was not found
+        500:
+          description: if an error occurred        
+
   /api/v1/projects/{id}/metrics:
     get:
       summary: Get available metrics types with their associated endpoints

--- a/src/pfe/portal/routes/projects/logStream.route.js
+++ b/src/pfe/portal/routes/projects/logStream.route.js
@@ -55,7 +55,7 @@ async function startStreamingAll(req, res, startStreams) {
             }
             logTypes[logType].push(logObject);
             let logFile = file;
-            let logOrigin = logs[logType].origin;
+            let logOrigin = logEntry.origin;
             if (startStreams) {
               project.startStreamingLog(user.uiSocket, logType, logOrigin, logName, logFile);
             }


### PR DESCRIPTION
https://github.com/eclipse/codewind/pull/917 removed the APIs for streaming individual log files as it was believed that these weren't used by the IDE plugins, rather than fixing them for the new format provided by turbine. 

Erin then realised that she was using them so this PR puts the APIs back in with minor changes to handle the new format.