### PR TITLE
upgrade to centos8

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -8,23 +8,27 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
-#FROM centos:7
+#FROM centos as codewind-pfe-base
 
-FROM centos@sha256:b5e66c4651870a1ad435cd75922fe2cb943c9e973a9673822d1414824a1d0475 as codewind-pfe-base
+FROM centos@sha256:f94c1d992c193b3dc09e297ffd54d8a4f1dc946c37cbeceb26d35ce1647f88d9 as codewind-pfe-base
 LABEL org.label-schema.name="Codewind PFE" org.label-schema.description="Codewind PFE" \
       org.label-schema.url="https://codewind.dev/" \
       org.label-schema.vcs-url="https://github.com/eclipse/codewind" org.label-schema.vendor="IBM"
 
-ARG BUILDAH_RPM=https://cbs.centos.org/kojifiles/packages/buildah/1.11.2/2.git0bafbfe.el7/x86_64/buildah-1.11.2-2.git0bafbfe.el7.x86_64.rpm
+ARG BUILDAH_RPM=https://cbs.centos.org/kojifiles/packages/buildah/1.11.4/4.el7/x86_64/buildah-1.11.4-4.el7.x86_64.rpm
+ARG SLIRP=https://cbs.centos.org/kojifiles/packages/slirp4netns/0.3.0/2.git4992082.el7/x86_64/slirp4netns-0.3.0-2.git4992082.el7.x86_64.rpm
+ARG LIBSEC=https://cbs.centos.org/kojifiles/packages/libseccomp/2.4.1/0.el7/x86_64/libseccomp-2.4.1-0.el7.x86_64.rpm
 
 # Download the buildah RPM
 RUN curl -f -o buildah.rpm $BUILDAH_RPM
+RUN curl -f -o slirp4netns.rpm $SLIRP
+RUN curl -f -o libseccomp.rpm $LIBSEC
 
 # Download and set up Node 10.x RPM
 RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
 
 RUN yum install -y epel-release \
-    && yum -y --enablerepo=epel install zip unzip sudo ca-certificates openssl nodejs buildah.rpm \
+    && yum -y --enablerepo=epel install zip unzip sudo ca-certificates openssl nodejs slirp4netns.rpm libseccomp.rpm buildah.rpm \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -12,7 +12,7 @@ const chai = require('chai');
 const chaiResValidator = require('chai-openapi-response-validator');
 
 const reqService = require('../../modules/request.service');
-const { ADMIN_COOKIE, pathToApiSpec } = require('../../config');
+const { ADMIN_COOKIE, pathToApiSpec, testTimeout } = require('../../config');
 
 chai.use(chaiResValidator(pathToApiSpec));
 chai.should();
@@ -20,7 +20,7 @@ chai.should();
 describe('Project Types API tests', function() {
 
     it('should return expected list of project types', async function() {
-        this.timeout(10000);
+        this.timeout(testTimeout.med);
         const res = await reqService.chai
             .get('/api/v1/project-types')
             .set('Cookie', ADMIN_COOKIE);


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

This pr bumps the level of centos to be centos8. This is to pick up the latest Python release as the 2.7 version in centos7 has security issues.

Centos8 no longer package 2 of the modules required by buildah so I have added them manually to the docker-compose file