### PR TITLE
Add appsody extension back into project-types test

### DIFF
--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -35,6 +35,7 @@ describe('Project Types API tests', function() {
             'spring',
             'swift',
             'docker',
+            'appsodyExtension',
         ]);
     });
 });


### PR DESCRIPTION
### Summary
* Adds the `AppsodyExtension` back into the `project-types` API test as a fix should have been put into fix it intermittently disappearing.
* See here: https://github.com/eclipse/codewind/issues/1105

Signed-off-by: James Wallis <james.wallis1@ibm.com>