### PR TITLE
Update ODO extension release version for all build files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
                         rm -f ${SRC_DIR}/pfe/extensions/odo
                         curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/master/latest/codewind-appsody-extension-0.6.0.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.5.0.zip https://github.com/eclipse/codewind-odo-extension/archive/0.5.0.zip
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/0.6.0.zip
                         curl -Lo ${SRC_DIR}/pfe/extensions/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64
 
                         # BUILD IMAGES

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
                         rm -f ${SRC_DIR}/pfe/extensions/odo
                         curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/master/latest/codewind-appsody-extension-0.6.0.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/0.6.0.zip
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/v0.6.0.zip
                         curl -Lo ${SRC_DIR}/pfe/extensions/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64
 
                         # BUILD IMAGES

--- a/script/build.sh
+++ b/script/build.sh
@@ -58,7 +58,7 @@ rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/odo
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/master/latest/codewind-appsody-extension-0.6.0.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.5.0.zip https://github.com/eclipse/codewind-odo-extension/archive/0.5.0.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/0.6.0.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64
 
 # BUILD IMAGES

--- a/script/build.sh
+++ b/script/build.sh
@@ -58,7 +58,7 @@ rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/odo
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/master/latest/codewind-appsody-extension-0.6.0.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/0.6.0.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/v0.6.0.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64
 
 # BUILD IMAGES


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/1001

Since ODO extension repository pre-release has been updated to 0.6.0, so need to do this changes to accommodate that.

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>