### PR TITLE
restruct the projectStatusChanged event for app status

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -62,7 +62,7 @@ class ProjectState {
     lastbuild?: number;
     appImageLastBuild?: string;
     buildImageLastBuild?: string;
-    detailedAppStatus?: string;
+    detailedAppStatus?: DetailedAppStatus;
 
     /**
      * @constructor
@@ -73,9 +73,9 @@ class ProjectState {
      * @param lastbuild <Optional | Number> - The timestamp of the last build.
      * @param appImageLastBuild <Optional | String> - The last app image info.
      * @param buildImageLastBuild <Optional | String> - The last build image info.
-     * @param detailedAppStatus <Optional | String> - The detailed app status to update.
+     * @param detailedAppStatus <Optional | DetailedAppStatus> - The detailed app status to update.
      */
-    constructor(state: any, msg: string, lastbuild?: number, appImageLastBuild?: string, buildImageLastBuild?: string, detailedAppStatus?: string) {
+    constructor(state: any, msg: string, lastbuild?: number, appImageLastBuild?: string, buildImageLastBuild?: string, detailedAppStatus?: DetailedAppStatus) {
         this.state = state;
         this.msg = msg;
         if (lastbuild)
@@ -175,7 +175,7 @@ export async function updateStatus(req: IUpdateStatusParams): Promise<IUpdateSta
  * @param type <Required | String> - The status type. Supported types include: 'appState' and 'buildState'.
  * @param projectID <Required | String> - An alphanumeric identifier for a project.
  * @param status <Required | String> - The states for appState and buildState.
- * @param detailedAppStatus <Optional | String> - The detailed app status to update.
+ * @param detailedAppStatus <Optional | DetailedAppStatus> - The detailed app status to update.
  * @param msg <Required | String> - The new message to update.
  * @param appImageLastBuild <Optional | String> - The last app image timestamp.
  * @param buildImageLastBuild <Optional | String> - The last build image timestamp.
@@ -183,16 +183,16 @@ export async function updateStatus(req: IUpdateStatusParams): Promise<IUpdateSta
  *
  * @returns Promise<void>
  */
-export async function updateProjectStatus(type: string, projectID: string, status: string, msg: string, appImageLastBuild?: string, buildImageLastBuild?: string, translatedMsg?: string, detailedAppStatus?: string): Promise<void> {
+export async function updateProjectStatus(type: string, projectID: string, status: string, msg: string, appImageLastBuild?: string, buildImageLastBuild?: string, translatedMsg?: string, detailedAppStatus?: DetailedAppStatus): Promise<void> {
 
     if (type == STATE_TYPES.appState) {
 
         const newState: string = status;
-        const newError = msg;
+        let newError = msg;
         const newDetailedState = detailedAppStatus;
         let oldState: AppState = AppState.unknown;
         let oldError = AppState.unknown;
-        let oldDetailedState = AppState.unknown;
+        let oldDetailedState = undefined;
 
         if (appStateMap.has(projectID)) {
             oldState = appStateMap.get(projectID).state;
@@ -203,8 +203,12 @@ export async function updateProjectStatus(type: string, projectID: string, statu
         // Only update if the state or message has changed. Also protect against changing from stopped state to stopping.
         // Also protect against changing from unknown state to stopped. For first time project creation, app status should be unknown before it's changed to starting state.
         if ((newState != oldState || newDetailedState != oldDetailedState || newError != oldError) && !(oldState == AppState.stopped && newState == AppState.stopping) && !(oldState == AppState.unknown && newState == AppState.stopped)) {
-            logger.logProjectInfo("Application state changed for project: " + projectID + " from: " + oldState + ", to: " + newState + (newDetailedState ? ", with message: " + newDetailedState : ""), projectID);
-            appStateMap.set(projectID, new ProjectState(newState, newError, undefined, undefined, undefined, newDetailedState));
+            logger.logProjectInfo("Application state changed for project: " + projectID + " from: " + oldState + ", to: " + newState + (newDetailedState ? ", with message: " + newDetailedState.message : ""), projectID);
+
+            // Delete the project from the array to show the next ping message
+            if (newState === AppState.starting && newState !== oldState && projectUtil.firstTimePingArray.indexOf(projectID) > -1) {
+                projectUtil.firstTimePingArray.splice(projectUtil.firstTimePingArray.indexOf(projectID), 1);
+            }
 
             const data: any = {
                 projectID: projectID,
@@ -212,16 +216,24 @@ export async function updateProjectStatus(type: string, projectID: string, statu
             };
 
             if (translatedMsg) {
-                data.appErrorStatus = translatedMsg;
-            }
-
-            else if (newError) {
-                data.appErrorStatus = (newError == " ") ? newError : await locale.getTranslation(newError);
+                newError = translatedMsg;
+            } else if (newError) {
+                newError = (newError == " ") ? undefined : await locale.getTranslation(newError);
             }
 
             if (newDetailedState) {
                 data.detailedAppStatus = newDetailedState;
             }
+            else if (newError) {
+                data.detailedAppStatus = {
+                    severity: "ERROR",
+                    message: newError,
+                    notify: false
+                };
+            }
+            appStateMap.set(projectID, new ProjectState(newState, newError, undefined, undefined, undefined, (data.detailedAppStatus) ? data.detailedAppStatus : appStateMap.get(projectID).detailedAppStatus ));
+
+
             io.emitOnListener("projectStatusChanged", data);
         }
     } else if (type == STATE_TYPES.buildState) {
@@ -378,7 +390,7 @@ function pingApplications(): void {
     appStateMap.forEach((stateObj, projectID) => {
         const currentState = stateObj.state;
         if (currentState === AppState.started || currentState === AppState.stopped || currentState === AppState.unknown) {
-            projectUtil.isApplicationUp(projectID, (stateInfo: any) => {
+            projectUtil.isApplicationUp(projectID, async (stateInfo: any) => {
                 if (appStateMap.get(projectID)) {
                     const oldState = appStateMap.get(projectID).state;
                     if (oldState !== AppState.started && oldState !== AppState.stopped && oldState !== AppState.unknown) {
@@ -392,23 +404,36 @@ function pingApplications(): void {
                         newState = stateInfo.isAppUp ? AppState.started : AppState.stopped;
                     } else if (newMsg) {
                         newState = AppState.stopped;
+                        pingCountMap.delete(projectID);
                     }
                     // Protect against changing from unknown state to stopped. For first time project creation, app status should be unknown before it's changed to starting state.
                     if (!(oldState == AppState.unknown && newState == AppState.stopped)) {
-                        appStateMap.set(projectID, new ProjectState(newState, newMsg));
-
-                        // Ensure that only new messages are logged
-                        if (newMsg && (newMsg.toString() !== (oldMsg ? oldMsg.toString() : oldMsg))) {
-                            logger.logProjectInfo("pingApplications: Application state error message: " + newMsg, projectID);
+                        let shouldEmitMsg: boolean = false;
+                        // Ensure that only new messages are emitted and logged
+                        if (newMsg && (newMsg.toString().trim() !== (oldMsg ? oldMsg.toString().trim() : oldMsg))) {
+                            logger.logProjectInfo("pingInTransitApplications: Application state error message: " + newMsg, projectID);
+                            shouldEmitMsg = true;
                         }
 
-                        // Update the state only if it has changed
-                        if (newState != oldState) {
+                        // Update the state only if it has changed or newMsg has been received
+                        if (newState != oldState || shouldEmitMsg) {
                             logger.logProjectInfo("pingApplications: Application state for project " + projectID + " has changed from " + oldState + " to " + newState, projectID);
                             const data: any = {
                                 projectID: projectID,
                                 appStatus: newState
                             };
+                            if (shouldEmitMsg) {
+                                let translatedMsg;
+                                if (newMsg) {
+                                    translatedMsg = (newMsg.trim().length === 0) ? newMsg : await locale.getTranslation(newMsg);
+                                }
+                                data.detailedAppStatus = {
+                                    severity: "ERROR",
+                                    message: translatedMsg,
+                                    notify: false
+                                };
+                            }
+                            appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, (data.detailedAppStatus) ? data.detailedAppStatus : appStateMap.get(projectID).detailedAppStatus));
                             io.emitOnListener("projectStatusChanged", data);
                         }
                     }
@@ -444,6 +469,8 @@ function pingInTransitApplications(): void {
                                 let newState = oldState;
                                 let newMsg = stateInfo.error;
                                 let pingCount = pingCountMap.get(projectID);
+                                // 30 pings = 1 min timeout
+                                const pingCountLimit = 30;
                                 if (newMsg) { newMsg = newMsg.toString(); } // Convert from Error to string
                                 if (stateInfo.hasOwnProperty("isAppUp")) {
                                     if (oldState === AppState.starting && stateInfo.isAppUp) {
@@ -462,41 +489,53 @@ function pingInTransitApplications(): void {
                                     }
                                 } else if (oldState === AppState.stopping && newMsg) {
                                     newState = AppState.stopped;
+                                    pingCountMap.delete(projectID);
                                 }
-                                if (pingCount >= 10) {
-                                    newState = AppState.stopped;
+                                if (pingCount == pingCountLimit) {
                                     newMsg = "projectStatusController.pingTimeout";
                                 }
 
-                                if (newState === AppState.started) {
-                                    appStateMap.set(projectID, new ProjectState(newState, newMsg));
-                                } else {
-                                    const detailedAppStatus = appStateMap.get(projectID).detailedAppStatus;
-                                    appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, detailedAppStatus));
-                                }
-
-                                // Ensure that only new messages are logged
-                                if (newMsg && (newMsg.toString() !== (oldMsg ? oldMsg.toString() : oldMsg))) {
+                                let shouldEmitMsg: boolean = false;
+                                 // Ensure that only new messages are emitted and logged
+                                if (newMsg && (newMsg.toString().trim() !== (oldMsg ? oldMsg.toString().trim() : oldMsg))) {
                                     logger.logProjectInfo("pingInTransitApplications: Application state error message: " + newMsg, projectID);
+                                    shouldEmitMsg = true;
                                 }
-
                                 // Update the state only if it has changed
-                                if (newState !== oldState || ((newState === AppState.starting) && pingCount >= 10)) {
+                                // first time reach the timeout, will not emit the same message when timeout exceeds.
+                                if (newState !== oldState || shouldEmitMsg || ((newState === AppState.starting) && pingCount == pingCountLimit)) {
                                     logger.logProjectInfo("pingInTransitApplications: Application state for project " + projectID + " has changed from " + oldState + " to " + newState, projectID);
                                     const data: any = {
                                         projectID: projectID,
                                         appStatus: newState
                                     };
-
-                                    if (newState === AppState.started) {
-                                        data.detailedAppStatus = " ";
-                                    }
+                                    let translatedMsg;
                                     if (newMsg) {
-                                        data.appErrorStatus = (newMsg.trim().length === 0) ? newMsg : await locale.getTranslation(newMsg);
+                                        translatedMsg = (newMsg.trim().length === 0) ? newMsg : await locale.getTranslation(newMsg);
                                     }
-
+                                    if (newState === AppState.started) {
+                                        data.detailedAppStatus = {
+                                            severity: "INFO",
+                                            message: "Application started.",
+                                            notify: false
+                                        };
+                                        pingCountMap.delete(projectID);
+                                    } else if (newState === AppState.starting && pingCount == pingCountLimit) {
+                                        data.detailedAppStatus = {
+                                            severity: "WARN",
+                                            message: translatedMsg,
+                                            notify: true
+                                        };
+                                    } else if (shouldEmitMsg) {
+                                        data.detailedAppStatus = {
+                                            severity: "ERROR",
+                                            message: translatedMsg,
+                                            notify: false
+                                        };
+                                    }
                                     io.emitOnListener("projectStatusChanged", data);
-                                    pingCountMap.delete(projectID);
+                                    appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, (data.detailedAppStatus) ? data.detailedAppStatus : appStateMap.get(projectID).detailedAppStatus));
+
                                 }
                             }
                         });
@@ -517,12 +556,17 @@ function pingInTransitApplications(): void {
                             if (oldState === AppState.starting) {
                                 // If the container stopped while the application was starting up then something went wrong
                                 data.appErrorStatus = "projectStatusController.appStatusContainerStopped";
-                                const detailedAppStatus = appStateMap.get(projectID).detailedAppStatus;
-                                appStateMap.set(projectID, new ProjectState(AppState.stopped, data.appErrorStatus, undefined, undefined, undefined, detailedAppStatus));
+                                data.detailedAppStatus = {
+                                    severity: "ERROR",
+                                    message: data.appErrorStatus,
+                                    notify: true
+                                };
+                                appStateMap.set(projectID, new ProjectState(AppState.stopped, data.appErrorStatus, undefined, undefined, undefined, data.detailedAppStatus));
                             } else {
                                 appStateMap.set(projectID, new ProjectState(AppState.stopped, undefined));
                             }
                             io.emitOnListener("projectStatusChanged", data);
+                            pingCountMap.delete(projectID);
                         }
                     } else if (containerStatus.state === ContainerStates.containerNotFound) {
                             // If app is starting then just assume the container is not created yet, but
@@ -535,6 +579,7 @@ function pingInTransitApplications(): void {
                                     appStatus: AppState.stopped
                                 };
                                 io.emitOnListener("projectStatusChanged", data);
+                                pingCountMap.delete(projectID);
                             }
                     }
                 } else if (containerStatus.hasOwnProperty("error")) {
@@ -546,12 +591,20 @@ function pingInTransitApplications(): void {
                         const oldMsg = appStateMap.get(projectID).msg;
                         let newMsg = containerStatus.error;
                         if (newMsg) { newMsg = newMsg.toString(); } // Convert from Error to string
-                        const detailedAppStatus = appStateMap.get(projectID).detailedAppStatus;
-                        appStateMap.set(projectID, new ProjectState(oldState, newMsg, undefined, undefined, undefined, detailedAppStatus));
-
-                        // Ensure that only new messages are logged
+                        // Ensure that only new messages are logged and emitted
                         if (newMsg && (newMsg.toString() !== (oldMsg ? oldMsg.toString() : oldMsg))) {
                             logger.logProjectInfo("pingInTransitApplications: Application state error message: " + newMsg, projectID);
+                            const data: any = {
+                                projectID: projectID,
+                                appStatus: oldState,
+                                detailedAppStatus: {
+                                    severity: "ERROR",
+                                    message: newMsg,
+                                    notify: false
+                                }
+                            };
+                            io.emitOnListener("projectStatusChanged", data);
+                            appStateMap.set(projectID, new ProjectState(oldState, newMsg, undefined, undefined, undefined, data.detailedAppStatus));
                         }
                     }
                 }
@@ -689,3 +742,8 @@ export interface IUpdateStatusFailure {
     statusCode: 400 | 404;
     error: { msg: string };
 }
+export interface DetailedAppStatus {
+    severity: "INFO" | "WARN" | "ERROR";
+    message: string;
+    notify: boolean;
+  }

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -414,7 +414,7 @@ function pingApplications(): void {
                         let shouldEmitMsg: boolean = false;
                         // Ensure that only new messages are emitted and logged
                         if (newMsg && (newMsg.toString().trim() !== (oldMsg ? oldMsg.toString().trim() : oldMsg))) {
-                            logger.logProjectInfo("pingInTransitApplications: Application state error message: " + newMsg, projectID);
+                            logger.logProjectInfo("pingApplications: Application state error message: " + newMsg, projectID);
                             shouldEmitMsg = true;
                         }
 

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -337,6 +337,9 @@ export function deleteProject(projectID: string): void {
     appStateMap.delete(projectID);
     buildStateMap.delete(projectID);
     buildRequiredMap.delete(projectID);
+    if (projectUtil.firstTimePingArray.indexOf(projectID) > -1) {
+        projectUtil.firstTimePingArray.splice(projectUtil.firstTimePingArray.indexOf(projectID), 1);
+    }
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -216,6 +216,11 @@ const changeInternalPort = async function (applicationPort: string, operation: O
         logger.logProjectInfo("The project has been updated", projectInfo.projectID);
         logger.logProjectTrace(JSON.stringify(projectInfo), projectInfo.projectID);
 
+        // Delete the project from the array to show the next ping message
+        if (projectUtil.firstTimePingArray.indexOf(projectID) > -1) {
+            projectUtil.firstTimePingArray.splice(projectUtil.firstTimePingArray.indexOf(projectID), 1);
+        }
+
         // Set the containerInfoForceRefreshMap for the project to true, so that isApplicationUp/ping can pick up the new port with a force refresh
         projectUtil.containerInfoForceRefreshMap.set(projectID, true);
 
@@ -327,6 +332,11 @@ const changeContextRoot = async function(args: any, operation: Operation): Promi
 
     try {
         await projectsController.updateProjectInfo(projectID, keyValuePair);
+
+        // Delete the project from the array to show the next ping message
+        if (projectUtil.firstTimePingArray.indexOf(projectID) > -1) {
+            projectUtil.firstTimePingArray.splice(projectUtil.firstTimePingArray.indexOf(projectID), 1);
+        }
 
         const data: ProjectSettingsEvent = {
             operationId: operation.operationId,
@@ -546,6 +556,12 @@ const reconfigWWWProtocol = async function (isHttps: boolean, operation: Operati
 
     try {
         await projectsController.updateProjectInfo(projectID, keyValuePair);
+
+        // Delete the project from the array to show the next ping message
+        if (projectUtil.firstTimePingArray.indexOf(projectID) > -1) {
+            projectUtil.firstTimePingArray.splice(projectUtil.firstTimePingArray.indexOf(projectID), 1);
+        }
+
         const data = {
             operationId: operation.operationId,
             projectID: projectID,

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -2149,18 +2149,18 @@ export function updateDetailedAppStatus(projectID: string, ip: string, port: str
     const oldState = appStateMap.get(projectID).state;
     const oldMsg = appStateMap.get(projectID).msg;
 
-    let pingPathMsg: DetailedAppStatus;
-    pingPathMsg = {
+    let pingPathEvent: DetailedAppStatus;
+    pingPathEvent = {
         severity: "INFO",
         message: `Pinging http://${ip}:${port}${path}`,
         notify: false
     };
 
     if (isDefaultPath) {
-        pingPathMsg.message = `${pingPathMsg.message} and http://${ip}:${port}/`;
+        pingPathEvent.message = `${pingPathEvent.message} and http://${ip}:${port}/`;
     }
 
     if (oldState === AppState.starting) {
-        projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathMsg);
+        projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathEvent);
     }
 }

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -66,7 +66,7 @@
     "buildRank": "Rank {{- rank}}",
     "buildStarted": "Build started",
     "appErrorWhenStopping": "An error occurred while the application was stopping. Check the application logs for details.",
-    "pingTimeout": "Failed to ping application due to timeout. The project start time takes longer than expected. Please ensure the endpoint provided is correct."
+    "pingTimeout": "The application is taking longer than expected to start. Please check the application logs for problems and ensure the project's 'healthCheck' setting is correct."
   },
   "quickfix": {
     "generateMissingFilesName": "Generate missing files",

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -66,7 +66,7 @@
     "buildRank": "Rank {{- rank}}",
     "buildStarted": "Build started",
     "appErrorWhenStopping": "An error occurred while the application was stopping. Check the application logs for details.",
-    "pingTimeout": "Failed to ping application due to timeout."
+    "pingTimeout": "Failed to ping application due to timeout. The project start time takes longer than expected. Please ensure the endpoint provided is correct."
   },
   "quickfix": {
     "generateMissingFilesName": "Generate missing files",


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>
This PR is for issue: https://github.com/eclipse/codewind/issues/1297'

Re-struct the `detailedAppStatus` to include more info, the message now has 3 different severity. `ERROR|INFO|WARN`. and also have a boolean property to indicate whether ide should notify user this message. 
```
[02/12/19 19:22:11 rogue-cloud-client-codewind] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "16ed4d40-0bb8-11ea-bc42-4763060621c7",
  "appStatus": "starting",
  "detailedAppStatus": {
    "severity": "INFO",
    "message": "Pinging http://192.168.240.5:9080/health and http://192.168.240.5:9080/",
    "notify": false
  }
}

[02/12/19 19:22:11 rogue-cloud-client-codewind] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "16ed4d40-0bb8-11ea-bc42-4763060621c7",
  "appStatus": "starting",
  "detailedAppStatus": {
    "severity": "ERROR",
    "message": " connect ECONNREFUSED 192.168.240.5.9080",
    "notify": false
  }
}

[02/12/19 18:04:26 rogue-cloud-client-codewind] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "16ed4d40-0bb8-11ea-bc42-4763060621c7",
  "appStatus": "starting",
  "detailedAppStatus": {
    "severity": "WARN",
    "message": "Failed to ping application due to timeout. The project start time takes longer than expected. Please ensure the endpoint provided is correct.",
    "notify": true
  }
}


```
