### PR TITLE
Change key from appErrorStatus -> detailedAppStatus on Turbine Test Configs

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
@@ -66,7 +66,7 @@ export function updateStatusTest(socket: SocketIO, projData: projectsController.
                 "parameters": ["projectID", "status", "error"],
                 "values": [projectID],
                 "states": ["unknown", "stopping", "stopped", "starting", "started"],
-                "eventKeys": ["projectID", "appStatus", "appErrorStatus"],
+                "eventKeys": ["projectID", "appStatus", "detailedAppStatus"],
                 "result": {
                     "projectID": projectID
                 }


### PR DESCRIPTION
### Description

https://github.com/eclipse/codewind/pull/1334 changed the key on `projectStatusChanged` event. This PR fixes it.

![Screen Shot 2019-12-04 at 3 10 37 PM](https://user-images.githubusercontent.com/15173354/70177449-656a3f00-16a8-11ea-8792-6b7fdae8705a.png)


Signed-off-by: ssh24 <sakib@ibm.com>