### PR TITLE
Fix project and projectlist tests timing out

### DIFF
--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -10,6 +10,7 @@
 *******************************************************************************/
 global.codewind = { RUNNING_IN_K8S: false };
 const fs = require('fs-extra');
+const { execSync } = require('child_process');
 const path = require('path');
 const rewire = require('rewire');
 const chai = require('chai');
@@ -39,8 +40,9 @@ describe('Project.js', () => {
         };
         fs.ensureDirSync(global.codewind.CODEWIND_TEMP_WORKSPACE);
     });
-    after(() => {
-        fs.removeSync(global.codewind.CODEWIND_WORKSPACE);
+    after(function() {
+        this.timeout(5000);
+        execSync(`rm -rf ${global.codewind.CODEWIND_WORKSPACE}`);
     });
     describe('new Project()', () => {
         it('Initialises a new Project with minimal arguments', () => {
@@ -589,8 +591,9 @@ describe('Project.js', () => {
             fs.existsSync(path.join(tempLoadDir, 'config.json')).should.be.true;
         });
     });
-    describe('writeNewLoadTestConfigFile()', () => {
+    describe('writeNewLoadTestConfigFile()', function() {
         it('Gets test config when it does not exist (creates a new config)', async() => {
+            this.timeout(5000);
             const project = createDefaultProjectAndCheckIsAnObject();
             const tempLoadDir = path.join(global.codewind.CODEWIND_TEMP_WORKSPACE, 'writeNewLoadTestConfigFile');
             await fs.ensureDir(tempLoadDir);

--- a/test/src/unit/modules/ProjectList.test.js
+++ b/test/src/unit/modules/ProjectList.test.js
@@ -11,6 +11,7 @@
 global.codewind = { RUNNING_IN_K8S: false };
 
 const fs = require('fs-extra');
+const { execSync } = require('child_process');
 const path = require('path');
 const rewire = require('rewire');
 const assert = require('assert');
@@ -36,7 +37,7 @@ describe('ProjectList.js', () => {
     });
     after(function() {
         this.timeout(5000);
-        fs.removeSync(global.codewind.CODEWIND_WORKSPACE);
+        execSync(`rm -rf ${global.codewind.CODEWIND_WORKSPACE}`);
     });
     describe('new ProjectList()', () => {
         it('Initialises a new, empty ProjectList', () => {


### PR DESCRIPTION
### Summary
* Fixes test timeouts for file removes.
* add higher timeout for writeCWSettings command

Fixes:
```
1) Project.js
10:35:02         writeNewLoadTestConfigFile()
10:35:02           Gets test config when it does exist (reads existing config):
10:35:02       Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/genie.codewind/jenkins-agent/workspace/Codewind_codewind_PR-1167/test/src/unit/modules/Project.test.js)
10:35:02    
10:35:02  
10:35:02    2) Project.js
10:35:02         "after all" hook in "Project.js":
10:35:02       Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/genie.codewind/jenkins-agent/workspace/Codewind_codewind_PR-1167/test/src/unit/modules/Project.test.js)
10:35:02    
10:35:02  
10:35:02    3) ProjectList.js
10:35:02         "after all" hook in "ProjectList.js":
10:35:02       Error: Timeout of 5000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/genie.codewind/jenkins-agent/workspace/Codewind_codewind_PR-1167/test/src/unit/modules/ProjectList.test.js)
```

Signed-off-by: James Wallis <james.wallis1@ibm.com>