### PR TITLE
update default template repo

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1412,7 +1412,7 @@ components:
         url:
           description: url of the modified template repository
           type: string
-          example: https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json
+          example: https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json
         value:
           type: string
           example: 'true'

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -22,7 +22,7 @@ const log = new Logger('Templates.js');
 
 const DEFAULT_REPOSITORY_LIST = [
   {
-    url: 'https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json',
+    url: 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json',
     description: 'Standard Codewind templates',
     enabled: true,
     protected: true,

--- a/test/src/unit/temp/.config/repository_list.json
+++ b/test/src/unit/temp/.config/repository_list.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/devfiles/index.json",
+    "url": "https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json",
     "description": "Standard Codewind templates",
     "enabled": true,
     "protected": true,


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

This moves the location of the template repo we access from kabanero to codewind-resources