### PR TITLE
Add creationtime to bind/start

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -55,6 +55,7 @@ module.exports = class Project {
     this.codewindVersion = args.codewindVersion || process.env.CODEWIND_VERSION;
     this.language = args.language;
     this.validate = args.validate;
+    this.creationTime = args.creationTime;
 
     if (args.contextRoot) this.contextRoot = args.contextRoot;
     if (args.framework) this.framework = args.framework;

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -48,6 +48,7 @@ async function bindStart(req, res) {
     const language = req.sanitizeBody('language');
     const projectType = req.sanitizeBody('projectType');
     const locOnDisk = req.sanitizeBody('path');
+    const creationTime = req.sanitizeBody('creationTime');
 
     const illegalNameChars = ILLEGAL_PROJECT_NAME_CHARS.filter(char => name.includes(char));
     if (illegalNameChars.length > 0) {
@@ -84,6 +85,10 @@ async function bindStart(req, res) {
       locOnDisk: locOnDisk,
       state: Project.STATES.closed,
     };
+
+    if (creationTime) {
+      projectDetails.creationTime = creationTime;
+    }
 
     if (projectType) {
       projectDetails.projectType = projectType


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

I've added creationTime to the bind/start call. This will be added to the project object so it can be used later to emit the socket message to fw daemon.  