### PR TITLE
Update for ODO extension jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,13 +67,16 @@ pipeline {
                         cp -r $DIR/docs ${SRC_DIR}/pfe/portal/
 
                         echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
+                        if [ $GIT_BRANCH == "master" ]; then
+                            VERSION="latest"
+                        else
+                            VERSION="$GIT_BRANCH"
+                        fi
                         mkdir -p ${SRC_DIR}/pfe/extensions
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
-                        rm -f ${SRC_DIR}/pfe/extensions/odo
                         curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/0.6.0/latest/codewind-appsody-extension-0.6.0.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/v0.6.0.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-$VERSION.zip http://download.eclipse.org/codewind/codewind-odo-extension/$GIT_BRANCH/latest/codewind-odo-extension-$VERSION.zip
 
                         # BUILD IMAGES
                         # Uses a build file in each of the directories that we want to use

--- a/script/build.sh
+++ b/script/build.sh
@@ -56,10 +56,8 @@ echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
 mkdir -p ${SRC_DIR}/pfe/extensions
 rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
-rm -f ${SRC_DIR}/pfe/extensions/odo
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/0.6.0/latest/codewind-appsody-extension-0.6.0.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-0.6.0.zip https://github.com/eclipse/codewind-odo-extension/archive/v0.6.0.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/odo https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/odo-linux-amd64
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-latest.zip http://download.eclipse.org/codewind/codewind-odo-extension/master/latest/codewind-odo-extension-latest.zip
 
 # BUILD IMAGES
 # Uses a build file in each of the directories that we want to use

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -21,10 +21,9 @@ const exec = promisify(require('child_process').exec);
 const log = new Logger(__filename);
 
 const extensionsDir = '/extensions';
-const extensionsPattern = /^(\S+)-(\d+\.\d+\.\d+)\.zip$/; // e.g. extension-name-0.0.1.zip
+const extensionsPattern = /^(\S+)-(\d+\.\d+\.\d+|latest)\.zip$/; // e.g. extension-name-0.0.1.zip
 const suffixOld = '__old';
 const odoExtensionName = "codewind-odo-extension";
-const odoBinarySource = "/extensions/odo"
 
 /**
  * The ExtensionList class
@@ -66,12 +65,6 @@ module.exports = class ExtensionList {
         try {
           if (await prepForUnzip(target, version)) {
             await exec(`unzip ${source} -d ${targetDir}`);
-              
-            if (name == odoExtensionName) {
-              await fs.ensureDir(`${targetWithVersion}/bin`);
-              await fs.move(odoBinarySource, `${targetWithVersion}/bin/odo`); 
-              await fs.chmod(`${targetWithVersion}/bin/odo`, '755');
-            }
 
             // top-level directory in zip will have the version suffix
             // rename to remove the version


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/929

This PR is for corresponding changes on Codewind side to enabling Jenkins build for ODO extension, changes on ODO extension repository are done and can be verified here: https://download.eclipse.org/codewind/codewind-odo-extension/.

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>