### PR TITLE
Add npm install step to gatekeeper

### DIFF
--- a/src/gatekeeper/Dockerfile
+++ b/src/gatekeeper/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache --update openssl
 # Create UI app directory and install source code
 WORKDIR /usr/src/app
 COPY . .
+RUN [ "npm", "i" ]
 
 # Run as the default node user from the image rather than root.
 USER 1000


### PR DESCRIPTION
https://github.com/eclipse/codewind/issues/1180

Signed-off-by: Tim Etchells <timetchells@ibm.com>

the container can run successfully now with this change