### PR TITLE
Remove old logic of linking the whole codewind workspace logs folder for spring projects

### DIFF
--- a/src/pfe/file-watcher/scripts/springScripts/new_entrypoint.sh
+++ b/src/pfe/file-watcher/scripts/springScripts/new_entrypoint.sh
@@ -41,7 +41,7 @@ if [[ "$IN_K8" == "true" ]]; then
 
     # Create symlinks to /root/logs and /root/app on the Liberty app container / pod
     # Note that $PROJECT_NAME is an env-var defined and set in the liberty app's deployment.yaml
-    ln -s /codewind-workspace/.logs /root/logs
+    mkdir -p /root/logs
     ln -s /codewind-workspace/$PROJECT_NAME /root/app
 fi
 


### PR DESCRIPTION
### Description

There is an old logic in our new entrypoint script for spring project which links the entire codewind workspace logs folder to the spring project log folder. We need to remove that and only create the `/root/logs` folder which stores the spring maven build log in the app container.

Note: previously `/root/logs` would also not exist in line 44 but creating a symlink would also create the directory for you so we didn't need to an additional `mkdir`.

Related to https://github.com/eclipse/codewind/issues/970

Example, before and after .logs folder in the PFE container will not have the `maven.build.log` under `/codewind-workspace/.logs` directory
```
[root@codewind-workspaceyjk1s8tmrvty5ozy-696c584bb8-j4gq5 /]# ls /codewind-workspace/.logs/
Turbine.log  liberty-app-cache.log  myspr-de512620-07fa-11ea-9b88-61db5c7f1280  spring-app-cache.log
[root@codewind-workspaceyjk1s8tmrvty5ozy-696c584bb8-j4gq5 /]# ls /codewind-workspace/.logs/
Turbine.log  liberty-app-cache.log  spring-app-cache.log
```

In the app container, we will only have the `maven.build` file under `/root/logs` as intended
```
root@cw-myspr-de512620-07fa-11ea-9b88-7cdf7bd5c6-qlwph:/# ls /codewind-workspace/.logs/
Turbine.log  liberty-app-cache.log  myspr-de512620-07fa-11ea-9b88-61db5c7f1280  spring-app-cache.log
root@cw-myspr-de512620-07fa-11ea-9b88-7cdf7bd5c6-qlwph:/# ls /root/logs/
maven.build.log
```

Signed-off-by: ssh24 <sakib@ibm.com>