### PR TITLE
Fix IDC code for buildah rmi

### DIFF
--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/tasks/ContainerRemoveTask.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/tasks/ContainerRemoveTask.java
@@ -85,36 +85,13 @@ public class ContainerRemoveTask {
 				
 				String imageName = appDB.get(Constants.DB_CONTAINER_NAME);
 				if (imageName != null) {
-					ProcessRunner pr = TaskUtils.runCmd(imageCommand + " rmi " + imageName + " -f", context,
+					ProcessRunner pr = TaskUtils.runCmd(imageCommand + " rmi -f " + imageName, context,
 							false);
 					if(pr.getErrorCode().orElse(0) != 0) {
 						Logger.error("Error code: " + pr.getErrorCode() + ", Failed to remove the image " + imageName);
 						return false;
 					} else {
 						Logger.info("Successfully removed the application image " + imageName);
-					}
-
-					String deploymentRegistry = appDB.get(Constants.DB_DEPLOYMENT_REGISTRY);
-					if (deploymentRegistry != null) {
-						pr = TaskUtils.runCmd("imageCommand rmi -f " + deploymentRegistry + "/" + imageName, context,
-								false);
-						if(pr.getErrorCode().orElse(0) != 0) {
-							Logger.error("Error code: " + pr.getErrorCode() + ", Failed to remove the image " + imageName +
-							" from docker registry " + deploymentRegistry);
-							return false;
-						} else {
-							Logger.info("Successfully removed the application image " + imageName + " from docker registry " + deploymentRegistry);
-						}
-					}
-
-					// Delete the image from Kube
-					pr = TaskUtils.runCmd("kubectl delete image " + imageName + " --force --grace-period=0", context,
-							false);
-					if(pr.getErrorCode().orElse(0) != 0) {
-						Logger.error("Error code: " + pr.getErrorCode() + ", Failed to remove the image from Kubernetes " + imageName);
-						return false;
-					} else {
-						Logger.info("Successfully removed the application image from Kubernetes " + imageName);
 					}
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

Fixes https://github.com/eclipse/codewind/issues/991

Tested disable/enable and also project delete
```
[05/11/19 23:30:39 testenabledisable] [INFO] operationId: 0bbba3b4f752b8e02f81e6fa6a9b2bd5
[05/11/19 23:30:39 testenabledisable] [INFO] containerDelete: Kill running processes and remove container... 
[05/11/19 23:30:39 testenabledisable] [INFO] Project ID:        0553ba10-0023-11ea-83e4-f54a9720ef56
[05/11/19 23:30:39 testenabledisable] [INFO] Project Location:  /codewind-workspace/testenabledisable
[05/11/19 23:30:39 testenabledisable] [INFO] Project Type:      liberty
[05/11/19 23:30:39 testenabledisable] [INFO] Project Container: cw-testenabledisable-0553ba10-0023-11ea-83e4
[05/11/19 23:30:39 testenabledisable] [INFO] projectInfo.deploymentRegistry: docker.io/maysunfaisal
[05/11/19 23:31:19 testenabledisable] [INFO] Removing dangling images for 0553ba10-0023-11ea-83e4-f54a9720ef56
[05/11/19 23:31:19 testenabledisable] [INFO] Project info cache is {}
[05/11/19 23:31:19 testenabledisable] [INFO] Successfully deleted 0553ba10-0023-11ea-83e4-f54a9720ef56
[05/11/19 23:31:19 Turbine] [INFO] Removing project logs directory
[05/11/19 23:31:19 Turbine] [INFO] Log directory removed from: /codewind-workspace/.logs/testenabledisable-0553ba10-0023-11ea-83e4-f54a9720ef56
[05/11/19 23:31:19 Turbine] [INFO] 0553ba10-0023-11ea-83e4-f54a9720ef56: Emitting event 
 message: projectDeletion
 data: {
  "operationId": "0bbba3b4f752b8e02f81e6fa6a9b2bd5",
  "projectID": "0553ba10-0023-11ea-83e4-f54a9720ef56",
  "status": "success"
}
[05/11/19 23:31:19 Turbine] [INFO] No dangling images were found.
```