### PR TITLE
Sync new directories to application container

### DIFF
--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -108,6 +108,19 @@ module.exports.readFile = function readFile(project, path) {
   });
 }
 
+module.exports.copyProjectContents = async function copyProjectContents(
+  project,
+  pathToPFEProject,
+  projectRoot
+) {
+  // docker cp requires a trailing . to copy the contents of a directory
+  const srcContents = `${pathToPFEProject}/.`;
+  //  const dockerCommand = `docker exec ${project.containerId} cp ${fileToCopy} ${projectRoot}/${relativePathOfFile}`;
+  const dockerCommand = `docker cp ${srcContents} ${project.containerId}:${projectRoot}`;
+  log.debug(`[docker cp command] ${dockerCommand}`);
+  await exec(dockerCommand);
+};
+
 module.exports.copyFile = async function copyFile(project, fileToCopy, projectRoot, relativePathOfFile) {
 //  const dockerCommand = `docker exec ${project.containerId} cp ${fileToCopy} ${projectRoot}/${relativePathOfFile}`;
   const dockerCommand = `docker cp ${fileToCopy} ${project.containerId}:${projectRoot}/${relativePathOfFile}`;

--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -114,9 +114,9 @@ module.exports.copyProjectContents = async function copyProjectContents(
   projectRoot
 ) {
   // docker cp requires a trailing . to copy the contents of a directory
-  const srcContents = `${pathToPFEProject}/.`;
+  const projectContents = `${pathToPFEProject}/.`;
   //  const dockerCommand = `docker exec ${project.containerId} cp ${fileToCopy} ${projectRoot}/${relativePathOfFile}`;
-  const dockerCommand = `docker cp ${srcContents} ${project.containerId}:${projectRoot}`;
+  const dockerCommand = `docker cp ${projectContents} ${project.containerId}:${projectRoot}`;
   log.debug(`[docker cp command] ${dockerCommand}`);
   await exec(dockerCommand);
 };

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -74,7 +74,7 @@ async function bindStart(req, res) {
     }
 
     const codewindWorkspace = global.codewind.CODEWIND_WORKSPACE
-   
+
     const projectDetails = {
       name: name,
       directory: name,
@@ -98,7 +98,7 @@ async function bindStart(req, res) {
 
     newProject = await user.createProject(projectDetails);
     let msg = `Project ${newProject.name} (${newProject.projectID}) opened.`;
-    
+
     res.status(202).send(newProject);
     log.info(msg);
   } catch (err) {
@@ -203,7 +203,7 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
         log.info("Temporary project directory doesn't exist, not syncing any files");
         res.status(404).send("No files have been synced");
       } else {
-      
+
         const currentFileList = await listFiles(pathToTempProj, '');
 
         const filesToDeleteSet = new Set(currentFileList);
@@ -244,10 +244,14 @@ async function syncToBuildContainer(project, filesToDelete, pathToTempProj, modi
     if (!global.codewind.RUNNING_IN_K8S && project.projectType != 'docker' &&
       (!project.extension || !project.extension.config.needsMount)) {
       await Promise.all(filesToDelete.map(file => cwUtils.deleteFile(project, projectRoot, file)));
-      modifiedList.forEach((file) => {
-        log.info(`project is ${project} file is ${file} projectRoot is ${projectRoot}`);
-        cwUtils.copyFile(project, path.join(globalProjectPath, file), projectRoot, file);
-      });
+      log.info(
+        `project ${project.name} syncing with build container, projectRoot is ${projectRoot}`
+      );
+      await cwUtils.copyProjectContents(
+        project,
+        globalProjectPath,
+        projectRoot
+      );
     }
     filesToDelete.forEach((f) => {
       const data = {

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -245,7 +245,7 @@ async function syncToBuildContainer(project, filesToDelete, pathToTempProj, modi
       (!project.extension || !project.extension.config.needsMount)) {
       await Promise.all(filesToDelete.map(file => cwUtils.deleteFile(project, projectRoot, file)));
       log.info(
-        `project ${project.name} syncing with build container, projectRoot is ${projectRoot}`
+        `Project ${project.name} syncing with build container, projectRoot is ${projectRoot}`
       );
       await cwUtils.copyProjectContents(
         project,


### PR DESCRIPTION
## Summary

Fixes: https://github.com/eclipse/codewind/issues/1112

When we run `docker cp` to copy a modified file, from the PFE workspace to the build container, the command will error if the parent dir for that filepath doesn't already exist (in the build container). The directory is then not copied across and hence won't be seen in a users project.

This changes that process to copy the contents of the project to the build container (`docker cp ~/workspace/projectName/.`). Any new directories are copied in as part of this.

I'd recommend we test this thoroughly, as it does change fundamental logic. If solving the issue this way does cause problems, there are potentially alternative ways to tackle it, such as syncing new directories separately to files. 

## Testing 

Created and synced changes (with a new directory) for node and java projects (liberty and spring). All changes appear in the build container, and projects build as expected. 

Signed-off-by: James Cockbain <james.cockbain@ibm.com>