### PR TITLE
Add another property to all project handlers to decide build or not

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -78,6 +78,8 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         let isSettingFileChanged = false;
         let isProjectBuildRequired = false;
 
+        const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
+        const builtByExtension = projectHandler.builtByExtension;
         try {
             for (let i = 0; i < eventArrayLength; i++) {
                 if (isSettingFileChanged && isProjectBuildRequired) {
@@ -91,7 +93,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                     const data = await readFileAsync(settingsFilePath, "utf8");
                     const projectSettings = JSON.parse(data);
                     projectSpecifications.projectSpecificationHandler(projectID, projectSettings);
-                } else if (eventArray[i].path && !eventArray[i].path.includes(".cw-settings")) {
+                } else if (eventArray[i].path && !eventArray[i].path.includes(".cw-settings") && !builtByExtension) {
                     logger.logProjectInfo("Detected other file changes, Codewind will build the project", projectID);
                     isProjectBuildRequired = true;
                 }
@@ -105,8 +107,12 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         }
 
         if (!isProjectBuildRequired) {
-            // .cw-settings file is the only changed file. return succeed status
-            logger.logProjectInfo("Only .cw-settings file change detected. Project will not re-build.", projectID);
+            if (builtByExtension) {
+                logger.logProjectInfo("This project file changes will be ignored by Turbine. The project extension will decide if it needs to be rebuilt.", projectID);
+            } else {
+                // .cw-settings file is the only changed file. return succeed status
+                logger.logProjectInfo("Only .cw-settings file change detected. Project will not re-build.", projectID);
+            }
             return { "statusCode": 202 };
         }
 

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -192,7 +192,6 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                 if (shouldTriggerBuild) {
                     if (projectInfo.autoBuildEnabled) {
                         if (!statusController.isBuildInProgress(projectID)) {
-                            const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
                             const operation = new projectOperation.Operation("update", projectInfo);
                             projectHandler.update(operation, changedFilesMap.get(projectInfo.projectID));
                         } else {
@@ -218,7 +217,6 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                 try {
                     if (projectInfo.autoBuildEnabled) {
                         if (!statusController.isBuildInProgress(projectID)) {
-                            const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
                             const operation = new projectOperation.Operation("update", projectInfo);
                             projectHandler.update(operation, changedFilesMap.get(projectInfo.projectID));
                         } else {

--- a/src/pfe/file-watcher/server/src/projects/DockerProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/DockerProject.ts
@@ -55,6 +55,7 @@ const logsOrigin: logHelper.ILogTypes = {
 export class DockerProject implements ProjectExtension {
 
     supportedType: string;
+    builtByExtension: boolean = false;
 
     /**
      * @constructor

--- a/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
@@ -69,6 +69,7 @@ interface OdoExtensionProjectConfig {
 export class OdoExtensionProject implements IExtensionProject {
 
     supportedType: string;
+    builtByExtension: boolean = true;
 
     private fullPath: string;
     private config: OdoExtensionProjectConfig;

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -86,6 +86,7 @@ export class ShellExtensionProject implements IExtensionProject {
 
     supportedType: string;
     // defaultIgnoredPath: string[] = ["*/*"];
+    builtByExtension: boolean = true;
 
     private fullPath: string;
     private config: ShellExtensionProjectConfig;

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -85,7 +85,6 @@ const logsOrigin: logHelper.ILogTypes = {
 export class ShellExtensionProject implements IExtensionProject {
 
     supportedType: string;
-    // defaultIgnoredPath: string[] = ["*/*"];
     builtByExtension: boolean = true;
 
     private fullPath: string;

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -38,6 +38,7 @@ export const requiredFiles = [ "/Dockerfile | /Dockerfile-lang", "/Dockerfile-bu
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debug], [ControlCommands.restart]);
 
 export const supportedType: string = "liberty";
+export const builtByExtension: boolean = false;
 
 const inContainerAppLogsDirectory = path.join(process.env.HOST_OS === "windows" ? path.join(path.sep, "tmp", "liberty") : path.join(path.sep, "home", "default", "app", "mc-target"), "liberty", "wlp", "usr", "servers", "defaultServer", "logs");
 

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -26,6 +26,7 @@ export const requiredFiles = [ "/Dockerfile", "/package.json"];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debugNoInit], [ControlCommands.restart]);
 
 export const supportedType = "nodejs";
+export const builtByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -31,6 +31,7 @@ export const requiredFiles = [ "/Dockerfile", "/pom.xml" ];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debug, StartModes.debugNoInit], [ControlCommands.restart]);
 
 export const supportedType = "spring";
+export const builtByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -21,6 +21,7 @@ import * as projectEventsController from "../controllers/projectEventsController
 export const requiredFiles = [ "/Dockerfile", "/Dockerfile-tools", "/Package.swift" ];
 
 export const supportedType = "swift";
+export const builtByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

For issue: https://github.com/eclipse/codewind/issues/943

This PR adds a property called `builtByExtension` to all project handlers to indicate if  the build of this project type should be done by the project extension or not.