### PR TITLE
Add creation time to bind start

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -449,6 +449,11 @@ module.exports = class FileWatcher {
       if (process.env.HOST_OS === "windows") {
         pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
       }
+
+      let time = Date.now()
+      if (project.creationTime) {
+        time = project.creationTime
+      }
       const projectWatchStateId = crypto.randomBytes(16).toString("hex");
       const data = {
         changeType: "add",
@@ -456,7 +461,7 @@ module.exports = class FileWatcher {
         projectID: projectID,
         pathToMonitor: pathToMonitor,
         ignoredPaths: ignoredPaths,
-        projectCreationTime: Date.now()
+        projectCreationTime: time
       }
       let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
       await this.handleFWProjectEvent(event, projectUpdate);

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -54,6 +54,7 @@ module.exports = class Project {
     this.codewindVersion = args.codewindVersion || process.env.CODEWIND_VERSION;
     this.language = args.language;
     this.validate = args.validate;
+    this.creationTime = args.creationTime;
 
     if (args.contextRoot) this.contextRoot = args.contextRoot;
     if (args.framework) this.framework = args.framework;

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -48,6 +48,7 @@ async function bindStart(req, res) {
     const language = req.sanitizeBody('language');
     const projectType = req.sanitizeBody('projectType');
     const locOnDisk = req.sanitizeBody('path');
+    const creationTime = req.sanitizeBody('creationTime')
 
     const illegalNameChars = ILLEGAL_PROJECT_NAME_CHARS.filter(char => name.includes(char));
     if (illegalNameChars.length > 0) {
@@ -84,6 +85,10 @@ async function bindStart(req, res) {
       locOnDisk: locOnDisk,
       state: Project.STATES.closed,
     };
+
+    if (creationTime) {
+      projectDetails.creationTime = creationTime;
+    }
 
     if (projectType) {
       projectDetails.projectType = projectType


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Add creation time to bind/start so this value can be used to start monitoring the project. Part of the fix for https://github.com/eclipse/codewind/issues/1039 