### PR TITLE
bump to centos8 to pick up latest python

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,8 @@ pipeline {
     }
     
     triggers {	
-      issueCommentTrigger('trigger_build')	
+      issueCommentTrigger('trigger_build')
+      upstream(upstreamProjects: "Codewind/codewind-odo-extension/${env.BRANCH_NAME},Codewind/codewind-appsody-extension/${env.BRANCH_NAME}", threshold: hudson.model.Result.SUCCESS)
     }
 
     options {

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -257,7 +257,7 @@ paths:
           schema:
             $ref: '#/components/schemas/ProjectID'
           required: true
-          description: id of the project        
+          description: id of the project
       responses:
         202:
           description: >
@@ -266,10 +266,10 @@ paths:
           description: Project with given projectiD was not found.
         500:
           description: Any other error
-  
+
   /api/v1/projects/{id}/upload:
     put:
-      summary: Receive gzipped content of a file for the project and write this to the codewind workspace 
+      summary: Receive gzipped content of a file for the project and write this to the codewind workspace
       parameters:
         - name: id
           in: path
@@ -278,19 +278,19 @@ paths:
           required: true
           description: id of project
       requestBody:
-          description: JSON object containing file info and content 
+          description: JSON object containing file info and content
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Upload'
-    
+
       responses:
         200:
           description: The file upload was successful
         404:
           description: Project with given projectID not found
         500:
-          description: Any other error  
+          description: Any other error
 
   /api/v1/projects/{id}/upload/end:
     post:
@@ -305,7 +305,7 @@ paths:
           required: true
           description: id of the project
       requestBody:
-          description: JSON object containing project information  
+          description: JSON object containing project information
           content:
             application/json:
               schema:
@@ -318,7 +318,7 @@ paths:
           description: Project with given projectiD was not found.
         500:
           description: Any other error
- 
+
 
   /api/v1/projects/{id}:
     get:
@@ -817,8 +817,7 @@ paths:
     post:
       summary: Enable auto injection of metrics
       description: >
-        Get all metrics for a certain type or types of metric, for a specific
-        project as specified by the project ID.
+        Injects metrics collector into project, or remove injected collector from project
       parameters:
         - name: id
           in: path
@@ -835,23 +834,18 @@ paths:
               required:
                 - enable
               properties:
-                types:
-                  description: Boolean
+                enable:
                   type: boolean
-                  example: true
       responses:
         202:
-          description: >
-            Successful update of project information and build triggered
+          description: Successful update of project information and build triggered
           content:
             application/json:
               schema:
                 type: object
         404:
           description: Project not found
-        500:
-          description: Internal error has occured
- 
+
 
   /api/v1/projects/{id}/metrics/types:
     post:
@@ -1717,7 +1711,7 @@ components:
           description: an array of files that have been modified since the last project upload
           type: array
           example: ["/project/modifiedfile1"]
-      
+
     Upload:
       type: object
       required:
@@ -1736,7 +1730,7 @@ components:
           type: number
           description: the permissions for the file https://nodejs.org/api/fs.html#fs_file_modes
           example: 0o775
-     
+
     LoadrunnerConfig:
       type: object
       required:
@@ -1776,7 +1770,7 @@ components:
               example: { id: 1, message: 'codewind' }
             - type: string
               example: "{ id: 1, message: 'codewind'}"
-    
+
     LogDetails:
       type: object
       required:

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -8,23 +8,27 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
-#FROM centos:8
+FROM centos as codewind-pfe-base
 
-FROM centos@sha256:0f3e07c0138fbe05abcb7a9cc7d63d9bd4c980c3f61fea5efa32e7c4217ef4da as codewind-pfe-base
+#FROM centos@sha256:0f3e07c0138fbe05abcb7a9cc7d63d9bd4c980c3f61fea5efa32e7c4217ef4da as codewind-pfe-base
 LABEL org.label-schema.name="Codewind PFE" org.label-schema.description="Codewind PFE" \
       org.label-schema.url="https://codewind.dev/" \
       org.label-schema.vcs-url="https://github.com/eclipse/codewind" org.label-schema.vendor="IBM"
 
-ARG BUILDAH_RPM=https://cbs.centos.org/kojifiles/packages/buildah/1.11.2/2.git0bafbfe.el7/x86_64/buildah-1.11.2-2.git0bafbfe.el7.x86_64.rpm
+ARG BUILDAH_RPM=https://cbs.centos.org/kojifiles/packages/buildah/1.11.4/4.el7/x86_64/buildah-1.11.4-4.el7.x86_64.rpm
+ARG SLIRP=https://cbs.centos.org/kojifiles/packages/slirp4netns/0.3.0/2.git4992082.el7/x86_64/slirp4netns-0.3.0-2.git4992082.el7.x86_64.rpm
+ARG LIBSEC=https://cbs.centos.org/kojifiles/packages/libseccomp/2.4.1/0.el7/x86_64/libseccomp-2.4.1-0.el7.x86_64.rpm
 
 # Download the buildah RPM
 RUN curl -f -o buildah.rpm $BUILDAH_RPM
+RUN curl -f -o slirp4netns.rpm $SLIRP
+RUN curl -f -o libseccomp.rpm $LIBSEC
 
 # Download and set up Node 10.x RPM
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
 
 RUN yum install -y epel-release \
-    && yum -y --enablerepo=epel install zip unzip sudo ca-certificates openssl nodejs buildah.rpm \
+    && yum -y --enablerepo=epel install zip unzip sudo ca-certificates openssl nodejs slirp4netns.rpm libseccomp.rpm buildah.rpm \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -8,9 +8,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
-FROM centos as codewind-pfe-base
+#FROM centos as codewind-pfe-base
 
-#FROM centos@sha256:0f3e07c0138fbe05abcb7a9cc7d63d9bd4c980c3f61fea5efa32e7c4217ef4da as codewind-pfe-base
+FROM centos@sha256:f94c1d992c193b3dc09e297ffd54d8a4f1dc946c37cbeceb26d35ce1647f88d9 as codewind-pfe-base
 LABEL org.label-schema.name="Codewind PFE" org.label-schema.description="Codewind PFE" \
       org.label-schema.url="https://codewind.dev/" \
       org.label-schema.vcs-url="https://github.com/eclipse/codewind" org.label-schema.vendor="IBM"

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -8,9 +8,9 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
-#FROM centos:7
+#FROM centos:8
 
-FROM centos@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973a9673822d1414824a1d0475 as codewind-pfe-base
+FROM centos@sha256:f94c1d992c193b3dc09e297ffd54d8a4f1dc946c37cbeceb26d35ce1647f88d9 as codewind-pfe-base
 LABEL org.label-schema.name="Codewind PFE" org.label-schema.description="Codewind PFE" \
       org.label-schema.url="https://codewind.dev/" \
       org.label-schema.vcs-url="https://github.com/eclipse/codewind" org.label-schema.vendor="IBM"

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -65,7 +65,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
     && mv ./kubectl /usr/local/bin/kubectl
 
 # Install helm, fixed to the 2.9.1 version
-RUN cd /tmp \ 
+RUN cd /tmp \
     && curl -O https://get.helm.sh/helm-v2.9.1-linux-amd64.tar.gz \
     && echo '56ae2d5d08c68d6e7400d462d6ed10c929effac929fedce18d2636a9b4e166ba  helm-v2.9.1-linux-amd64.tar.gz' | sha256sum -c - \
     && tar -xvf helm-v2.9.1-linux-amd64.tar.gz \
@@ -124,6 +124,7 @@ RUN chmod -R +rx /portal/npm-start.sh
 COPY /portal/server.js /portal/
 COPY /portal/modules /portal/modules
 COPY /portal/routes /portal/routes
+COPY /portal/controllers /portal/controllers
 COPY /portal/config /portal/config
 COPY /portal/middleware /portal/middleware
 COPY /portal/docs /portal/docs

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -10,7 +10,7 @@
 #*******************************************************************************
 #FROM centos:8
 
-FROM centos@sha256:f94c1d992c193b3dc09e297ffd54d8a4f1dc946c37cbeceb26d35ce1647f88d9 as codewind-pfe-base
+FROM centos@sha256:0f3e07c0138fbe05abcb7a9cc7d63d9bd4c980c3f61fea5efa32e7c4217ef4da as codewind-pfe-base
 LABEL org.label-schema.name="Codewind PFE" org.label-schema.description="Codewind PFE" \
       org.label-schema.url="https://codewind.dev/" \
       org.label-schema.vcs-url="https://github.com/eclipse/codewind" org.label-schema.vendor="IBM"

--- a/src/pfe/file-watcher/idc/artifacts/run_docker.sh
+++ b/src/pfe/file-watcher/idc/artifacts/run_docker.sh
@@ -64,7 +64,7 @@ if [[ $MICROCLIMATE_WS_ORIGIN &&  "$APPDIR" == '/codewind-workspace'* ]]
 		OUTPUT_DOCKER_RUN="$(docker run -dt --entrypoint "/home/default/artifacts/new_entrypoint.sh" --name $CONTAINER_NAME -v "$LOGSDIR":/logs --network=codewind_network $PORT_MAPPING_PARAMS $CONTAINER_IMAGE_NAME)"
 		if [ $? -eq 0 ]; then
 			echo -e "Copying over source files"
-			docker cp "$APP_DIRECTORY" $CONTAINER_NAME:$HOME/app
+			docker cp "$APP_DIRECTORY"/. $CONTAINER_NAME:$HOME/app
 		fi
 		echo "${OUTPUT_DOCKER_RUN}"
 
@@ -73,7 +73,7 @@ if [[ $MICROCLIMATE_WS_ORIGIN &&  "$APPDIR" == '/codewind-workspace'* ]]
 		OUTPUT_DOCKER_RUN="$(docker run -dt --name $CONTAINER_NAME -v "$LOGSDIR":$HOME/logs $PORT_MAPPING_PARAMS $CONTAINER_IMAGE_NAME)"
 		if [ $? -eq 0 ]; then
 			echo -e "Copying over source files"
-			docker cp "$APP_DIRECTORY" $CONTAINER_NAME:$HOME/app
+			docker cp "$APP_DIRECTORY"/. $CONTAINER_NAME:$HOME/app
 		fi
 		echo "${OUTPUT_DOCKER_RUN}"
 fi

--- a/src/pfe/file-watcher/scripts/spring-container.sh
+++ b/src/pfe/file-watcher/scripts/spring-container.sh
@@ -300,7 +300,7 @@ function dockerRun() {
 		--expose 8080 -p 127.0.0.1::$DEBUG_PORT -P -dt $project
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
-		docker cp "$WORKSPACE/$projectName" $project:/root/app
+		docker cp "$WORKSPACE/$projectName"/. $project:/root/app
 	fi
 
 }

--- a/src/pfe/file-watcher/scripts/swift-container.sh
+++ b/src/pfe/file-watcher/scripts/swift-container.sh
@@ -250,7 +250,7 @@ function dockerRun() {
 	$IMAGE_COMMAND run --network=codewind_network --name "$project" -dt -P -w /swift-project "$project"
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
-		docker cp "$workspace/$projectName" "$project":/swift-project
+		docker cp "$workspace/$projectName"/. "$project":/swift-project
 	fi
 
 }

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -166,11 +166,13 @@ const changeInternalPort = async function (applicationPort: string, operation: O
     }
 
     try {
+        let isContainerRunning: boolean = true;
         let isApplicationPortExposed: boolean = false;
 
         // Check if the port requested has been exposed
         if (process.env.IN_K8) {
             const containerInfo: any = await projectUtil.getContainerInfo(projectInfo, true);
+            isContainerRunning = containerInfo.podName.trim().length > 0;
             for (let i = 0; i < containerInfo.podPorts.length; i++) {
                 const port = containerInfo.podPorts[i];
 
@@ -181,6 +183,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             }
         } else {
             const containerInfo: any = await projectUtil.getContainerInfo(projectInfo, true);
+            isContainerRunning = containerInfo.containerId.trim().length > 0;
             for (let i = 0; i < containerInfo.containerPorts.length; i++) {
                 const port = containerInfo.containerPorts[i];
 
@@ -191,7 +194,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             }
         }
 
-        if (!isApplicationPortExposed) {
+        if (isContainerRunning && !isApplicationPortExposed) {
             logger.logProjectInfo("The requested application port is not exposed: " + applicationPort, projectInfo.projectID);
             const data: ProjectSettingsEvent = {
                 operationId: operation.operationId,

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -236,7 +236,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             status: "success",
             ports: {
                 exposedPort: containerInfo.exposedPort,
-                internalPort: containerInfo.internalPort
+                internalPort: applicationPort
             }
         };
 

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectSettings.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectSettings.module.test.ts
@@ -28,6 +28,8 @@ export function projectSettingsTestModule(): void {
     let internalPortStatus = "";
     let projectSettingsStatus = "";
 
+    let internalPortValue = "";
+
     socket.registerListener({
         name: "codewindunittest",
         handleEvent: (event, data) => {
@@ -42,10 +44,14 @@ export function projectSettingsTestModule(): void {
                     mavenPropertiesStatus = data.status;
                 } else if (data.ignoredPaths || (data.error && data.error.includes("ignoredPaths"))) {
                     ignoredPathsStatus = data.status;
-                } else if ((data.ports && data.ports.internalDebugPort)) {
-                    internalDebugPortStatus = data.status;
-                } else if ((data.ports && data.ports.internalPort)) {
-                    internalPortStatus = data.status;
+                } else if (data.ports) {
+                    if (data.ports.internalDebugPort) {
+                        internalDebugPortStatus = data.status;
+                    }
+                    if (data.ports.internalPort) {
+                        internalPortValue = data.ports.internalPort;
+                        internalPortStatus = data.status;
+                    }
                 } else {
                     projectSettingsStatus = data.status;
                 }
@@ -148,21 +154,31 @@ export function projectSettingsTestModule(): void {
         const combinations: any = {
             "combo1": {
                 "internalPortSettings": {
+                    "internalPort": ""
+                },
+                "expectedPortValue": "",
+                "result": ""
+            },
+            "combo2": {
+                "internalPortSettings": {
                     "internalPort": "1234"
                 },
-                "result": "failed"
+                "expectedPortValue": "1234",
+                "result": "success"
             }
         };
 
         for (const combo of Object.keys(combinations)) {
             const internalPortSettings = combinations[combo]["internalPortSettings"];
             const expectedResult = combinations[combo]["result"];
+            const expectedPortValue = combinations[combo]["expectedPortValue"];
 
             it(combo + " => internalPortSettings: " + JSON.stringify(internalPortSettings), async () => {
                 const projectID: string = "dummynodeproject";
 
                 await projectSettings.projectSpecificationHandler(projectID, internalPortSettings);
                 expect(internalPortStatus).to.equal(expectedResult);
+                expect(internalPortValue).to.equal(expectedPortValue);
             });
         }
     });

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const path = require('path');
+
+const metricsService = require('../modules/metricsService');
+const Logger = require('../modules/utils/Logger');
+const cwUtils = require('../modules/utils/sharedFunctions');
+
+const log = new Logger(__filename);
+
+/**
+ * Enable or disable the auto injection of metrics collector
+ * @param project, the project
+ * @return 202 if the specified setting was applied and build requested
+ * @return 404 if the specified project does not exist
+ * @return 500 if internal error
+ */
+async function inject(req, res) {
+  try {
+    const projectID = req.sanitizeParams('id');
+    const injectMetrics = req.sanitizeBody('enable');
+    const user = req.cw_user;
+    const project = user.projectList.retrieveProject(projectID);
+    if (!project) {
+      const message = `Unable to find project ${projectID}`;
+      log.error(message);
+      res.status(404).send({ message });
+      return;
+    }
+
+    await user.projectList.updateProject({
+      projectID: projectID,
+      injectMetrics: injectMetrics
+    });
+
+    const projectDir = path.join(project.workspace, project.directory);
+    if (injectMetrics) {
+      await metricsService.injectMetricsCollectorIntoProject(project.projectType, projectDir);
+    } else {
+      await metricsService.removeMetricsCollectorFromProject(project.projectType, projectDir);
+    }
+
+    res.sendStatus(202);
+
+    await syncProjectFilesIntoBuildContainer(project, user);
+  } catch (err) {
+    log.error(err);
+    res.status(500).send(err.info || err);
+  }
+}
+
+async function syncProjectFilesIntoBuildContainer(project, user){
+  const globalProjectPath = path.join(project.workspace, project.name);
+  const projectRoot = cwUtils.getProjectSourceRoot(project);
+  if (project.buildStatus != "inProgress") {
+    await cwUtils.copyProjectContents(
+      project,
+      globalProjectPath,
+      projectRoot
+    );
+    await user.buildProject(project, "build");
+  } else {
+    // if a build is in progress, wait 5 seconds and try again
+    await cwUtils.timeout(5000)
+    await syncProjectFilesIntoBuildContainer(project, user);
+  }
+}
+
+module.exports = {
+  inject,
+}

--- a/src/pfe/portal/controllers/performance.controller.js
+++ b/src/pfe/portal/controllers/performance.controller.js
@@ -1,8 +1,8 @@
 const request = require('request');
 
-const Logger = require('./utils/Logger');
+const Logger = require('../modules/utils/Logger');
 
-const log = new Logger('PerformanceController.js');
+const log = new Logger(__filename);
 
 // if we are running in Che use the workspace codewind performance service,  else use the codewind container name of "codewind-performance"
 const performance_host = process.env.CODEWIND_PERFORMANCE_SERVICE ? process.env.CODEWIND_PERFORMANCE_SERVICE : "codewind-performance";

--- a/src/pfe/portal/modules/metricsService/node.js
+++ b/src/pfe/portal/modules/metricsService/node.js
@@ -1,0 +1,65 @@
+const fs = require('fs-extra');
+const path = require('path');
+const util = require('util');
+
+const Logger = require('../utils/Logger');
+const { deepClone } = require('../utils/sharedFunctions');
+
+const log = new Logger(__filename);
+
+const getPathToPackageJson = (projectDir) => path.join(projectDir, 'package.json');
+const getPathToBackupPackageJson = (projectDir) => path.join(projectDir, 'backupPackage.json');
+
+async function injectMetricsCollectorIntoNodeProject(projectDir) {
+  const pathToPackageJson = getPathToPackageJson(projectDir);
+  const originalContentsOfPackageJson = await fs.readJSON(pathToPackageJson);
+
+  const pathToBackupPackageJson = getPathToBackupPackageJson(projectDir);
+  await fs.writeJSON(pathToBackupPackageJson, originalContentsOfPackageJson, { spaces: 2 });
+
+  const newContentsOfPackageJson = getNewContentsOfPackageJson(originalContentsOfPackageJson);
+  log.trace(`Injecting metrics collector into project's package.json, which is now ${ util.inspect(newContentsOfPackageJson) }`);
+
+  await fs.writeJSON(pathToPackageJson, newContentsOfPackageJson, { spaces: 2 });
+}
+
+async function removeMetricsCollectorFromNodeProject(projectDir) {
+  const pathToBackupPackageJson = getPathToBackupPackageJson(projectDir);
+  const backupPackageJson = await fs.readJSON(pathToBackupPackageJson);
+
+  const pathToPackageJson = getPathToPackageJson(projectDir);
+  await fs.writeJSON(pathToPackageJson, backupPackageJson, { spaces: 2 });
+  log.trace(`Restored project's package.json to ${ util.inspect(backupPackageJson) }`);
+
+  await fs.remove(pathToBackupPackageJson);
+}
+
+function getNewContentsOfPackageJson(originalContentsOfPackageJson) {
+  const newContentsOfPackageJson = deepClone(originalContentsOfPackageJson);
+
+  newContentsOfPackageJson.scripts.start = getNewStartScript(originalContentsOfPackageJson.scripts.start);
+  newContentsOfPackageJson.dependencies['appmetrics-codewind'] = '^0.1.0';
+  return newContentsOfPackageJson;
+}
+
+function getNewStartScript(originalStartScript) {
+  const metricsCollectorScript = '-r appmetrics-codewind/attach';
+
+  if (originalStartScript.includes(metricsCollectorScript)) {
+    return originalStartScript;
+  }
+
+  const splitOriginalStartScript = originalStartScript.split(' ');
+  const indexOfNodeCmd = splitOriginalStartScript.findIndex(word => ['node', 'nodemon'].includes(word));
+
+  let newStartScript = deepClone(splitOriginalStartScript);
+  newStartScript.splice(indexOfNodeCmd + 1, 0, metricsCollectorScript);
+  newStartScript = newStartScript.join(' ');
+
+  return newStartScript;
+}
+
+module.exports = {
+  injectMetricsCollectorIntoNodeProject,
+  removeMetricsCollectorFromNodeProject,
+};

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -20,7 +20,7 @@ const exec = promisify(require('child_process').exec);
 
 // This if statement allows us to only include one utils function, exporting either
 //      the Docker of K8s one depending on which environment we're in
-module.exports = require((global.codewind.RUNNING_IN_K8S ? './kubernetesFunctions' : './dockerFunctions'));
+module.exports = require((global.codewind && global.codewind.RUNNING_IN_K8S ? './kubernetesFunctions' : './dockerFunctions'));
 
 // variable to do a async timeout
 module.exports.timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -134,7 +134,7 @@ module.exports.convertFromWindowsDriveLetter = function convertFromWindowsDriveL
 /**
  * Force remove a path, regardless of whether it exists, or it's file or directory that may or may not be empty.
  * Better than fs-extra fs.remove as it won't recurse down each directory tree and take over the event loop
- * 
+ *
  * @param {string} path, path to remove
  */
 module.exports.forceRemove = async function forceRemove(path) {
@@ -199,3 +199,6 @@ module.exports.getProjectSourceRoot = function getProjectSourceRoot(project) {
   }
   return projectRoot;
 }
+
+const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+module.exports.deepClone = deepClone;

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -19,7 +19,7 @@ const inflateAsync = promisify(zlib.inflate);
 const cwUtils = require('../../modules/utils/sharedFunctions');
 const Logger = require('../../modules/utils/Logger');
 const Project = require('../../modules/Project');
-const metricsService = require('../../modules/MetricsService');
+const metricsService = require('../../modules/metricsService');
 const ProjectInitializerError = require('../../modules/utils/errors/ProjectInitializerError');
 const { ILLEGAL_PROJECT_NAME_CHARS } = require('../../config/requestConfig');
 const router = express.Router();
@@ -228,9 +228,9 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
           await deleteFilesInArray(pathToProj, filesToDelete);
         }
         res.sendStatus(200);
- 
+
         await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
- 
+
         if (project.injectMetrics) {
           try {
             await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const Logger = require('./modules/utils/Logger');
-const { pipePerfProxyReqsToPerfContainer } = require('./modules/PerformanceController');
+const { pipePerfProxyReqsToPerfContainer } = require('./controllers/performance.controller');
 
 const log = new Logger('server.js');
 

--- a/test/package.json
+++ b/test/package.json
@@ -41,19 +41,20 @@
     "mocha-logger": "^1.0.6",
     "mocha-multi-reporters": "^1.1.7",
     "mocha-sinon": "^2.1.0",
+    "nyc": "^14.1.1",
+    "rewire": "^4.0.1",
     "path": "^0.12.7",
     "read-each-line-sync": "^1.0.5",
     "rimraf": "^3.0.0",
     "simple-git": "^1.110.0",
     "sinon": "^7.3.2",
+    "sinon-express-mock": "^2.2.1",
     "socket.io-client": "^2.0.4",
     "util": "^0.12.1",
     "uuid": "^3.3.2",
     "xml2js": "^0.4.22",
     "yamljs": "^0.3.0",
-    "zlib": "^1.0.5",
-    "nyc": "^14.1.1",
-    "rewire": "^4.0.1"
+    "zlib": "^1.0.5"
   },
   "devDependencies": {
     "eslint": "^5.9.0",

--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -12,7 +12,7 @@ const chai = require('chai');
 const chaiResValidator = require('chai-openapi-response-validator');
 
 const reqService = require('../../modules/request.service');
-const { ADMIN_COOKIE, pathToApiSpec } = require('../../config');
+const { ADMIN_COOKIE, pathToApiSpec, testTimeout } = require('../../config');
 
 chai.use(chaiResValidator(pathToApiSpec));
 chai.should();
@@ -20,7 +20,7 @@ chai.should();
 describe('Project Types API tests', function() {
 
     it('should return expected list of project types', async function() {
-        this.timeout(10000);
+        this.timeout(testTimeout.med);
         const res = await reqService.chai
             .get('/api/v1/project-types')
             .set('Cookie', ADMIN_COOKIE);

--- a/test/src/unit/controllers/metrics.controller.test.js
+++ b/test/src/unit/controllers/metrics.controller.test.js
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+const chai = require('chai');
+const rewire = require('rewire');
+const { mockReq, mockRes } = require('sinon-express-mock');
+
+const metricsController = rewire('../../../../src/pfe/portal/controllers/metrics.controller');
+const { suppressLogOutput } = require('../../../modules/log.service');
+
+chai.should();
+
+describe('metrics.controller.js', () => {
+    suppressLogOutput(metricsController);
+    describe('inject(req, res)', () => {
+        it('returns 404 if the specified project does not exist', async() => {
+            const request = {
+                sanitizeParams: () => 'nonexistentProjectId',
+                sanitizeBody: () => 'foo',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => {},
+                    },
+                },
+            };
+            const req = mockReq(request);
+            const res = mockRes();
+
+            await metricsController.inject(req, res);
+
+            res.status.should.be.calledOnceWith(404);
+            res.send.should.be.calledOnceWith({ message: 'Unable to find project nonexistentProjectId' });
+        });
+        it('returns 500 if our server errors', async() => {
+            const request = {};
+            const req = mockReq(request);
+            const res = mockRes();
+
+            await metricsController.inject(req, res);
+
+            res.status.should.be.calledOnceWith(500);
+            res.send.args[0][0].message.should.equal('req.sanitizeParams is not a function');
+        });
+        it('returns 500 if our server errors while inserting metrics collector into project', async() => {
+            const request = {
+                sanitizeParams: () => 'goodProjectID',
+                sanitizeBody: () => true,
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => ({
+                            workspace: 'test',
+                            directory: 'projectDir',
+                            projectType: 'unsupportedProjectType',
+                        }),
+                        updateProject: () => {},
+                    },
+                },
+            };
+            const req = mockReq(request);
+            const res = mockRes();
+
+            await metricsController.inject(req, res);
+
+            res.status.should.be.calledOnceWith(500);
+            res.send.args[0][0].message.should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
+        });
+        it('returns 500 if our server errors while removing metrics collector from project', async() => {
+            const request = {
+                sanitizeParams: () => 'goodProjectID',
+                sanitizeBody: () => false,
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => ({
+                            workspace: 'test',
+                            directory: 'projectDir',
+                            projectType: 'unsupportedProjectType',
+                        }),
+                        updateProject: () => {},
+                    },
+                },
+            };
+            const req = mockReq(request);
+            const res = mockRes();
+
+            await metricsController.inject(req, res);
+
+            res.status.should.be.calledOnceWith(500);
+            res.send.args[0][0].message.should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
+        });
+        it('returns 202 and injects metrics collector into project build container if we provide a good request', async() => {
+            const request = {
+                sanitizeParams: () => 'goodProjectID',
+                sanitizeBody: () => true,
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => ({
+                            workspace: 'test',
+                            directory: 'projectDir',
+                            projectType: 'nodejs',
+                        }),
+                        updateProject: () => {},
+                    },
+                },
+            };
+            const req = mockReq(request);
+            const res = mockRes();
+            const mockedFunctions = {
+                metricsService: {
+                    injectMetricsCollectorIntoProject: () => {},
+                    removeMetricsCollectorFromProject: () => {},
+                },
+                syncProjectFilesIntoBuildContainer: () => {},
+            };
+
+            await metricsController.__with__(mockedFunctions)(
+                () => metricsController.inject(req, res)
+            );
+
+            res.sendStatus.should.be.calledOnceWith(202);
+            res.status.should.not.be.calledWith(500);
+        });
+    });
+});

--- a/test/src/unit/controllers/performance.controller.test.js
+++ b/test/src/unit/controllers/performance.controller.test.js
@@ -11,11 +11,11 @@
 const chai = require('chai');
 const rewire = require('rewire');
 
-const performanceController = rewire('../../../src/pfe/portal/modules/PerformanceController');
+const performanceController = rewire('../../../../src/pfe/portal/controllers/performance.controller');
 
 chai.should();
 
-describe('PerformanceController.js', function() {
+describe('performance.controller.js', function() {
     describe('getReqToPerfContainer(req, performance_host, performance_port)', function() {
         it(`returns a request object that can be made against the perf container`, function() {
             const req = {

--- a/test/src/unit/modules/metricsService.test.js
+++ b/test/src/unit/modules/metricsService.test.js
@@ -16,7 +16,9 @@ const path = require('path');
 const rewire = require('rewire');
 const xml2js = require('xml2js');
 
-const metricsService = rewire('../../../../src/pfe/portal/modules/MetricsService');
+const { suppressLogOutput } = require('../../../modules/log.service');
+const metricsService = rewire('../../../../src/pfe/portal/modules/metricsService');
+const nodeMetricsService = rewire('../../../../src/pfe/portal/modules/metricsService/node');
 
 chai.use(chaiAsPromised);
 chai.use(deepEqualInAnyOrder);
@@ -24,50 +26,54 @@ chai.should();
 
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 
-describe('MetricsService.js', () => {
-    const projectDir = path.join('.', 'src', 'unit', 'modules');
+const projectDir = path.join('.', 'src', 'unit', 'modules', 'test');
 
-    // nodejs
-    const pathToPackageJson = path.join(projectDir, 'package.json');
-    const originalPackageJson = {
-        /* eslint-disable quote-props, quotes, comma-dangle */
-        "name": "node",
-        "version": "1.0.0",
-        "description": "A generated IBM Cloud application",
-        "scripts": {
-            "start": "node $npm_package_config_entrypoint",
-            "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint"
-        },
-        "dependencies": {
-            "body-parser": "^1.18.3",
-            "express": "^4.16.4"
-        }
-        /* eslint-enable quote-props, quotes, comma-dangle */
-    };
+// nodejs
+const pathToPackageJson = path.join(projectDir, 'package.json');
+const pathToBackupPackageJson = path.join(projectDir, 'backupPackage.json');
+const originalPackageJson = {
+    /* eslint-disable quote-props, quotes, comma-dangle */
+    "name": "node",
+    "version": "1.0.0",
+    "description": "A generated IBM Cloud application",
+    "scripts": {
+        "start": "node $npm_package_config_entrypoint",
+        "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint"
+    },
+    "dependencies": {
+        "body-parser": "^1.18.3",
+        "express": "^4.16.4"
+    }
+    /* eslint-enable quote-props, quotes, comma-dangle */
+};
 
-    const expectedPackageJson = {
-        /* eslint-disable quote-props, quotes, comma-dangle */
-        "name": "node",
-        "version": "1.0.0",
-        "description": "A generated IBM Cloud application",
-        "scripts": {
-            "start": "node -r appmetrics-codewind/attach $npm_package_config_entrypoint",
-            "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint"
-        },
-        "dependencies": {
-            "body-parser": "^1.18.3",
-            "express": "^4.16.4",
-            "appmetrics-codewind": "^0.1.0",
-        }
-        /* eslint-enable quote-props, quotes, comma-dangle */
-    };
+const expectedPackageJson = {
+    /* eslint-disable quote-props, quotes, comma-dangle */
+    "name": "node",
+    "version": "1.0.0",
+    "description": "A generated IBM Cloud application",
+    "scripts": {
+        "start": "node -r appmetrics-codewind/attach $npm_package_config_entrypoint",
+        "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint"
+    },
+    "dependencies": {
+        "body-parser": "^1.18.3",
+        "express": "^4.16.4",
+        "appmetrics-codewind": "^0.1.0",
+    }
+    /* eslint-enable quote-props, quotes, comma-dangle */
+};
+describe('metricsService/index.js', () => {
+    suppressLogOutput(metricsService);
 
     // java
     const pathToTestPomXml = path.join(projectDir, 'pom.xml');
+    const pathToTestBackupPomXml = path.join(projectDir, 'backupPom.xml');
     const pathToTestResourcesDir = path.join('.', 'resources', 'metricsService');
 
     // liberty
     const pathToJvmOptions = path.join(projectDir, 'src', 'main', 'liberty', 'config', 'jvm.options');
+    const pathToBackupJvmOptions = path.join(projectDir, 'src', 'main', 'liberty', 'config', 'backupJvm.options');
     const originalJvmOptions = 'foobar';
     const expectedJvmOptions = `${originalJvmOptions}\n-javaagent:resources/javametrics-agent.jar`;
 
@@ -78,15 +84,17 @@ describe('MetricsService.js', () => {
     let expectedPomXmlForLiberty;
 
     // spring
-    const pathToApplicationJava = path.join(projectDir, 'src', 'main', 'java', 'application', 'Application.java');
+    const pathToJavaProjectSrcFiles = path.join(projectDir, 'src', 'main', 'java');
+    const pathToMainAppClassFile = path.join(pathToJavaProjectSrcFiles, 'application', 'Application.java');
+    const pathToBackupMainAppClassFile = path.join(projectDir, 'codewind-backup', 'Application.java');
 
     const pathToTestResourcesForSpring = path.join(pathToTestResourcesDir, 'spring');
 
-    const pathToApplicationJavas = path.join(pathToTestResourcesForSpring, 'Application.java');
-    const pathToOriginalApplicationJava = path.join(pathToApplicationJavas, 'package1', 'without collector.java');
-    const pathToExpectedApplicationJava = path.join(pathToApplicationJavas, 'package1', 'with collector.java');
-    const originalApplicationJava = fs.readFileSync(pathToOriginalApplicationJava, 'utf8');
-    const expectedApplicationJava = fs.readFileSync(pathToExpectedApplicationJava, 'utf8');
+    const pathToMainAppClassFiles = path.join(pathToTestResourcesForSpring, 'Application.java');
+    const pathToOriginalMainAppClassFile = path.join(pathToMainAppClassFiles, 'package1', 'without collector.java');
+    const pathToExpectedMainAppClassFile = path.join(pathToMainAppClassFiles, 'package1', 'with collector.java');
+    const originalMainAppClassFile = fs.readFileSync(pathToOriginalMainAppClassFile, 'utf8');
+    const expectedMainAppClassFile = fs.readFileSync(pathToExpectedMainAppClassFile, 'utf8');
 
     const pathToPomXmlsForSpring = path.join(pathToTestResourcesForSpring, 'pom.xml');
     const pathToOriginalPomXmlForSpring = path.join(pathToPomXmlsForSpring, 'without collector.xml');
@@ -110,61 +118,68 @@ describe('MetricsService.js', () => {
     describe('injectMetricsCollectorIntoProject(projectType, projectDir)', () => {
         describe(`('nodejs', <goodProjectDir>)`, () => {
             beforeEach(() => {
-                fs.writeJSONSync(pathToPackageJson, originalPackageJson);
+                fs.outputJSONSync(pathToPackageJson, originalPackageJson);
             });
             afterEach(() => {
-                fs.unlinkSync(pathToPackageJson);
+                fs.removeSync(projectDir);
             });
-            it(`injects metrics collector into the project's package.json`, async() => {
+            it(`injects metrics collector into the project's package.json, and saves a back up`, async() => {
                 await metricsService.injectMetricsCollectorIntoProject('nodejs', projectDir);
 
                 fs.readJSONSync(pathToPackageJson).should.deep.equal(expectedPackageJson);
+                fs.readJSONSync(pathToBackupPackageJson).should.deep.equal(originalPackageJson);
             });
         });
         describe(`('liberty', <goodProjectDir>)`, () => {
             beforeEach(() => {
-                fs.writeFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
+                fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
                 fs.outputFileSync(pathToJvmOptions, originalJvmOptions);
             });
             afterEach(() => {
-                fs.unlinkSync(pathToTestPomXml);
-                fs.unlinkSync(pathToJvmOptions);
+                fs.removeSync(projectDir);
             });
-            it(`injects metrics collector into the project's jvm.options and pom.xml`, async() => {
+            it(`injects metrics collector into the project's jvm.options and pom.xml, and saves backups`, async() => {
                 await metricsService.injectMetricsCollectorIntoProject('liberty', projectDir);
-
-                const outputPomXml = await readXml(pathToTestPomXml);
-                outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForLiberty);
 
                 const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                 outputJvmOptions.should.equal(expectedJvmOptions);
+                const outputBackupJvmOptions = fs.readFileSync(pathToBackupJvmOptions, 'utf8');
+                outputBackupJvmOptions.should.deep.equal(originalJvmOptions);
+
+                const outputPomXml = await readXml(pathToTestPomXml);
+                outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForLiberty);
+                const outputBackupPomXml = await readXml(pathToTestBackupPomXml);
+                outputBackupPomXml.should.deep.equal(originalPomXmlForLiberty);
             });
         });
         describe(`('spring', <goodProjectDir>)`, () => {
             beforeEach(() => {
-                fs.writeFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForSpring));
-                fs.outputFileSync(pathToApplicationJava, originalApplicationJava);
+                fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForSpring));
+                fs.outputFileSync(pathToMainAppClassFile, originalMainAppClassFile);
             });
             afterEach(() => {
-                fs.unlinkSync(pathToTestPomXml);
-                fs.unlinkSync(pathToApplicationJava);
+                fs.removeSync(projectDir);
             });
-            it(`injects metrics collector into the project's Application.java and pom.xml`, async() => {
+            it(`injects metrics collector into the project's main app class file and pom.xml`, async() => {
                 await metricsService.injectMetricsCollectorIntoProject('spring', projectDir);
+
+                const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
+                outputClassFile.should.equal(expectedMainAppClassFile);
+                const outputBackupClassFile = fs.readFileSync(pathToBackupMainAppClassFile, 'utf8');
+                outputBackupClassFile.should.deep.equal(originalMainAppClassFile);
 
                 const outputPomXml = await readXml(pathToTestPomXml);
                 outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForSpring);
-
-                const outputApplicationJava = fs.readFileSync(pathToApplicationJava, 'utf8');
-                outputApplicationJava.should.equal(expectedApplicationJava);
+                const outputBackupPomXml = await readXml(pathToTestBackupPomXml);
+                outputBackupPomXml.should.deep.equal(originalPomXmlForSpring);
             });
         });
         describe(`('unsupportedProjectType', <goodProjectDir>)`, () => {
             beforeEach(() => {
-                fs.writeJSONSync(pathToPackageJson, originalPackageJson);
+                fs.outputJSONSync(pathToPackageJson, originalPackageJson);
             });
             afterEach(() => {
-                fs.unlinkSync(pathToPackageJson);
+                fs.removeSync(projectDir);
             });
             it(`throws a useful error`, () => {
                 const funcToTest = () => metricsService.injectMetricsCollectorIntoProject('unsupportedProjectType', projectDir);
@@ -172,99 +187,111 @@ describe('MetricsService.js', () => {
             });
         });
     });
-    describe('nodejs', () => {
-        describe('injectMetricsCollectorIntoNodeProject(projectDir)', () => {
-            describe('package.json does not have metrics injection code', () => {
-                before(() => {
-                    fs.writeJSONSync(pathToPackageJson, originalPackageJson);
-                });
-                after(() => {
-                    fs.unlinkSync(pathToPackageJson);
-                });
-                it(`injects metrics collector into the project's package.json`, async() => {
-                    const funcToTest = metricsService.__get__('injectMetricsCollectorIntoNodeProject');
-                    await funcToTest(projectDir);
 
-                    fs.readJSONSync(pathToPackageJson).should.deep.equal(expectedPackageJson);
-                });
+    describe('removeMetricsCollectorFromProject(projectType, projectDir)', () => {
+        describe(`('nodejs', <goodProjectDir>)`, () => {
+            beforeEach(() => {
+                fs.outputJSONSync(pathToPackageJson, expectedPackageJson);
+                fs.outputJSONSync(pathToBackupPackageJson, originalPackageJson);
             });
-            describe('package.json already has metrics injection code', () => {
-                before(() => {
-                    fs.writeJSONSync(pathToPackageJson, expectedPackageJson);
-                });
-                after(() => {
-                    fs.unlinkSync(pathToPackageJson);
-                });
-                it(`injects metrics collector into the project's package.json`, async() => {
-                    const funcToTest = metricsService.__get__('injectMetricsCollectorIntoNodeProject');
-                    await funcToTest(projectDir);
+            afterEach(() => {
+                fs.removeSync(projectDir);
+            });
+            it(`removes metrics collector from the project's package.json`, async() => {
+                await metricsService.removeMetricsCollectorFromProject('nodejs', projectDir);
 
-                    fs.readJSONSync(pathToPackageJson).should.deep.equal(expectedPackageJson);
-                });
+                fs.readJSONSync(pathToPackageJson).should.deep.equal(originalPackageJson);
+                fs.existsSync(pathToBackupPackageJson).should.be.false;
             });
         });
-        describe('getNewContentsOfPackageJson(originalContents)', () => {
-            it(`returns an object representing a package.json injected with metrics collector`, () => {
-                const funcToTest = metricsService.__get__('getNewContentsOfPackageJson');
-                const output = funcToTest(originalPackageJson);
-                output.should.deep.equal(expectedPackageJson);
+        describe(`('liberty', <goodProjectDir>)`, () => {
+            beforeEach(() => {
+                fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToExpectedPomXmlForLiberty));
+                fs.outputFileSync(pathToTestBackupPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
+
+                fs.outputFileSync(pathToJvmOptions, expectedJvmOptions);
+                fs.outputFileSync(pathToBackupJvmOptions, originalJvmOptions);
+            });
+            afterEach(() => {
+                fs.removeSync(projectDir);
+            });
+            it(`removes metrics collector from the project's jvm.options and pom.xml`, async() => {
+                await metricsService.removeMetricsCollectorFromProject('liberty', projectDir);
+
+                const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
+                outputJvmOptions.should.equal(originalJvmOptions);
+                fs.existsSync(pathToBackupJvmOptions).should.be.false;
+
+                const outputPomXml = await readXml(pathToTestPomXml);
+                outputPomXml.should.deep.equal(originalPomXmlForLiberty);
+                fs.existsSync(pathToTestBackupPomXml).should.be.false;
             });
         });
-        describe('getNewStartScript(originalStartScript)', () => {
-            const tests = [
-                {
-                    input: 'node server.js',
-                    expectedOutput: 'node -r appmetrics-codewind/attach server.js',
-                },
-                {
-                    input: 'nodemon server.js',
-                    expectedOutput: 'nodemon -r appmetrics-codewind/attach server.js',
-                },
-                {
-                    input: 'node -r appmetrics-codewind/attach server.js',
-                    expectedOutput: 'node -r appmetrics-codewind/attach server.js',
-                },
-            ];
-            for (const test of tests) {
-                describe(test.input, () => { // eslint-disable-line no-loop-func
-                    it(`returns ${test.expectedOutput}`, () => {
-                        const funcToTest = metricsService.__get__('getNewStartScript');
-                        const output = funcToTest(test.input);
-                        output.should.deep.equal(test.expectedOutput);
-                    });
-                });
-            }
+        describe(`('spring', <goodProjectDir>)`, () => {
+            beforeEach(() => {
+                fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToExpectedPomXmlForSpring));
+                fs.outputFileSync(pathToTestBackupPomXml, fs.readFileSync(pathToOriginalPomXmlForSpring));
+
+                fs.outputFileSync(pathToMainAppClassFile, expectedMainAppClassFile);
+                fs.outputFileSync(pathToBackupMainAppClassFile, originalMainAppClassFile);
+            });
+            afterEach(() => {
+                fs.removeSync(projectDir);
+            });
+            it(`removes metrics collector from the project's main app class file and pom.xml`, async() => {
+                await metricsService.removeMetricsCollectorFromProject('spring', projectDir);
+
+                const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
+                outputClassFile.should.equal(originalMainAppClassFile);
+                fs.existsSync(pathToBackupMainAppClassFile).should.be.false;
+
+                const outputPomXml = await readXml(pathToTestPomXml);
+                outputPomXml.should.deep.equal(originalPomXmlForSpring);
+                fs.existsSync(pathToTestBackupPomXml).should.be.false;
+            });
+        });
+        describe(`('unsupportedProjectType', <goodProjectDir>)`, () => {
+            beforeEach(() => {
+                fs.outputJSONSync(pathToPackageJson, expectedPackageJson);
+                fs.outputJSONSync(pathToBackupPackageJson, originalPackageJson);
+            });
+            afterEach(() => {
+                fs.removeSync(projectDir);
+            });
+            it(`throws a useful error`, () => {
+                const funcToTest = () => metricsService.removeMetricsCollectorFromProject('unsupportedProjectType', projectDir);
+                return funcToTest().should.be.rejectedWith(`Injection of metrics collector is not supported for projects of type 'unsupportedProjectType'`);
+            });
         });
     });
 
     describe('liberty', () => {
         describe('injectMetricsCollectorIntoLibertyProject(projectDir)', () => {
             beforeEach(() => {
-                fs.writeFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
+                fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
                 fs.outputFileSync(pathToJvmOptions, originalJvmOptions);
             });
             afterEach(() => {
-                fs.unlinkSync(pathToTestPomXml);
-                fs.unlinkSync(pathToJvmOptions);
+                fs.removeSync(projectDir);
             });
             it(`injects metrics collector into the project's jvm.options and pom.xml`, async() => {
                 const funcToTest = metricsService.__get__('injectMetricsCollectorIntoLibertyProject');
                 await funcToTest(projectDir);
 
-                const outputPomXml = await readXml(pathToTestPomXml);
-                outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForLiberty);
-
                 const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                 outputJvmOptions.should.equal(expectedJvmOptions);
+
+                const outputPomXml = await readXml(pathToTestPomXml);
+                outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForLiberty);
             });
         });
 
         describe('injectMetricsCollectorIntoPomXml(pathToPomXml)', () => {
             beforeEach(() => {
-                fs.writeFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
+                fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForLiberty));
             });
             afterEach(() => {
-                fs.unlinkSync(pathToTestPomXml);
+                fs.removeSync(projectDir);
             });
             it(`injects metrics collector into the project's pom.xml`, async() => {
                 const funcToTest = metricsService.__get__('injectMetricsCollectorIntoPomXml');
@@ -280,7 +307,7 @@ describe('MetricsService.js', () => {
                 fs.outputFileSync(pathToJvmOptions, originalJvmOptions);
             });
             afterEach(() => {
-                fs.unlinkSync(pathToJvmOptions);
+                fs.removeSync(projectDir);
             });
             it(`injects metrics collector into the project's pom.xml`, async() => {
                 const funcToTest = metricsService.__get__('injectMetricsCollectorIntoJvmOptions');
@@ -482,58 +509,77 @@ describe('MetricsService.js', () => {
     describe('spring', () => {
         describe('injectMetricsCollectorIntoSpringProject(projectDir)', () => {
             const tests = {
-                'Application.java in a dir with a name': {
-                    pathToApplicationJava: path.join(projectDir, 'src', 'main', 'java', 'application', 'Application.java'),
+                'main app class file in a dir with a name': {
+                    pathToMainAppClassFile: path.join(projectDir, 'src', 'main', 'java', 'application', 'Application.java'),
                 },
-                'Application.java with different name': {
-                    pathToApplicationJava: path.join(projectDir, 'src', 'main', 'java', 'application', 'Application2.java'),
+                'main app class file with different name': {
+                    pathToMainAppClassFile: path.join(projectDir, 'src', 'main', 'java', 'application', 'Application2.java'),
                 },
-                'Application.java in a different dir': {
-                    pathToApplicationJava: path.join(projectDir, 'src', 'main', 'java', 'Application.java'),
+                'main app class file in a different dir': {
+                    pathToMainAppClassFile: path.join(projectDir, 'src', 'main', 'java', 'Application.java'),
                 },
             };
             for (const [testName, test] of Object.entries(tests)) {
                 describe(testName, () => { // eslint-disable-line no-loop-func
                     before(() => {
-                        fs.writeFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForSpring));
-                        fs.outputFileSync(test.pathToApplicationJava, originalApplicationJava);
+                        fs.outputFileSync(pathToTestPomXml, fs.readFileSync(pathToOriginalPomXmlForSpring));
+                        fs.outputFileSync(test.pathToMainAppClassFile, originalMainAppClassFile);
                     });
                     after(() => {
-                        fs.unlinkSync(pathToTestPomXml);
-                        fs.unlinkSync(test.pathToApplicationJava);
+                        fs.removeSync(projectDir);
                     });
-                    it(`injects metrics collector into the project's Application.java and pom.xml`, async() => {
+                    it(`injects metrics collector into the project's main app class file and pom.xml`, async() => {
                         const funcToTest = metricsService.__get__('injectMetricsCollectorIntoSpringProject');
                         await funcToTest(projectDir);
 
+                        const outputClassFile = fs.readFileSync(test.pathToMainAppClassFile, 'utf8');
+                        outputClassFile.should.equal(expectedMainAppClassFile);
+                        const outputBackupClassFile = fs.readFileSync(pathToBackupMainAppClassFile, 'utf8');
+                        outputBackupClassFile.should.deep.equal(originalMainAppClassFile);
+
                         const outputPomXml = await readXml(pathToTestPomXml);
                         outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForSpring);
-
-                        const outputApplicationJava = fs.readFileSync(test.pathToApplicationJava, 'utf8');
-                        outputApplicationJava.should.equal(expectedApplicationJava);
+                        const outputBackupPomXml = await readXml(pathToTestBackupPomXml);
+                        outputBackupPomXml.should.deep.equal(originalPomXmlForSpring);
                     });
                 });
             }
         });
 
+        describe('getPathToMainAppClassFile(projectDir)', () => {
+            describe('<projectDir> contains multiple files', () => {
+                beforeEach(() => {
+                    fs.outputFileSync(pathToMainAppClassFile, expectedMainAppClassFile);
+                    fs.outputFileSync(path.join(pathToJavaProjectSrcFiles, 'second file.java'), 'dummy contents');
+                });
+                afterEach(() => {
+                    fs.removeSync(projectDir);
+                });
+                it('returns the path to the main app class file', async() => {
+                    const funcToTest = metricsService.__get__('getPathToMainAppClassFile');
+                    const output = await funcToTest(projectDir);
+                    output.should.equal(pathToMainAppClassFile);
+                });
+            });
+        });
 
-        describe('getNewContentsOfApplicationJava(originalContents)', () => {
+        describe('getNewContentsOfMainAppClassFile(originalContents)', () => {
             const tests = {
                 'package application': {
-                    originalApplicationJava,
-                    expectedApplicationJava,
+                    originalMainAppClassFile,
+                    expectedMainAppClassFile,
                 },
                 'package application2': {
-                    originalApplicationJava: fs.readFileSync(path.join(pathToApplicationJavas, 'package2', 'without collector.java'), 'utf8'),
-                    expectedApplicationJava: fs.readFileSync(path.join(pathToApplicationJavas, 'package2', 'with collector.java'), 'utf8'),
+                    originalMainAppClassFile: fs.readFileSync(path.join(pathToMainAppClassFiles, 'package2', 'without collector.java'), 'utf8'),
+                    expectedMainAppClassFile: fs.readFileSync(path.join(pathToMainAppClassFiles, 'package2', 'with collector.java'), 'utf8'),
                 },
             };
             for (const [testName, test] of Object.entries(tests)) {
                 describe(testName, () => { // eslint-disable-line no-loop-func
-                    it('returns an object representing an Application.java injected with metrics collector', () => {
-                        const funcToTest = metricsService.__get__('getNewContentsOfApplicationJava');
-                        const output = funcToTest(test.originalApplicationJava);
-                        output.should.deep.equalInAnyOrder(test.expectedApplicationJava);
+                    it('returns an object representing an app class file injected with metrics collector', () => {
+                        const funcToTest = metricsService.__get__('getNewContentsOfMainAppClassFile');
+                        const output = funcToTest(test.originalMainAppClassFile);
+                        output.should.deep.equalInAnyOrder(test.expectedMainAppClassFile);
                     });
                 });
             }
@@ -586,6 +632,92 @@ describe('MetricsService.js', () => {
             });
         });
 
+    });
+});
+
+describe('metricsService/node.js', () => {
+    suppressLogOutput(nodeMetricsService);
+
+    describe('removeMetricsCollectorFromNodeProject(projectDir)', () => {
+        before(() => {
+            fs.outputJSONSync(pathToPackageJson, expectedPackageJson);
+            fs.outputJSONSync(pathToBackupPackageJson, originalPackageJson);
+        });
+        after(() => {
+            fs.removeSync(projectDir);
+        });
+        it(`removes metrics collector from the project's package.json`, async() => {
+            const funcToTest = nodeMetricsService.removeMetricsCollectorFromNodeProject;
+            await funcToTest(projectDir);
+
+            fs.readJSONSync(pathToPackageJson).should.deep.equal(originalPackageJson);
+            fs.existsSync(pathToBackupPackageJson).should.be.false;
+        });
+    });
+    describe('injectMetricsCollectorIntoNodeProject(projectDir)', () => {
+        describe('package.json does not have metrics injection code', () => {
+            before(() => {
+                fs.outputJSONSync(pathToPackageJson, originalPackageJson);
+            });
+            after(() => {
+                fs.removeSync(projectDir);
+            });
+            it(`injects metrics collector into the project's package.json, and saves a back up`, async() => {
+                const funcToTest = nodeMetricsService.injectMetricsCollectorIntoNodeProject;
+                await funcToTest(projectDir);
+
+                fs.readJSONSync(pathToPackageJson).should.deep.equal(expectedPackageJson);
+                fs.readJSONSync(pathToBackupPackageJson).should.deep.equal(originalPackageJson);
+            });
+        });
+        describe('package.json already has metrics injection code', () => {
+            before(() => {
+                fs.outputJSONSync(pathToPackageJson, expectedPackageJson);
+            });
+            after(() => {
+                fs.removeSync(projectDir);
+            });
+            it(`does not change the project's package.json, but saves a back up`, async() => {
+                const funcToTest = nodeMetricsService.__get__('injectMetricsCollectorIntoNodeProject');
+                await funcToTest(projectDir);
+
+                fs.readJSONSync(pathToPackageJson).should.deep.equal(expectedPackageJson);
+                fs.readJSONSync(pathToBackupPackageJson).should.deep.equal(expectedPackageJson);
+            });
+        });
+    });
+
+    describe('getNewContentsOfPackageJson(originalContents)', () => {
+        it(`returns an object representing a package.json injected with metrics collector`, () => {
+            const funcToTest = nodeMetricsService.__get__('getNewContentsOfPackageJson');
+            const output = funcToTest(originalPackageJson);
+            output.should.deep.equal(expectedPackageJson);
+        });
+    });
+    describe('getNewStartScript(originalStartScript)', () => {
+        const tests = [
+            {
+                input: 'node server.js',
+                expectedOutput: 'node -r appmetrics-codewind/attach server.js',
+            },
+            {
+                input: 'nodemon server.js',
+                expectedOutput: 'nodemon -r appmetrics-codewind/attach server.js',
+            },
+            {
+                input: 'node -r appmetrics-codewind/attach server.js',
+                expectedOutput: 'node -r appmetrics-codewind/attach server.js',
+            },
+        ];
+        for (const test of tests) {
+            describe(test.input, () => { // eslint-disable-line no-loop-func
+                it(`returns ${test.expectedOutput}`, () => {
+                    const funcToTest = nodeMetricsService.__get__('getNewStartScript');
+                    const output = funcToTest(test.input);
+                    output.should.deep.equal(test.expectedOutput);
+                });
+            });
+        }
     });
 });
 


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

This pr bumps the level of centos to be centos8.  This is to pick up the latest Python release as the 2.7 version in centos7 has security issues.   

Centos8 no longer package 2 of the modules required by buildah so I have added them manually to the docker-compose file