### PR TITLE
Add a CODEOWNERS file for Codewind

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Global owners
+* @elsony @tobespc
+
+# Docs
+docs/** @elsony @tobespc
+
+# Releng
+script/** @josephca @tetchel 
+
+# Iterative dev
+src/pfe/file-watcher/** @elsony @rajivnathan
+src/pfe/iterative-dev/** @elsony @rajivnathan
+
+# Portal
+src/pfe/portal/** @hhellyer @tobespc
+src/gatekeeper/** @markcor11 @tobespc 
+src/keycloak/** @markcor11 @tobespc 
+src/performance/** @markcor11 @tobespc 
+test/** @stalleyj @tobespc


### PR DESCRIPTION
Creating a CODEOWNERS file to automatically add review requests for specific areas of the code.

This does not require an approval from one of the CODEOWNERS at this time. An approval from any committer will still allow the PR to be merged.