### PR TITLE
Copy contents of node.js project into its container

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -276,7 +276,7 @@ function dockerRun() {
 	$IMAGE_COMMAND run --network=codewind_network -e $heapdump --name $project -p 127.0.0.1::$DEBUG_PORT -P -dt $project /bin/bash -c "$dockerCmd";
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
-		docker cp "$WORKSPACE/$projectName" $project:/app
+		docker cp "$WORKSPACE/$projectName/." $project:/app
 	fi
 
 }


### PR DESCRIPTION
Resolves https://github.com/eclipse/codewind/issues/1144. 

## Summary

We currently copy into a node.js project container under `/app/{project-name}/`. This modifies the turbine build script to copy under `/app`, in-line with other project types (and PFE syncing). 

## Testing 

Created a node.js project, all code now under `/app`, file modifications and directory creation build  the container as expected.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>