### PR TITLE
Do not emit event on bind start

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -121,8 +121,6 @@ async function bindStart(req, res) {
 
     newProject.workspaceDir = dirName;
     log.debug(`Creating directory in ${dirName} and ${tempDirName}`);
-
-    user.uiSocket.emit('projectBind', { status: 'success', ...newProject });
     log.info(`Successfully created project - name: ${newProject.name}, ID: ${newProject.projectID}`);
 
   } catch (err) {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Remove the event emit from bind start as we can't call all APIs on a project at this point.  Event is emitted at bind end.