### PR TITLE
add new injectMetrics variable

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -99,6 +99,9 @@ module.exports = class Project {
     if (args.hasOwnProperty('autoBuild')) {
       this.autoBuild = args.autoBuild;
     }
+
+    // Default the injection of monitoring to be off
+    this.injectMetrics = false;
   }
 
   toJSON() {


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

As part of the work to provided monitoring without the developer manually adding the required packages, this change will provide a project setting that can be used to toggle the injection of metrics on / off