### PR TITLE
fix the odo project update issue

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -79,7 +79,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         let isProjectBuildRequired = false;
 
         const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-        const builtByExtension = projectHandler.builtByExtension;
+        const detectBuildByExtension = projectHandler.detectBuildByExtension;
         try {
             for (let i = 0; i < eventArrayLength; i++) {
                 if (isSettingFileChanged && isProjectBuildRequired) {
@@ -93,7 +93,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                     const data = await readFileAsync(settingsFilePath, "utf8");
                     const projectSettings = JSON.parse(data);
                     projectSpecifications.projectSpecificationHandler(projectID, projectSettings);
-                } else if (eventArray[i].path && !eventArray[i].path.includes(".cw-settings") && !builtByExtension) {
+                } else if (eventArray[i].path && !eventArray[i].path.includes(".cw-settings") && !detectBuildByExtension) {
                     logger.logProjectInfo("Detected other file changes, Codewind will build the project", projectID);
                     isProjectBuildRequired = true;
                 }
@@ -107,7 +107,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         }
 
         if (!isProjectBuildRequired) {
-            if (builtByExtension) {
+            if (detectBuildByExtension) {
                 logger.logProjectInfo("This project file changes will be ignored by Turbine. The project extension will decide if it needs to be rebuilt.", projectID);
             } else {
                 // .cw-settings file is the only changed file. return succeed status

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -79,7 +79,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         let isProjectBuildRequired = false;
 
         const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-        const detectBuildByExtension = projectHandler.detectBuildByExtension;
+        const detectChangeByExtension = projectHandler.detectChangeByExtension;
         try {
             for (let i = 0; i < eventArrayLength; i++) {
                 if (isSettingFileChanged && isProjectBuildRequired) {
@@ -93,7 +93,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                     const data = await readFileAsync(settingsFilePath, "utf8");
                     const projectSettings = JSON.parse(data);
                     projectSpecifications.projectSpecificationHandler(projectID, projectSettings);
-                } else if (eventArray[i].path && !eventArray[i].path.includes(".cw-settings") && !detectBuildByExtension) {
+                } else if (eventArray[i].path && !eventArray[i].path.includes(".cw-settings") && !detectChangeByExtension) {
                     logger.logProjectInfo("Detected other file changes, Codewind will build the project", projectID);
                     isProjectBuildRequired = true;
                 }
@@ -107,7 +107,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
         }
 
         if (!isProjectBuildRequired) {
-            if (detectBuildByExtension) {
+            if (detectChangeByExtension) {
                 logger.logProjectInfo("This project file changes will be ignored by Turbine. The project extension will decide if it needs to be rebuilt.", projectID);
             } else {
                 // .cw-settings file is the only changed file. return succeed status

--- a/src/pfe/file-watcher/server/src/projects/DockerProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/DockerProject.ts
@@ -55,7 +55,7 @@ const logsOrigin: logHelper.ILogTypes = {
 export class DockerProject implements ProjectExtension {
 
     supportedType: string;
-    detectBuildByExtension: boolean = false;
+    detectChangeByExtension: boolean = false;
 
     /**
      * @constructor

--- a/src/pfe/file-watcher/server/src/projects/DockerProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/DockerProject.ts
@@ -55,7 +55,7 @@ const logsOrigin: logHelper.ILogTypes = {
 export class DockerProject implements ProjectExtension {
 
     supportedType: string;
-    builtByExtension: boolean = false;
+    detectBuildByExtension: boolean = false;
 
     /**
      * @constructor

--- a/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
@@ -69,7 +69,7 @@ interface OdoExtensionProjectConfig {
 export class OdoExtensionProject implements IExtensionProject {
 
     supportedType: string;
-    detectBuildByExtension: boolean = false;
+    detectChangeByExtension: boolean = false;
 
     private fullPath: string;
     private config: OdoExtensionProjectConfig;

--- a/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
@@ -69,7 +69,7 @@ interface OdoExtensionProjectConfig {
 export class OdoExtensionProject implements IExtensionProject {
 
     supportedType: string;
-    builtByExtension: boolean = true;
+    detectBuildByExtension: boolean = false;
 
     private fullPath: string;
     private config: OdoExtensionProjectConfig;

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -85,7 +85,7 @@ const logsOrigin: logHelper.ILogTypes = {
 export class ShellExtensionProject implements IExtensionProject {
 
     supportedType: string;
-    builtByExtension: boolean = true;
+    detectBuildByExtension: boolean = true;
 
     private fullPath: string;
     private config: ShellExtensionProjectConfig;

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -85,7 +85,7 @@ const logsOrigin: logHelper.ILogTypes = {
 export class ShellExtensionProject implements IExtensionProject {
 
     supportedType: string;
-    detectBuildByExtension: boolean = true;
+    detectChangeByExtension: boolean = true;
 
     private fullPath: string;
     private config: ShellExtensionProjectConfig;

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -38,7 +38,7 @@ export const requiredFiles = [ "/Dockerfile | /Dockerfile-lang", "/Dockerfile-bu
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debug], [ControlCommands.restart]);
 
 export const supportedType: string = "liberty";
-export const detectBuildByExtension: boolean = false;
+export const detectChangeByExtension: boolean = false;
 
 const inContainerAppLogsDirectory = path.join(process.env.HOST_OS === "windows" ? path.join(path.sep, "tmp", "liberty") : path.join(path.sep, "home", "default", "app", "mc-target"), "liberty", "wlp", "usr", "servers", "defaultServer", "logs");
 

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -38,7 +38,7 @@ export const requiredFiles = [ "/Dockerfile | /Dockerfile-lang", "/Dockerfile-bu
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debug], [ControlCommands.restart]);
 
 export const supportedType: string = "liberty";
-export const builtByExtension: boolean = false;
+export const detectBuildByExtension: boolean = false;
 
 const inContainerAppLogsDirectory = path.join(process.env.HOST_OS === "windows" ? path.join(path.sep, "tmp", "liberty") : path.join(path.sep, "home", "default", "app", "mc-target"), "liberty", "wlp", "usr", "servers", "defaultServer", "logs");
 

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -26,7 +26,7 @@ export const requiredFiles = [ "/Dockerfile", "/package.json"];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debugNoInit], [ControlCommands.restart]);
 
 export const supportedType = "nodejs";
-export const builtByExtension: boolean = false;
+export const detectBuildByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -26,7 +26,7 @@ export const requiredFiles = [ "/Dockerfile", "/package.json"];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debugNoInit], [ControlCommands.restart]);
 
 export const supportedType = "nodejs";
-export const detectBuildByExtension: boolean = false;
+export const detectChangeByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -31,7 +31,7 @@ export const requiredFiles = [ "/Dockerfile", "/pom.xml" ];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debug, StartModes.debugNoInit], [ControlCommands.restart]);
 
 export const supportedType = "spring";
-export const detectBuildByExtension: boolean = false;
+export const detectChangeByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -31,7 +31,7 @@ export const requiredFiles = [ "/Dockerfile", "/pom.xml" ];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debug, StartModes.debugNoInit], [ControlCommands.restart]);
 
 export const supportedType = "spring";
-export const builtByExtension: boolean = false;
+export const detectBuildByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -21,7 +21,7 @@ import * as projectEventsController from "../controllers/projectEventsController
 export const requiredFiles = [ "/Dockerfile", "/Dockerfile-tools", "/Package.swift" ];
 
 export const supportedType = "swift";
-export const detectBuildByExtension: boolean = false;
+export const detectChangeByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -21,7 +21,7 @@ import * as projectEventsController from "../controllers/projectEventsController
 export const requiredFiles = [ "/Dockerfile", "/Dockerfile-tools", "/Package.swift" ];
 
 export const supportedType = "swift";
-export const builtByExtension: boolean = false;
+export const detectBuildByExtension: boolean = false;
 
 const logsOrigin: logHelper.ILogTypes = {
     "build": {


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for https://github.com/eclipse/codewind/issues/1210

Odo project cannot detect the build by the extension itself. 
Turbine needs to detect the file change and call odo cli to update the project. 

Changed the property name to be more clear: ~`detectBuildByExtension`~ `detectChangeByExtension`