### PR TITLE
Update IDC for Win check - master

### DIFF
--- a/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDC.java
+++ b/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/IDC.java
@@ -542,7 +542,7 @@ public class IDC {
 		StatusTracker.updateProjectState(context, "app", "starting", null, null);
 		
 
-		String logPathPrefix = HOST_OS.contains("windows") ? "/tmp/liberty/" : "/home/default/app/mc-target/";
+		String logPathPrefix = context.isWin() ? "/tmp/liberty/" : "/home/default/app/mc-target/";
 		String messagesLog = logPathPrefix + "liberty/wlp/usr/servers/defaultServer/logs/messages.log";
 		Logger.info("Touching application messages log: " + messagesLog);
 		boolean logFileTouched = BuildApplicationTask.touchLogFile(curRunCmd, messagesLog, context);


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

Issue https://github.com/eclipse/codewind/issues/1222

An update on Windows performs mvn package because of the wrong Win condition check.