### PR TITLE
Remove docker cp of mc-target to PFE container

### DIFF
--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDC.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDC.java
@@ -541,16 +541,6 @@ public class IDC {
 		Logger.info("Starting server in start mode: " + context.getStartMode());
 		StatusTracker.updateProjectState(context, "app", "starting", null, null);
 		
-		String dockerCpCmd = "docker cp " + context.getContainerName() + ":/home/default/app/mc-target " + context.getAppDirectory();
-		Logger.info("Docker copy command to copy the mc-target folder: " + dockerCpCmd);
-		
-		ProcessRunner copyMcTarget = TaskUtils.runCmd(dockerCpCmd, context, true);
-		if (copyMcTarget.getErrorCode().orElse(0) != 0) {
-			Logger.error("Failed to copy mc-target folder to the PFE container");
-			appDb.put(Constants.DB_SERVER_START, "false");
-			StatusTracker.updateProjectState(context, "app", "stopped", "projectStatusController.serverNotStarted",  null);
-		}
-
 
 		String logPathPrefix = HOST_OS.contains("windows") ? "/tmp/liberty/" : "/home/default/app/mc-target/";
 		String messagesLog = logPathPrefix + "liberty/wlp/usr/servers/defaultServer/logs/messages.log";


### PR DESCRIPTION
### Description

So it does look like the `docker cp` back to PFE was added initially in the hybrid stages to have a snapshot of the logs such as console, message log available. It can safely be removed. Verified it works after removing.

Related to https://github.com/eclipse/codewind/issues/1072

Signed-off-by: ssh24 <sakib@ibm.com>