### PR TITLE
Use windows cwctl when on windows

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -101,6 +101,9 @@ OS=$(uname -a | awk '{print $1;}')
 CWCTL=./script/linux/cwctl
 if [ $OS == "Darwin" ]; then
   CWCTL=./script/darwin/cwctl
+else if [ `echo $OS | grep "_NT-10"` ]; then
+    CWCTL=./script/windows/cwctl.exe
+  fi
 fi
 
 # REMOVE PREVIOUS DOCKER PROCESSES FOR CODEWIND


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

#1085 didn't code a path for Windows to find the Windows CWCTL - this PR corrects that.