### PR TITLE
trigger build on metrics injection

### DIFF
--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -140,7 +140,7 @@ module.exports.convertFromWindowsDriveLetter = function convertFromWindowsDriveL
  */
 module.exports.forceRemove = async function forceRemove(path) {
   try {
-    await exec(`rm -rf ${path}`);
+    await exec(`rm -rf "${path}"`);
   }
   catch (err) {
     log.warn(err.message);

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -169,3 +169,34 @@ function isLetter(currentChar) {
   return ("a" <= currentChar && currentChar <= "z")
       || ("A" <= currentChar && currentChar <= "Z");
 }
+
+module.exports.getProjectSourceRoot = function getProjectSourceRoot(project) {
+  let projectRoot = "";
+  switch (project.projectType) {
+  case 'nodejs': {
+    projectRoot = "/app";
+    break
+  }
+  case 'liberty': {
+    projectRoot = "/home/default/app";
+    break
+  }
+  case 'swift': {
+    projectRoot = "/swift-project";
+    break
+  }
+  case 'spring': {
+    projectRoot = "/root/app";
+    break
+  }
+  case 'docker': {
+    projectRoot = "/code";
+    break
+  }
+  default: {
+    projectRoot = "/";
+    break
+  }
+  }
+  return projectRoot;
+}

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -194,8 +194,6 @@ router.post('/api/v1/projects/:id/metrics/inject', validateReq, async function (
     // We now need to synch files in to the build container
     copyProjectToBuild(project);
 
-    user.buildProject(project, "build");
-
     res.sendStatus(202);
 
   } catch (err) {
@@ -213,6 +211,7 @@ async function copyProjectToBuild(project){
       globalProjectPath,
       projectRoot
     );
+    user.buildProject(project, "build");
   } else {
     // if a build is in progress, wait 5 seconds and try again
     await cwUtils.timeout(5000)

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -192,7 +192,7 @@ router.post('/api/v1/projects/:id/metrics/inject', validateReq, async function (
 
     await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
     // We now need to synch files in to the build container
-    copyProjectToBuild(project);
+    copyProjectToBuild(project, user);
 
     res.sendStatus(202);
 
@@ -202,7 +202,7 @@ router.post('/api/v1/projects/:id/metrics/inject', validateReq, async function (
   }
 });
 
-async function copyProjectToBuild(project){
+async function copyProjectToBuild(project, user){
   const globalProjectPath = path.join(project.workspace, project.name);
   const projectRoot = cwUtils.getProjectSourceRoot(project);
   if (project.buildStatus != "inProgress") {

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -211,7 +211,7 @@ async function copyProjectToBuild(project){
       globalProjectPath,
       projectRoot
     );
-    user.buildProject(project, "build");
+    await user.buildProject(project, "build");
   } else {
     // if a build is in progress, wait 5 seconds and try again
     await cwUtils.timeout(5000)

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -192,7 +192,7 @@ router.post('/api/v1/projects/:id/metrics/inject', validateReq, async function (
 
     await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
     // We now need to synch files in to the build container
-    await copyProjectToBuild(project);
+    copyProjectToBuild(project);
 
     user.buildProject(project, "build");
 

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -228,7 +228,9 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
           await deleteFilesInArray(pathToProj, filesToDelete);
         }
         res.sendStatus(200);
-
+ 
+        await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
+ 
         if (project.injectMetrics) {
           try {
             await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
@@ -236,7 +238,7 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
             log.warn(error);
           }
         }
-        await syncToBuildContainer(project, filesToDelete, pathToTempProj, modifiedList, timeStamp, IFileChangeEvent, user, projectID);
+        await syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID);
         timersyncend = Date.now();
         let timersynctime = (timersyncend - timersyncstart) / 1000;
         log.info(`Total time to sync project ${project.name} to build container is ${timersynctime} seconds`);
@@ -269,16 +271,14 @@ function getMode(project) {
   return (project.extension && project.extension.config.needsMount) ? "777" : "";
 }
 
-async function syncToBuildContainer(project, filesToDelete, pathToTempProj, modifiedList, timeStamp, IFileChangeEvent, user, projectID) {
+async function syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID) {
   // If the current project is being built, we do not want to copy the files as this will
   // interfere with the current build
   if (project.buildStatus != "inProgress") {
     const globalProjectPath = path.join(project.workspace, project.name);
     // We now need to remove any files that have been deleted from the global workspace
     await Promise.all(filesToDelete.map(oldFile => cwUtils.forceRemove(path.join(globalProjectPath, oldFile))));
-    // now move temp project to real project
-    await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
-    let projectRoot = getProjectSourceRoot(project);
+    let projectRoot = cwUtils.getProjectSourceRoot(project);
     // need to delete from the build container as well
     if (!global.codewind.RUNNING_IN_K8S && project.projectType != 'docker' &&
       (!project.extension || !project.extension.config.needsMount)) {
@@ -314,7 +314,7 @@ async function syncToBuildContainer(project, filesToDelete, pathToTempProj, modi
   } else {
     // if a build is in progress, wait 5 seconds and try again
     await cwUtils.timeout(5000)
-    await syncToBuildContainer(project, filesToDelete, pathToTempProj, modifiedList, timeStamp, IFileChangeEvent, user, projectID);
+    await syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID);
   }
 }
 
@@ -339,39 +339,6 @@ async function listFilesInDirectory(absolutePath, relativePath = '') {
   }
   return fileList;
 }
-
-function getProjectSourceRoot(project) {
-  let projectRoot = "";
-  switch (project.projectType) {
-  case 'nodejs': {
-    projectRoot = "/app";
-    break
-  }
-  case 'liberty': {
-    projectRoot = "/home/default/app";
-    break
-  }
-  case 'swift': {
-    projectRoot = "/swift-project";
-    break
-  }
-  case 'spring': {
-    projectRoot = "/root/app";
-    break
-  }
-  case 'docker': {
-    projectRoot = "/code";
-    break
-  }
-  default: {
-    projectRoot = "/";
-    break
-  }
-  }
-  return projectRoot;
-}
-
-
 
 /**
  * API Function to complete binding a given project on a file system visible

--- a/test/package.json
+++ b/test/package.json
@@ -59,8 +59,12 @@
   },
   "nyc": {
     "cwd": "../src/pfe/portal",
-    "reporter": ["html", "text", "text-summary"],
+    "reporter": [
+      "html",
+      "text",
+      "text-summary"
+    ],
     "report-dir": "../../../test/coverage",
-    "temp-directory": "../../../test/coverage/.nyc_output" 
+    "temp-directory": "../../../test/coverage/.nyc_output"
   }
 }

--- a/test/src/unit/modules/utils/sharedFunctions.test.js
+++ b/test/src/unit/modules/utils/sharedFunctions.test.js
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+global.codewind = { RUNNING_IN_K8S: false };
+const fs = require('fs-extra');
+const path = require('path');
+const rewire = require('rewire');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+const sharedFunctions = rewire('../../../../../src/pfe/portal/modules/utils/sharedFunctions');
+
+const { suppressLogOutput } = require('../../../../modules/log.service');
+
+chai.use(chaiAsPromised);
+chai.should();
+
+const testDirectory = path.join(__dirname, 'sharedFunctionsTest');
+
+describe('sharedFunctions.js', () => {
+    suppressLogOutput(sharedFunctions);
+    describe('forceRemove(path)', () => {
+        beforeEach(() => {
+            fs.ensureDirSync(testDirectory);
+        });
+        after(() => {
+            fs.removeSync(testDirectory);
+        });
+        it('deletes a file', async() => {
+            const testFile = path.join(testDirectory, 'testFile');
+            await fs.ensureFile(testFile);
+            await sharedFunctions.forceRemove(testFile);
+            return fs.pathExists(testFile).should.eventually.be.false;
+        });
+        it('deletes a file which has a space in its name', async() => {
+            const testFile = path.join(testDirectory, 'test File');
+            await fs.ensureFile(testFile);
+            await sharedFunctions.forceRemove(testFile);
+            return fs.pathExists(testFile).should.eventually.be.false;
+        });
+        it('deletes an empty folder', async() => {
+            const testFile = path.join(testDirectory, 'testDir');
+            await fs.ensureDir(testFile);
+            await sharedFunctions.forceRemove(testFile);
+            return fs.pathExists(testFile).should.eventually.be.false;
+        });
+        it('deletes an empty folder which has a space in its name', async() => {
+            const testFile = path.join(testDirectory, 'test Dir');
+            await fs.ensureDir(testFile);
+            await sharedFunctions.forceRemove(testFile);
+            return fs.pathExists(testFile).should.eventually.be.false;
+        });
+        it('deletes a folder which has contents', async() => {
+            const testFile = path.join(testDirectory, 'testDir/something/file');
+            await fs.ensureDir(testFile);
+            await sharedFunctions.forceRemove(testFile);
+            return fs.pathExists(testFile).should.eventually.be.false;
+        });
+    });
+});

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+global.codewind = { RUNNING_IN_K8S: false };
+const fs = require('fs-extra');
+const path = require('path');
+const rewire = require('rewire');
+const chai = require('chai');
+const chaiFiles = require('chai-files');
+const chaiPromise = require('chai-as-promised');
+
+const RemoteBind = rewire('../../../../../src/pfe/portal/routes/projects/remoteBind.route');
+
+const { suppressLogOutput } = require('../../../../modules/log.service');
+
+chai.should();
+chai.use(chaiFiles);
+chai.use(chaiPromise);
+const { file: chaiFile, dir: chaiDir } = chaiFiles;
+
+const testDirectory = path.join(__dirname, 'remoteBindRouteTest');
+
+describe('remoteBind.route.js', () => {
+    suppressLogOutput(RemoteBind);
+    describe('getFilesToDelete(existingFileArray, newFileArray)', () => {
+        const getFilesToDelete = RemoteBind.__get__('getFilesToDelete');
+        it('returns an array of files to be deleted', () => {
+            const existingFileArray = ['package.json', 'package.lock'];
+            const newFileArray = ['package.json'];
+            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            filesToDelete.length.should.equal(1);
+            filesToDelete.should.deep.equal(['package.lock']);
+        });
+        it('returns an empty array of files to be deleted as both existing files are also in the new file array', () => {
+            const existingFileArray = ['package.json', 'package.lock'];
+            const filesToDelete = getFilesToDelete(existingFileArray, existingFileArray);
+            filesToDelete.length.should.equal(0);
+            filesToDelete.should.deep.equal([]);
+        });
+        it('returns an empty array as no files are given', () => {
+            const filesToDelete = getFilesToDelete([], []);
+            filesToDelete.length.should.equal(0);
+            filesToDelete.should.deep.equal([]);
+        });
+        it('returns an empty array as atleast all the new files exist in the existingFileArray', () => {
+            const existingFileArray = ['package.json'];
+            const newFileArray = ['package.json', 'package.lock'];
+            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            filesToDelete.length.should.equal(0);
+            filesToDelete.should.deep.equal([]);
+        });
+    });
+    describe('deleteFilesInArray(directory, arrayOfFiles)', () => {
+        const deleteFilesInArray = RemoteBind.__get__('deleteFilesInArray');
+        const testFileArray = ['package.json', 'server.js', 'dir/file', 'dir/anotherfile', 'anotherdir/file'];
+        beforeEach(async() => {
+            await createFilesFromArray(testDirectory, testFileArray);
+        });
+        afterEach(() => {
+            fs.removeSync(testDirectory);
+        });
+        it('should delete no files on disk as an empty array is given', async() => {
+            assertFilesExist(testDirectory, testFileArray);
+            await deleteFilesInArray(testDirectory, []);
+            assertFilesExist(testDirectory, testFileArray);
+        });
+        it('should delete all files on disk as the whole testFileArray is given but leave the directory', async() => {
+            assertFilesExist(testDirectory, testFileArray);
+            await deleteFilesInArray(testDirectory, testFileArray);
+            assertFilesDoNotExist(testDirectory, testFileArray);
+        });
+        it('should delete the files in the testFileArray but leave the directories in place', async() => {
+            assertFilesExist(testDirectory, testFileArray);
+            await deleteFilesInArray(testDirectory, testFileArray);
+            assertFilesDoNotExist(testDirectory, testFileArray);
+            chaiDir(testDirectory).should.not.be.empty;
+        });
+    });
+    describe('listFilesInDirectory(absolutePath, relativePath)', () => {
+        const listFilesInDirectory = RemoteBind.__get__('listFilesInDirectory');
+        const testFileArray = ['dir/file', 'dir/anotherfile', 'dir/dirinanother/file', 'anotherdir/file', 'anotherdir/anotherfile'];
+        beforeEach(async() => {
+            const promiseArray = testFileArray.map(file => {
+                return fs.ensureFile(path.join(testDirectory, file));
+            });
+            await Promise.all(promiseArray);
+        });
+        afterEach(() => {
+            fs.removeSync(testDirectory);
+        });
+        it('should recursively list all files in testFileArray', async() => {
+            const filesInDirectory = await listFilesInDirectory(testDirectory, '');
+            filesInDirectory.length.should.equal(testFileArray.length);
+            filesInDirectory.should.have.members(testFileArray);
+        });
+        it('should recursively list all files in directory testDirectory/anotherdir', async() => {
+            const filesInDirectory = await listFilesInDirectory(path.join(testDirectory, 'anotherdir'), '');
+            filesInDirectory.length.should.equal(2);
+            filesInDirectory.should.have.members(['file', 'anotherfile']);
+        });
+        it('should recursively list all files in directory testDirectory/dir (two levels of recursion)', async() => {
+            const filesInDirectory = await listFilesInDirectory(path.join(testDirectory, 'dir'), '');
+            filesInDirectory.length.should.equal(3);
+            filesInDirectory.should.have.members(['file', 'anotherfile', 'dirinanother/file']);
+        });
+        it('should be rejected as directory does not exist', () => {
+            return listFilesInDirectory('', '').should.be.rejected;
+        });
+        it('returns an array which equals testFileArray as all the files should be listed in the directory', async() => {
+            const filesInDirectory = await listFilesInDirectory(path.join(testDirectory, 'dir/dirinanother'));
+            filesInDirectory.length.should.equal(1);
+            filesInDirectory.should.have.members(['file']);
+        });
+    });
+});
+
+function createFilesFromArray(directory, fileArray) {
+    const promiseArray = fileArray.map(file => {
+        return fs.ensureFile(path.join(directory, file));
+    });
+    return Promise.all(promiseArray);
+}
+
+function assertFilesExist(directory, fileArray) {
+    for (let i = 0; i < fileArray.length; i++) {
+        const relativePath = fileArray[i];
+        const absolutePath = path.join(directory, relativePath);
+        chaiFile(absolutePath).should.exist;
+    }
+}
+
+function assertFilesDoNotExist(directory, fileArray) {
+    for (const relativePath of fileArray) {
+        const absolutePath = path.join(directory, relativePath);
+        chaiFile(absolutePath).should.not.exist;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

When the injection api is called to either enable of disable the injection, we need to trigger a build straight away. This will require the project code in the pfe container to be synced to the build container and a build then triggered