### PR TITLE
Add License/Notice to Security images

### DIFF
--- a/src/gatekeeper/Dockerfile
+++ b/src/gatekeeper/Dockerfile
@@ -15,6 +15,9 @@ EXPOSE 9096 9496
 
 RUN apk add --no-cache --update openssl
 
+# Copy our license files into the new image
+COPY LICENSE NOTICE.md ./
+
 # Create UI app directory and install source code
 WORKDIR /usr/src/app
 COPY . .

--- a/src/keycloak/Dockerfile
+++ b/src/keycloak/Dockerfile
@@ -11,5 +11,8 @@
 
 FROM jboss/keycloak:latest
 
+# Copy our license files into the new image
+COPY LICENSE NOTICE.md ./
+
 COPY ./theme/  /opt/jboss/keycloak/themes/
 EXPOSE 8080 8443


### PR DESCRIPTION
# Problem

License files missing from docker images for keycloak and gatekeeper

# Solution

Add License and Notice files

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>