### PR TITLE
Add additional label for service selector

### DIFF
--- a/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
+++ b/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh
@@ -54,6 +54,7 @@ yq w -i $deploymentFile -- spec.template.spec.serviceAccountName $SERVICE_ACCOUN
 
 # Add the labels to the service
 yq w -i $serviceFile -- metadata.labels.release $releaseName
+yq w -i $serviceFile -- spec.selector.release $releaseName
 
 # Add owner reference for deletion when workspace is deleted
 addOwnerReference $serviceFile


### PR DESCRIPTION
Add the release label to the service selector to ensure services pick out the exact pod for the project.

Related issue: https://github.com/eclipse/codewind/issues/1195

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>