### PR TITLE
Increase create test timeout because Swift takes too long (not ideal)

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/configs/timeout.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/timeout.config.ts
@@ -14,6 +14,6 @@ import ms from "ms";
 export const defaultTimeout = ms("5m");
 export const defaultInterval = ms("5s");
 
-export const createTestTimeout = ms("20m");
+export const createTestTimeout = ms("60m");
 export const deleteTestTimeout = ms("1m");
 export const testDeploymentRegistryTimeout = ms("60s");


### PR DESCRIPTION
Signed-off-by: ssh24 <sakib@ibm.com>

@maysunfaisal PTAL