### PR TITLE
Fix timestamp check condition on updateProjectForNewChange

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -47,7 +47,7 @@ const timeout = (workspaceSettingsInfo && workspaceSettingsInfo.watcherChunkTime
  * @see [[Filewatcher.updateProjectForNewChange]]
  */
 export async function updateProjectForNewChange(projectID: string, timestamp: number,  chunkNum: number, chunk_total: number, eventArray: IFileChangeEvent[]): Promise<IUpdateProjectSuccess | IUpdateProjectFailure> {
-    if (!projectID || !timestamp || !eventArray || !chunkNum || !chunk_total) {
+    if (!projectID || (timestamp === null || isNaN(timestamp)) || !eventArray || !chunkNum || !chunk_total) {
         return { "statusCode": 400, "error": {"msg": "Bad request. projectID, timestamp, chunk, chunk_total and eventArray are required." }};
     }
 


### PR DESCRIPTION
### Description

The timestamp check condition on `updateProjectForNewChange` function would fail if the number was 0. This was because it would literally treat it as boolean. Changed the condition to take care of the null cases as well as the case when it is not a number.

Related to https://github.com/eclipse/codewind/issues/1009

Signed-off-by: ssh24 <sakib@ibm.com>