### PR TITLE
Set Keycloak to V8.0.0

### DIFF
--- a/src/keycloak/Dockerfile
+++ b/src/keycloak/Dockerfile
@@ -9,7 +9,7 @@
 #     IBM Corporation - initial API and implementation
 ################################################################################
 
-FROM jboss/keycloak:latest
+FROM jboss/keycloak:8.0.0
 
 # Copy our license files into the new image
 COPY LICENSE NOTICE.md ./


### PR DESCRIPTION

## Problem 

Keycloak fails to start with latest (8.0.1) docker image

## Solution : 

Sets base image version of keycloak to V8.0.0

Resolves Keycloak startup problem  : 

```

  | Added 'admin' to '/opt/jboss/keycloak/standalone/configuration/keycloak-add-user.json', restart server to load user
-- | --
  | /opt/jboss/tools/docker-entrypoint.sh: line 47: KEYCLOAK_FRONTEND_URL: unbound variable
```



Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>