### PR TITLE
change timestamp to projectCreationTime

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -456,7 +456,7 @@ module.exports = class FileWatcher {
         projectID: projectID,
         pathToMonitor: pathToMonitor,
         ignoredPaths: ignoredPaths,
-        timestamp: Date.now()
+        projectCreationTime: Date.now()
       }
       let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
       await this.handleFWProjectEvent(event, projectUpdate);


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

FileWatcher is expecting the timestamp field to be called projectCreationTime - hence this change