### PR TITLE
Don't error when the container isn't available

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -166,11 +166,13 @@ const changeInternalPort = async function (applicationPort: string, operation: O
     }
 
     try {
+        let isContainerRunning: boolean = true;
         let isApplicationPortExposed: boolean = false;
 
         // Check if the port requested has been exposed
         if (process.env.IN_K8) {
             const containerInfo: any = await projectUtil.getContainerInfo(projectInfo, true);
+            isContainerRunning = containerInfo.podName.trim().length > 0;
             for (let i = 0; i < containerInfo.podPorts.length; i++) {
                 const port = containerInfo.podPorts[i];
 
@@ -181,6 +183,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             }
         } else {
             const containerInfo: any = await projectUtil.getContainerInfo(projectInfo, true);
+            isContainerRunning = containerInfo.containerId.trim().length > 0;
             for (let i = 0; i < containerInfo.containerPorts.length; i++) {
                 const port = containerInfo.containerPorts[i];
 
@@ -191,7 +194,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             }
         }
 
-        if (!isApplicationPortExposed) {
+        if (isContainerRunning && !isApplicationPortExposed) {
             logger.logProjectInfo("The requested application port is not exposed: " + applicationPort, projectInfo.projectID);
             const data: ProjectSettingsEvent = {
                 operationId: operation.operationId,

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -236,7 +236,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             status: "success",
             ports: {
                 exposedPort: containerInfo.exposedPort,
-                internalPort: containerInfo.internalPort
+                internalPort: applicationPort
             }
         };
 

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectSettings.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectSettings.module.test.ts
@@ -28,6 +28,8 @@ export function projectSettingsTestModule(): void {
     let internalPortStatus = "";
     let projectSettingsStatus = "";
 
+    let internalPortValue = "";
+
     socket.registerListener({
         name: "codewindunittest",
         handleEvent: (event, data) => {
@@ -42,10 +44,14 @@ export function projectSettingsTestModule(): void {
                     mavenPropertiesStatus = data.status;
                 } else if (data.ignoredPaths || (data.error && data.error.includes("ignoredPaths"))) {
                     ignoredPathsStatus = data.status;
-                } else if ((data.ports && data.ports.internalDebugPort)) {
-                    internalDebugPortStatus = data.status;
-                } else if ((data.ports && data.ports.internalPort)) {
-                    internalPortStatus = data.status;
+                } else if (data.ports) {
+                    if (data.ports.internalDebugPort) {
+                        internalDebugPortStatus = data.status;
+                    }
+                    if (data.ports.internalPort) {
+                        internalPortValue = data.ports.internalPort;
+                        internalPortStatus = data.status;
+                    }
                 } else {
                     projectSettingsStatus = data.status;
                 }
@@ -148,21 +154,31 @@ export function projectSettingsTestModule(): void {
         const combinations: any = {
             "combo1": {
                 "internalPortSettings": {
+                    "internalPort": ""
+                },
+                "expectedPortValue": "",
+                "result": ""
+            },
+            "combo2": {
+                "internalPortSettings": {
                     "internalPort": "1234"
                 },
-                "result": "failed"
+                "expectedPortValue": "1234",
+                "result": "success"
             }
         };
 
         for (const combo of Object.keys(combinations)) {
             const internalPortSettings = combinations[combo]["internalPortSettings"];
             const expectedResult = combinations[combo]["result"];
+            const expectedPortValue = combinations[combo]["expectedPortValue"];
 
             it(combo + " => internalPortSettings: " + JSON.stringify(internalPortSettings), async () => {
                 const projectID: string = "dummynodeproject";
 
                 await projectSettings.projectSpecificationHandler(projectID, internalPortSettings);
                 expect(internalPortStatus).to.equal(expectedResult);
+                expect(internalPortValue).to.equal(expectedPortValue);
             });
         }
     });


### PR DESCRIPTION
Related issue #1248. The error will always be seen if the container is not running. The container checks are mainly a safeguard to provide an error to the user when they try to change to a port that is not exposed. However, if there is no container we cannot assert whether it's exposed so we should not error. The fix ensures a container is running before proceeding with the container checks. If the container is not running it allows the setting to persist.

Signed-off-by: Rajiv Senthilnathan <rajivsen@ca.ibm.com>