### PR TITLE
fix: prevent injecting metrics collector twice

### DIFF
--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -103,25 +103,33 @@ async function backUpFile(pathToOriginal, pathToBackup) {
 }
 
 async function injectMetricsCollectorIntoLibertyProject(projectDir) {
-  const pathToPomXml = getPathToPomXml(projectDir);
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
+  const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
+  if ((await fs.exists(pathToBackupPomXml)) || (await fs.exists(pathToBackupJvmOptions))) {
+    throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
+  }
+
+  const pathToPomXml = getPathToPomXml(projectDir);
   await backUpFile(pathToPomXml, pathToBackupPomXml);
   await injectMetricsCollectorIntoPomXml(pathToPomXml);
 
   const pathToJvmOptions = getPathToJvmOptions(projectDir);
-  const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
   await backUpFile(pathToJvmOptions, pathToBackupJvmOptions);
   await injectMetricsCollectorIntoJvmOptions(pathToJvmOptions);
 }
 
 async function injectMetricsCollectorIntoSpringProject(projectDir) {
-  const pathToPomXml = getPathToPomXml(projectDir);
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
+  const pathToBackupMainAppClassFile = getPathToBackupMainAppClassFile(projectDir);
+  if ((await fs.exists(pathToBackupPomXml)) || (await fs.exists(pathToBackupMainAppClassFile))) {
+    throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
+  }
+
+  const pathToPomXml = getPathToPomXml(projectDir);
   await backUpFile(pathToPomXml, pathToBackupPomXml);
   await injectMetricsCollectorIntoPomXmlForSpring(pathToPomXml);
 
   const pathToMainAppClassFile = await getPathToMainAppClassFile(projectDir);
-  const pathToBackupMainAppClassFile = getPathToBackupMainAppClassFile(projectDir);
   await backUpFile(pathToMainAppClassFile, pathToBackupMainAppClassFile);
   await injectMetricsCollectorIntoMainAppClassFile(pathToMainAppClassFile);
 }

--- a/src/pfe/portal/modules/metricsService/node.js
+++ b/src/pfe/portal/modules/metricsService/node.js
@@ -11,10 +11,14 @@ const getPathToPackageJson = (projectDir) => path.join(projectDir, 'package.json
 const getPathToBackupPackageJson = (projectDir) => path.join(projectDir, 'backupPackage.json');
 
 async function injectMetricsCollectorIntoNodeProject(projectDir) {
+  const pathToBackupPackageJson = getPathToBackupPackageJson(projectDir);
+  if (await fs.exists(pathToBackupPackageJson)) {
+    throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
+  }
+
   const pathToPackageJson = getPathToPackageJson(projectDir);
   const originalContentsOfPackageJson = await fs.readJSON(pathToPackageJson);
 
-  const pathToBackupPackageJson = getPathToBackupPackageJson(projectDir);
   await fs.writeJSON(pathToBackupPackageJson, originalContentsOfPackageJson, { spaces: 2 });
 
   const newContentsOfPackageJson = getNewContentsOfPackageJson(originalContentsOfPackageJson);


### PR DESCRIPTION
Improves part 1 of #1315. 

**Problem**
When we inject metrics collector into a project (e.g. by calling `POST projects/{id}/metrics/inject` with `{ enable: true }`), we save a backup of the project files we've changed. If we then injected again (e.g. if the user calls the api again), we would comply and in the process overwrite that backup with the project files that we injected into the first time.

**Solution**
Whenever we are about to inject metrics collector into a project, first check whether we have already injected metrics into that project. If so, return a 500 error to the user. 

(We could change this to return 4XX, but I think 500 is fine for now, because no user should currently be allowed to trigger metrics injection if we have already injected metrics). 

To "check whether we have already injected metrics into that project", we check whether relevant backup files already exist. We assume that we are the only people who would create files with these names (e.g. `backupPackage.json`, `backupPom.xml`). To further avoid clashes, we could make these names more unique to Codewind.


**Testing**
Unit tests with 100% coverage

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>