### PR TITLE
Copy contents of node.js project into its container (0.6.0)

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -276,7 +276,7 @@ function dockerRun() {
 	$IMAGE_COMMAND run --network=codewind_network -e $heapdump --name $project -p 127.0.0.1::$DEBUG_PORT -P -dt $project /bin/bash -c "$dockerCmd";
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
-		docker cp "$WORKSPACE/$projectName" $project:/app
+		docker cp "$WORKSPACE/$projectName/." $project:/app
 	fi
 
 }


### PR DESCRIPTION
Ports https://github.com/eclipse/codewind/pull/1155 to 0.6.0.

Signed-off-by: James Cockbain <james.cockbain@ibm.com>