### PR TITLE
Tweak version for extensions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,16 +65,14 @@ pipeline {
 
                         echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
                         if [ $GIT_BRANCH == "master" ]; then
-                            APVERSION="9.9.9999"
-                            VERSION="latest"
+                            VERSION="9.9.9999"
                         else
-                            APVERSION="$GIT_BRANCH"
                             VERSION="$GIT_BRANCH"
                         fi
                         mkdir -p ${SRC_DIR}/pfe/extensions
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-$APVERSION.zip http://download.eclipse.org/codewind/codewind-appsody-extension/$GIT_BRANCH/latest/codewind-appsody-extension-$APVERSION.zip
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-$VERSION.zip http://download.eclipse.org/codewind/codewind-appsody-extension/$GIT_BRANCH/latest/codewind-appsody-extension-$VERSION.zip
                         curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-$VERSION.zip http://download.eclipse.org/codewind/codewind-odo-extension/$GIT_BRANCH/latest/codewind-odo-extension-$VERSION.zip
 
                         # BUILD IMAGES

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,14 +65,16 @@ pipeline {
 
                         echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
                         if [ $GIT_BRANCH == "master" ]; then
+                            APVERSION="9.9.9999"
                             VERSION="latest"
                         else
+                            APVERSION="$GIT_BRANCH"
                             VERSION="$GIT_BRANCH"
                         fi
                         mkdir -p ${SRC_DIR}/pfe/extensions
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
-                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/0.6.0/latest/codewind-appsody-extension-0.6.0.zip
+                        curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-$APVERSION.zip http://download.eclipse.org/codewind/codewind-appsody-extension/$GIT_BRANCH/latest/codewind-appsody-extension-$APVERSION.zip
                         curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-$VERSION.zip http://download.eclipse.org/codewind/codewind-odo-extension/$GIT_BRANCH/latest/codewind-odo-extension-$VERSION.zip
 
                         # BUILD IMAGES

--- a/script/build.sh
+++ b/script/build.sh
@@ -63,7 +63,7 @@ mkdir -p ${SRC_DIR}/pfe/extensions
 rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-9.9.9999.zip http://download.eclipse.org/codewind/codewind-appsody-extension/master/latest/codewind-appsody-extension-9.9.9999.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-latest.zip http://download.eclipse.org/codewind/codewind-odo-extension/master/latest/codewind-odo-extension-latest.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-9.9.9999.zip http://download.eclipse.org/codewind/codewind-odo-extension/master/latest/codewind-odo-extension-9.9.9999.zip
 
 # BUILD IMAGES
 # Uses a build file in each of the directories that we want to use

--- a/script/build.sh
+++ b/script/build.sh
@@ -62,7 +62,7 @@ echo -e "\n+++   DOWNLOADING EXTENSIONS   +++\n";
 mkdir -p ${SRC_DIR}/pfe/extensions
 rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
 rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
-curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-0.6.0.zip http://download.eclipse.org/codewind/codewind-appsody-extension/0.6.0/latest/codewind-appsody-extension-0.6.0.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-9.9.9999.zip http://download.eclipse.org/codewind/codewind-appsody-extension/master/latest/codewind-appsody-extension-9.9.9999.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-latest.zip http://download.eclipse.org/codewind/codewind-odo-extension/master/latest/codewind-odo-extension-latest.zip
 
 # BUILD IMAGES


### PR DESCRIPTION
Make master branch version of appsody and odo extensions consistent.

Discussed with @jingfuwang to use `9.9.9999`, as `latest` will cause problem for installation code.