### PR TITLE
Fix update build status with correct detailed message to emit

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -262,7 +262,7 @@ export async function updateProjectStatus(type: string, projectID: string, statu
             if (buildImageLastBuild) {
                 data.buildImageLastBuild = buildImageLastBuild;
             }
-            buildStateMap.set(projectID, new ProjectState(newState, newDetailedState, timestamp, appImageLastBuild, buildImageLastBuild));
+            buildStateMap.set(projectID, new ProjectState(newState, data.detailedBuildStatus, timestamp, appImageLastBuild, buildImageLastBuild));
             io.emitOnListener("projectStatusChanged", data);
 
             // Trigger project validation after every build


### PR DESCRIPTION
Related to https://github.com/eclipse/codewind/issues/257

The update build status function was using the wrong detailed message and hence was not able to emit on changes of the detailed message, for example: project rank changes. This PR uses the correct detailed message to emit the events and store the build state map.

You can watch the screen recording here on how it is done now:
[Screen Recording 2019-11-12 at 11.57.52 AM.zip](https://github.com/eclipse/codewind/files/3837308/Screen.Recording.2019-11-12.at.11.57.52.AM.zip)

Signed-off-by: ssh24 <sakib@ibm.com>