### PR TITLE
Add extenisons trigger for jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,8 @@ pipeline {
     }
     
     triggers {	
-      issueCommentTrigger('trigger_build')	
+      issueCommentTrigger('trigger_build')
+      upstream(upstreamProjects: "Codewind/codewind-odo-extension/${env.BRANCH_NAME}, Codewind/codewind-appsody-extension/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
     }
 
     options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     
     triggers {	
       issueCommentTrigger('trigger_build')
-      upstream(upstreamProjects: "Codewind/codewind-odo-extension/${env.BRANCH_NAME}, Codewind/codewind-appsody-extension/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
+      upstream(upstreamProjects: "Codewind/codewind-odo-extension/${env.BRANCH_NAME},Codewind/codewind-appsody-extension/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
     }
 
     options {


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/1214

This PR is for adding `codewind-appsody-extension` and `codewind-odo-extension` as upstream jobs to trigger jenkins build so that If a change is merged into `codewind-appsody-extension` or `codewind-odo-extension`, kick off a Jenkins build for the corresponding branch in the `codewind` repo

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>