### PR TITLE
Add tests on new log architecture

### DIFF
--- a/src/pfe/file-watcher/server/src/utils/dockerutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/dockerutil.ts
@@ -314,7 +314,7 @@ export async function getFilesOrFoldersInContainerWithTimestamp(projectID: strin
         return [];
       } else {
         logger.logInfo("At least one file was found");
-        const lines =  data.split("\n");
+        const lines = data.split("\n");
         const fileIndex = 8; // file is the 9th argument from the above command
         const filesTimestamp: Array<logHelper.LogFiles> = [];
         for (let line of lines) {

--- a/src/pfe/file-watcher/server/src/utils/dockerutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/dockerutil.ts
@@ -314,20 +314,23 @@ export async function getFilesOrFoldersInContainerWithTimestamp(projectID: strin
         return [];
       } else {
         logger.logInfo("At least one file was found");
-        const files = data.replace(/\n/g, " ").replace(/[^ -~]+/g, "").split(" ").filter((entry: string) => { return entry.trim() != ""; });
+        const lines =  data.split("\n");
         const fileIndex = 8; // file is the 9th argument from the above command
         const filesTimestamp: Array<logHelper.LogFiles> = [];
-        for (let index = fileIndex; index < files.length; index = index + fileIndex + 1) {
-          const file = files[index];
-          const dateString = files[index - 3] + " " + files[index - 2] + " " + files[index - 1];
-          if (!folderName) {
-            filesTimestamp.push({file: path.join(fileLocation, file), time: +new Date(dateString)});
-          } else {
-            if (file.toLowerCase() === folderName.toLowerCase()) {
-              filesTimestamp.push({file: path.join(fileLocation, folderName), time: +new Date(dateString)});
-              break;
+        for (let line of lines) {
+            line = line.replace(/[^ -~]+/g, "").replace(/\s+/g, " ").trim();
+            if (line != "") {
+                const file = line.split(" ")[fileIndex];
+                const dateString = line.split(" ")[fileIndex - 3] + " " + line.split(" ")[fileIndex - 2] + " " + line.split(" ")[fileIndex - 1];
+                if (!folderName) {
+                    filesTimestamp.push({file: path.join(fileLocation, file), time: +new Date(dateString)});
+                } else {
+                    if (file.toLowerCase() === folderName.toLowerCase()) {
+                        filesTimestamp.push({file: path.join(fileLocation, folderName), time: +new Date(dateString)});
+                        break;
+                    }
+                }
             }
-          }
         }
         return filesTimestamp;
       }

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -228,7 +228,7 @@ export async function getFilesOrFoldersInContainerWithTimestamp(projectID: strin
                 return [];
             } else {
                 logger.logInfo("At least one file was found");
-                const lines =  data.stdout.split("\n");
+                const lines = data.stdout.split("\n");
                 const fileIndex = 8; // file is the 9th argument from the above command
                 const filesTimestamp: Array<logHelper.LogFiles> = [];
                 for (let line of lines) {

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -227,23 +227,26 @@ export async function getFilesOrFoldersInContainerWithTimestamp(projectID: strin
                 logger.logInfo("No files were found");
                 return [];
             } else {
-            logger.logInfo("At least one file was found");
-            const files = data.stdout.replace(/\n/g, " ").replace(/[^ -~]+/g, "").split(" ").filter((entry: string) => { return entry.trim() != ""; });
-            const fileIndex = 8; // file is the 9th argument from the above command
-            const filesTimestamp: Array<logHelper.LogFiles> = [];
-            for (let index = fileIndex; index < files.length; index = index + fileIndex + 1) {
-                const file = files[index];
-                const dateString = files[index - 3] + " " + files[index - 2] + " " + files[index - 1];
-                if (!folderName) {
-                filesTimestamp.push({file: path.join(fileLocation, file), time: +new Date(dateString)});
-                } else {
-                if (file.toLowerCase() === folderName.toLowerCase()) {
-                    filesTimestamp.push({file: path.join(fileLocation, folderName), time: +new Date(dateString)});
-                    break;
+                logger.logInfo("At least one file was found");
+                const lines =  data.stdout.split("\n");
+                const fileIndex = 8; // file is the 9th argument from the above command
+                const filesTimestamp: Array<logHelper.LogFiles> = [];
+                for (let line of lines) {
+                    line = line.replace(/[^ -~]+/g, "").replace(/\s+/g, " ").trim();
+                    if (line != "") {
+                        const file = line.split(" ")[fileIndex];
+                        const dateString = line.split(" ")[fileIndex - 3] + " " + line.split(" ")[fileIndex - 2] + " " + line.split(" ")[fileIndex - 1];
+                        if (!folderName) {
+                            filesTimestamp.push({file: path.join(fileLocation, file), time: +new Date(dateString)});
+                        } else {
+                            if (file.toLowerCase() === folderName.toLowerCase()) {
+                                filesTimestamp.push({file: path.join(fileLocation, folderName), time: +new Date(dateString)});
+                                break;
+                            }
+                        }
+                    }
                 }
-                }
-            }
-            return filesTimestamp;
+                return filesTimestamp;
             }
         } catch (err) {
             const errMsg = "Error checking existence for " + fileLocation + " in container " + containerName;

--- a/src/pfe/file-watcher/server/test/.gitignore
+++ b/src/pfe/file-watcher/server/test/.gitignore
@@ -1,0 +1,2 @@
+cwctl
+projects

--- a/src/pfe/file-watcher/server/test/cronjob/cronjob-win.sh
+++ b/src/pfe/file-watcher/server/test/cronjob/cronjob-win.sh
@@ -164,7 +164,7 @@ for i in "${PROJECT_CLONE[@]}"; do
 
     echo -e "${BLUE}>> Creating project $PROJECT_NAME from $PROJECT_URL in "$PROJECT_PATH/$PROJECT_NAME" ${RESET}"
     createProject $PROJECT_URL "$PROJECT_PATH/$PROJECT_NAME"
-	checkExitCode $? "Failed to download latest tests."
+	checkExitCode $? "Failed to created project $PROJECT_NAME."
 
 	echo -e "${BLUE}>> Copying $PROJECT_NAME to PFE container ${RESET}"
 	copyToPFE "$PROJECT_PATH/$PROJECT_NAME"

--- a/src/pfe/file-watcher/server/test/cronjob/cronjob-win.sh
+++ b/src/pfe/file-watcher/server/test/cronjob/cronjob-win.sh
@@ -28,9 +28,11 @@ IMAGE_TAG=""
 TEST_REPO="https://github.com/eclipse/codewind.git"
 TEST_BRANCH="master"
 CW_DIR="$TEST_WD/codewind"
+PROJECT_PATH="$TEST_WD/projects"
 CLEAN_UP=""
 
 TEST_DIR="$CW_DIR/src/pfe/file-watcher/server/test"
+PROJECTS_CLONE_DATA_FILE="$TEST_DIR/resources/projects-clone-data"
 
 DATE_NOW=$(date +"%d-%m-%Y")
 TIME_NOW=$(date +"%H.%M.%S")
@@ -95,16 +97,33 @@ function checkExitCode() {
 	fi
 }
 
+function createProject() {
+   ./$EXECUTABLE_NAME project create --url $1 $2
+}
+
+function copyToPFE() {
+   docker cp $1 $CW_CONTAINER:"/codewind-workspace"
+}
+
+echo -e "${BLUE}>> Downloading latest installer ... ${RESET}"
+EXECUTABLE_NAME="cwctl"
+curl -X GET http://download.eclipse.org/codewind/codewind-installer/master/latest/cwctl-win.exe --output $EXECUTABLE_NAME
+checkExitCode $? "Failed to download latest installer."
+
+echo -e "${BLUE}>> Giving executable permission to installer ... ${RESET}"
+chmod +x $EXECUTABLE_NAME
+checkExitCode $? "Failed to give correct permission to run installer."
+
 echo -e "${BLUE}>> Cleaning up docker system ... ${RESET}"
 docker system prune -af
 checkExitCode $? "Failed to clean up docker system."
 
 echo -e "${BLUE}>> Stopping existing codewind ... ${RESET}"
-./codewind-installer-win.exe stop-all
+./cwctl stop-all
 checkExitCode $? "Failed to stop existing codewind."
 
 echo -e "${BLUE}>> Installing latest codewind ... ${RESET}"
-./codewind-installer-win.exe install -t latest
+./cwctl install -t latest
 checkExitCode $? "Failed to install latest codewind."
 
 if [[ ! -z "$IMAGE_TAG" ]]; then
@@ -118,7 +137,7 @@ if [[ ! -z "$IMAGE_TAG" ]]; then
 fi
 
 echo -e "${BLUE}>> Starting codewind ... ${RESET}"
-./codewind-installer-win.exe start
+./cwctl start
 checkExitCode $? "Failed to start codewind."
 
 if [[ ! -d $CW_DIR ]]; then
@@ -126,6 +145,31 @@ if [[ ! -d $CW_DIR ]]; then
 	git clone $TEST_REPO -b $TEST_BRANCH
 	checkExitCode $? "Failed to download latest tests."
 fi
+
+echo -e "${BLUE}>> Creating test projects directory ... ${RESET}"
+mkdir -p $PROJECT_PATH
+checkExitCode $? "Failed to create test projects directory."
+
+CTR=0
+# Read project git config
+while IFS='\n' read -r LINE; do
+    PROJECT_CLONE[$CTR]=$LINE
+    let CTR++
+done < "$PROJECTS_CLONE_DATA_FILE"
+    
+# Clone projects to workspace
+for i in "${PROJECT_CLONE[@]}"; do
+    PROJECT_NAME=$(echo $i | cut -d "=" -f 1)
+    PROJECT_URL=$(echo $i | cut -d "=" -f 2)
+
+    echo -e "${BLUE}>> Creating project $PROJECT_NAME from $PROJECT_URL in "$PROJECT_PATH/$PROJECT_NAME" ${RESET}"
+    createProject $PROJECT_URL "$PROJECT_PATH/$PROJECT_NAME"
+	checkExitCode $? "Failed to download latest tests."
+
+	echo -e "${BLUE}>> Copying $PROJECT_NAME to PFE container ${RESET}"
+	copyToPFE "$PROJECT_PATH/$PROJECT_NAME"
+	checkExitCode $? "Failed to copy project to PFE container."
+done
 
 echo -e "${BLUE}>> Copying test files over to container ... ${RESET}"
 docker cp $TEST_DIR $CW_CONTAINER:$IN_CONTAINER_PATH
@@ -152,6 +196,7 @@ checkExitCode $? "Failed to copy test results from container."
 if [[ ! -z "$CLEAN_UP" ]]; then
 	echo -e "${BLUE}>> Cleaning up test directory ... ${RESET}"
 	rm -rf $CW_DIR
+	rm -rf $PROJECT_PATH
 	checkExitCode $? "Failed to clean up test directory."
 fi
 

--- a/src/pfe/file-watcher/server/test/functional-test/configs/log.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/log.config.ts
@@ -14,13 +14,69 @@
  * maven.build -> maven build log file
  * app.compile -> app compilation log file
  */
-export const log_names = ["docker.build.log", "maven.build.log", "app.compile.log", "app.log", "docker.app.log"];
+export const log_names = ["docker.build.log", "maven.build.log", "app.compile.log", "app.log", "docker.app.log", "messages.log", "console.log"];
 
 export const logTypes = ["build", "app"];
+const logOrigins = ["container", "workspace"];
 
 export const logFileMappings: any = {
     "docker": {
-        [logTypes[0]]: [log_names[0]],
-        [logTypes[1]]: [log_names[3]],
-    }
+        [logTypes[0]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[0]]
+        }],
+        [logTypes[1]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[3]]
+        }]
+    },
+    "liberty": {
+        [logTypes[0]]: [{
+            "origin": logOrigins[0],
+            "files": [log_names[1]]
+        }, {
+            "origin": logOrigins[1],
+            "files": [log_names[0]]
+        }],
+        [logTypes[1]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[3]]
+        }, {
+            "origin": logOrigins[0],
+            "files": [log_names[6], log_names[5]]
+        }]
+    },
+    "nodejs": {
+        [logTypes[0]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[0]]
+        }],
+        [logTypes[1]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[3]]
+        }]
+    },
+    "spring": {
+        [logTypes[0]]: [{
+            "origin": logOrigins[0],
+            "files": [log_names[1]]
+        }, {
+            "origin": logOrigins[1],
+            "files": [log_names[0]]
+        }],
+        [logTypes[1]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[3]]
+        }]
+    },
+    "swift": {
+        [logTypes[0]]: [{
+            "origin": logOrigins[1],
+            "files": process.env.IN_K8 ? [log_names[2], log_names[4]] : [log_names[4], log_names[2], log_names[0]]
+        }],
+        [logTypes[1]]: [{
+            "origin": logOrigins[1],
+            "files": [log_names[3]]
+        }]
+    },
 };

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/logs.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/logs.ts
@@ -50,32 +50,12 @@ export function logsTest(socket: SocketIO, projData: ProjectCreation): void {
             expect(info.statusCode);
             expect(info.statusCode).to.equal(200);
             expect(info.logs);
-            expect(info.logs).to.haveOwnProperty("build");
-            expect(info.logs.build).to.haveOwnProperty("origin");
-            expect(info.logs.build).to.haveOwnProperty("files");
-            expect(info.logs.build.files[0].indexOf(projData.projectID) > -1);
-            expect(info.logs).to.haveOwnProperty("app");
-            expect(info.logs.app).to.haveOwnProperty("origin");
-            expect(info.logs.app).to.haveOwnProperty("files");
-            expect(info.logs.app.files[0].indexOf(projData.projectID) > -1);
 
-            if (log_configs.logFileMappings[projData.projectType]) {
-                const actualBuildLogFiles = log_configs.logFileMappings[projData.projectType].build;
-                const actualAppLogFiles = log_configs.logFileMappings[projData.projectType].app;
-
-                const expectedBuildLogFiles = info.logs.build.files;
-                for (const logFile of expectedBuildLogFiles) {
-                    const tokens = logFile.split("/");
-                    const fileName = tokens[tokens.length - 1];
-                    expect(_.includes(actualBuildLogFiles, fileName));
-                }
-
-                const expectedAppLogFiles = info.logs.app.files;
-                for (const logFile of expectedAppLogFiles) {
-                    const tokens = logFile.split("/");
-                    const fileName = tokens[tokens.length - 1];
-                    expect(_.includes(actualAppLogFiles, fileName));
-                }
+            for (const logType of log_configs.logTypes) {
+                expect(info.logs).to.haveOwnProperty(logType);
+                expect(info.logs[logType]).to.be.an.instanceof(Array);
+                expect(info.logs[logType].length).to.equal(log_configs.logFileMappings[projData.projectType][logType].length);
+                expect(_.isMatch(info.logs[logType], log_configs.logFileMappings[projData.projectType][logType]));
             }
         });
     });
