### PR TITLE
Prevent build running while project is queued

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -191,7 +191,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                 }
                 if (shouldTriggerBuild) {
                     if (projectInfo.autoBuildEnabled) {
-                        if (!statusController.isBuildInProgress(projectID)) {
+                        if (!statusController.isBuildInProgressOrQueued(projectID)) {
                             const operation = new projectOperation.Operation("update", projectInfo);
                             projectHandler.update(operation, changedFilesMap.get(projectInfo.projectID));
                         } else {
@@ -216,7 +216,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
             const timer = setTimeout(async () => {
                 try {
                     if (projectInfo.autoBuildEnabled) {
-                        if (!statusController.isBuildInProgress(projectID)) {
+                        if (!statusController.isBuildInProgressOrQueued(projectID)) {
                             const operation = new projectOperation.Operation("update", projectInfo);
                             projectHandler.update(operation, changedFilesMap.get(projectInfo.projectID));
                         } else {

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -568,8 +568,8 @@ function pingInTransitApplications(): void {
  *
  * @returns boolean
  */
-export function isBuildInProgress(projectID: string): boolean {
-    if (buildStateMap.has(projectID) && buildStateMap.get(projectID).state == BuildState.inProgress)
+export function isBuildInProgressOrQueued(projectID: string): boolean {
+    if (buildStateMap.has(projectID) && (buildStateMap.get(projectID).state == BuildState.inProgress || buildStateMap.get(projectID).state == BuildState.queued))
         return true;
     else
         return false;

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -48,8 +48,6 @@ const fileStatAsync = promisify(fs.stat);
 
 const projectInfoCache = {} as ProjectInfoCache;
 
-const projectList = new Map();
-
 let buildQueue: Array<BuildQueueType> = [];
 let runningBuilds: Array<BuildQueueType> = [];
 const MAX_BUILDS = parseInt(process.env.MC_MAX_BUILDS) || 3;

--- a/src/pfe/file-watcher/server/src/projects/actions.ts
+++ b/src/pfe/file-watcher/server/src/projects/actions.ts
@@ -140,7 +140,7 @@ async function enableAndBuild(projectInfo: ProjectInfo): Promise<void> {
         logger.logProjectInfo("Build required is true on switch to auto build enabled so start or queue build", projectID, projectName);
         statusController.buildRequired(projectInfo.projectID, false);
         try {
-            if (!statusController.isBuildInProgress(projectInfo.projectID)) {
+            if (!statusController.isBuildInProgressOrQueued(projectInfo.projectID)) {
                 logger.logProjectInfo("Start build on switch to auto build enabled", projectID, projectName);
                 const operation = new Operation("update", projectInfo);
                 await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, projectID, statusController.BuildState.inProgress, "action.calculateDifference");
@@ -226,7 +226,7 @@ export const build = async function (args: IProjectActionParams): Promise<{ oper
         error.name = "FILE_NOT_EXIST";
         throw error;
     }
-    if (!statusController.isBuildInProgress(args.projectID)) {
+    if (!statusController.isBuildInProgressOrQueued(args.projectID)) {
         await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, args.projectID, statusController.BuildState.inProgress, "action.calculateDifference");
         const operation = new Operation("update", projectInfo);
         const intervaltimer = setInterval(() => {
@@ -315,7 +315,7 @@ export const restart = async function(args: IProjectActionParams): Promise<{ ope
         error.name = "BAD_REQUEST";
         throw error;
     }
-    if (statusController.isBuildInProgress(args.projectID)) {
+    if (statusController.isBuildInProgressOrQueued(args.projectID)) {
         const error = new Error("Restart is invalid when the project is building.");
         error.name = "BAD_REQUEST";
         throw error;

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectStatusController.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectStatusController.test.ts
@@ -128,7 +128,7 @@ export function projectStatusControllerTestModule(): void {
                     } else if (data.type === projectStatusController.STATE_TYPES.buildState) {
                         const buildStateResult = await projectStatusController.getBuildState(projectID);
                         expect(buildStateResult).to.equal(data.buildStatus);
-                        const isBuildInProgress = await projectStatusController.isBuildInProgress(projectID);
+                        const isBuildInProgress = await projectStatusController.isBuildInProgressOrQueued(projectID);
                         expect(isBuildInProgress).to.equal(true);
                     }
                 }
@@ -170,7 +170,7 @@ export function projectStatusControllerTestModule(): void {
                 expect(buildRequired).to.equal(true);
                 const getBuildRequired = await projectStatusController.isBuildRequired(projectID);
                 expect(getBuildRequired).to.equal(true);
-                const getIsBuildInProgress = await projectStatusController.isBuildInProgress(projectID);
+                const getIsBuildInProgress = await projectStatusController.isBuildInProgressOrQueued(projectID);
                 expect(getIsBuildInProgress).to.equal(false);
             });
     });


### PR DESCRIPTION
Related to #1161 this fixes the problem where an update build is running while the create is still scheduled on the build queue.
Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>