### PR TITLE
Remove failing test

### DIFF
--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -35,7 +35,6 @@ describe('Project Types API tests', function() {
             'spring',
             'swift',
             'docker',
-            'appsodyExtension',
         ]);
     });
 });


### PR DESCRIPTION
### Summary
* Remove `appsodyExtension` from projectTypes because it is intermittently failing our PR tests.

Signed-off-by: James Wallis <james.wallis1@ibm.com>