@@ -123,19 +103,9 @@ export function logsTest(socket: SocketIO, projData: ProjectCreation): void {
                 expect(info.logs.type).to.equal(logType);
                 expect(info.logs).to.haveOwnProperty(logType);
                 expect(info.logs[logType]);
-                expect(info.logs[logType]).to.haveOwnProperty("origin");
-                expect(info.logs[logType]).to.haveOwnProperty("files");
-                expect(info.logs[logType].files[0].indexOf(projData.projectID) > -1);
-
-                if (log_configs.logFileMappings[projData.projectType]) {
-                    const actualFiles = log_configs.logFileMappings[projData.projectType][logType];
-                    const expectedFiles = info.logs[logType].files;
-                    for (const logFile of expectedFiles) {
-                        const tokens = logFile.split("/");
-                        const fileName = tokens[tokens.length - 1];
-                        expect(_.includes(actualFiles, fileName));
-                    }
-                }
+                expect(info.logs[logType]).to.be.an.instanceof(Array);
+                expect(info.logs[logType].length).to.equal(log_configs.logFileMappings[projData.projectType][logType].length);
+                expect(_.isMatch(info.logs[logType], log_configs.logFileMappings[projData.projectType][logType]));
 
                 const targetEvent = eventConfigs.events.logsListChanged;
                 const returnData = info.logs;

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/logs.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/logs.ts
@@ -57,7 +57,7 @@ export function logsTest(socket: SocketIO, projData: ProjectCreation): void {
                 expect(info.logs[logType].length).to.equal(log_configs.logFileMappings[projData.projectType][logType].length);
                 expect(_.isMatch(info.logs[logType], log_configs.logFileMappings[projData.projectType][logType]));
             }
-        });
+        }).timeout(timeoutConfigs.defaultTimeout);
     });
 
     describe("checkNewLogFile function", () => {

--- a/src/pfe/file-watcher/server/test/scripts/exec.sh
+++ b/src/pfe/file-watcher/server/test/scripts/exec.sh
@@ -24,29 +24,49 @@ Options:
 EOF
 }
 
+function checkExitCode() {
+	exit_code=$1
+	error_msg=$2
+	if [[ $exit_code -eq 0 ]]; then
+		echo -e "${GREEN}✔ Done. ${RESET}\n"
+	else
+		echo -e "${RED}✖ $error_msg  ${RESET}\n"
+		exit 1
+	fi
+}
+
 function downloadCwctl() {
+    echo -e "${BLUE}>> Downloading latest installer ... ${RESET}"
     EXECUTABLE_NAME="cwctl"
-    DOWNLOAD_CMD="curl -X GET http://download.eclipse.org/codewind/codewind-installer/master/latest/cwctl-linux --output /usr/local/bin/$EXECUTABLE_NAME"
-    if [ $TEST_TYPE == "local" ]; then
-        docker exec -i $CODEWIND_CONTAINER_ID bash -c "$DOWNLOAD_CMD"
-        docker exec -i $CODEWIND_CONTAINER_ID bash -c "chmod +x /usr/local/bin/$EXECUTABLE_NAME"
-    elif [ $TEST_TYPE == "kube" ]; then
-        kubectl exec -i $CODEWIND_POD_ID -- bash -c "$DOWNLOAD_CMD"
-        kubectl exec -i $CODEWIND_POD_ID -- bash -c "chmod +x /usr/local/bin/$EXECUTABLE_NAME"
+    HOST_OS=$(uname -a)
+    if [[ "$HOST_OS" =~ "Darwin" ]]; then
+        extension="macos"
+    elif [[ "$HOST_OS" =~ "Linux" ]]; then
+        extension="linux"
     fi
+    echo "Extension is $extension"
+    curl -X GET http://download.eclipse.org/codewind/codewind-installer/master/latest/cwctl-$extension --output $EXECUTABLE_NAME
+    checkExitCode $? "Failed to download latest installer."
+
+    echo -e "${BLUE}>> Giving executable permission to installer ... ${RESET}"
+    chmod +x $EXECUTABLE_NAME
+    checkExitCode $? "Failed to give correct permission to run installer."
 }
 
 function createProject() {
-    CREATE_CMD="$EXECUTABLE_NAME project create --url $1 $2"
+   ./$EXECUTABLE_NAME project create --url $1 $2
+}
+
+function copyToPFE() {
     if [ $TEST_TYPE == "local" ]; then
-        docker exec -i $CODEWIND_CONTAINER_ID bash -c "$CREATE_CMD"
+        docker cp $1 $CODEWIND_CONTAINER_ID:"$PROJECT_PATH"
     elif [ $TEST_TYPE == "kube" ]; then
-        kubectl exec -i $CODEWIND_POD_ID -- bash -c "$CREATE_CMD"
+        kubectl cp $1 $CODEWIND_POD_ID:"$PROJECT_PATH"
     fi
 }
 
-
 function setup {
+    PROJECT_DIR="$CW_DIR/src/pfe/file-watcher/server/test/projects"
     DATE_NOW=$(date +"%d-%m-%Y")
     TIME_NOW=$(date +"%H.%M.%S")
     BUCKET_NAME=turbine-$TEST_TYPE-$TEST_SUITE
@@ -55,7 +75,7 @@ function setup {
     TURBINE_DIR_CONTAINER=/file-watcher
     TEST_OUTPUT_DIR=~/test_results/$TEST_TYPE/$TEST_SUITE/$DATE_NOW/$TIME_NOW
     TEST_OUTPUT=$TEST_OUTPUT_DIR/test_output.xml
-    PROJECTS_CLONE_DATA_FILE="./resources/projects-clone-data"
+    PROJECTS_CLONE_DATA_FILE="$CW_DIR/src/pfe/file-watcher/server/test/resources/projects-clone-data"
     TEST_LOG=$TEST_OUTPUT_DIR/$TEST_TYPE-$TEST_SUITE-test.log
     TURBINE_NPM_INSTALL_CMD="cd /file-watcher/server; npm install --only=dev"
     TURBINE_EXEC_TEST_CMD="cd /file-watcher/server; JUNIT_REPORT_PATH=/test_output.xml npm run $TEST_SUITE:test:xml"
@@ -93,9 +113,13 @@ function setup {
 
     downloadCwctl
 
+    echo -e "${BLUE}>> Creating test projects directory ... ${RESET}"
+    mkdir -p $PROJECT_DIR
+    checkExitCode $? "Failed to create test projects directory."
+
     CTR=0
     # Read project git config
-    echo -e "${BLUE}Creating projects to $PROJECT_PATH. ${RESET}"
+    echo -e "${BLUE}Creating projects to $PROJECT_DIR. ${RESET}"
     while IFS='\n' read -r LINE; do
         PROJECT_CLONE[$CTR]=$LINE
         let CTR++
@@ -105,9 +129,14 @@ function setup {
     for i in "${PROJECT_CLONE[@]}"; do
         PROJECT_NAME=$(echo $i | cut -d "=" -f 1)
         PROJECT_URL=$(echo $i | cut -d "=" -f 2)
-        echo -e "\n\nProject name is: $PROJECT_NAME, project URL is $PROJECT_URL"
-        echo -e "${BLUE}Creating project $PROJECT_NAME from $PROJECT_URL in "$PROJECT_PATH/$PROJECT_NAME" ${RESET}"
-        createProject $PROJECT_URL "$PROJECT_PATH/$PROJECT_NAME"
+
+        echo -e "${BLUE}>> Creating project $PROJECT_NAME from $PROJECT_URL in "$PROJECT_DIR/$PROJECT_NAME" ${RESET}"
+        createProject $PROJECT_URL "$PROJECT_DIR/$PROJECT_NAME"
+	    checkExitCode $? "Failed to created project $PROJECT_NAME."
+
+        echo -e "${BLUE}>> Copying $PROJECT_NAME to PFE container ${RESET}"
+	    copyToPFE "$PROJECT_DIR/$PROJECT_NAME"
+	    checkExitCode $? "Failed to copy project to PFE container."
     done
 }
 
@@ -131,6 +160,10 @@ function run {
         $WEBSERVER_FILE $TEST_OUTPUT_DIR > /dev/null
         curl --header "Content-Type:text/xml" --data-binary @$TEST_OUTPUT --insecure "https://$DASHBOARD_IP/postxmlresult/$BUCKET_NAME/test" > /dev/null
     fi
+
+    echo -e "${BLUE}>> Cleaning up test projects ... ${RESET}"
+	rm -rf $PROJECT_DIR
+	checkExitCode $? "Failed to clean up test directory."
 }
 
 while getopts "t:s:d:h" OPTION; do


### PR DESCRIPTION
### Description

This PR:
- [x] adds the tests on new log architecture
- [x] enables the cronjob on windows to pull down and use the latest installer
- [x] enables the linux/macos to pull down and use the latest installer from the vm instead of inside PFE

Related to https://github.com/eclipse/codewind/issues/908 and https://github.com/eclipse/codewind/issues/907