### PR TITLE
Add error - token validation failed

### DIFF
--- a/src/pfe/portal/modules/utils/socketAuth.js
+++ b/src/pfe/portal/modules/utils/socketAuth.js
@@ -31,7 +31,7 @@ module.exports.verifySocketUser = function verifySocketUser (token, keycloakPubl
       }
       return false
     });
-    return reject('USER_NOT_FOUND');
+    return reject('TOKEN_NOT_VALID');
   });
 };
 

--- a/src/pfe/portal/modules/utils/socketAuth.js
+++ b/src/pfe/portal/modules/utils/socketAuth.js
@@ -31,7 +31,7 @@ module.exports.verifySocketUser = function verifySocketUser (token, keycloakPubl
       }
       return false
     });
-    return reject('TOKEN_NOT_VALID');
+    return reject('TOKEN_REJECTED');
   });
 };
 


### PR DESCRIPTION
Changes token validation error when token is invalid.

```
2019-11-19T10:16:17.312Z 'Connected to remote'
2019-11-19T10:16:17.475Z 'Received [unauthorized] : {"message":"TOKEN_REJECTED"}'
2019-11-19T10:16:18.465Z 'Disconnected from remote'
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>