### PR TITLE
Minor fixes to /projects/{id}/metrics/inject api

### DIFF
--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -36,17 +36,17 @@ async function inject(req, res) {
       return;
     }
 
-    await user.projectList.updateProject({
-      projectID: projectID,
-      injectMetrics: injectMetrics
-    });
-
     const projectDir = path.join(project.workspace, project.directory);
     if (injectMetrics) {
       await metricsService.injectMetricsCollectorIntoProject(project.projectType, projectDir);
     } else {
       await metricsService.removeMetricsCollectorFromProject(project.projectType, projectDir);
     }
+
+    await user.projectList.updateProject({
+      projectID: projectID,
+      injectMetrics: injectMetrics
+    });
 
     res.sendStatus(202);
 

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -32,7 +32,7 @@ async function inject(req, res) {
     if (!project) {
       const message = `Unable to find project ${projectID}`;
       log.error(message);
-      res.status(404).send({ message });
+      res.status(404).send(message);
       return;
     }
 
@@ -53,7 +53,7 @@ async function inject(req, res) {
     await syncProjectFilesIntoBuildContainer(project, user);
   } catch (err) {
     log.error(err);
-    res.status(500).send(err.info || err);
+    res.status(500).send(err.info || err.message);
   }
 }
 

--- a/test/src/unit/controllers/metrics.controller.test.js
+++ b/test/src/unit/controllers/metrics.controller.test.js
@@ -38,7 +38,7 @@ describe('metrics.controller.js', () => {
             res.status.should.be.calledOnceWith(404);
             res.send.should.be.calledOnceWith('Unable to find project nonexistentProjectId');
         });
-        it('returns 500 if our server errors', async() => {
+        it('returns 500 if our server errors while parsing the request', async() => {
             const request = {};
             const req = mockReq(request);
             const res = mockRes();
@@ -48,7 +48,7 @@ describe('metrics.controller.js', () => {
             res.status.should.be.calledOnceWith(500);
             res.send.args[0][0].should.equal('req.sanitizeParams is not a function');
         });
-        it('returns 500 if our server errors while inserting metrics collector into project', async() => {
+        it('returns 500 and does not update the project.inf if our server errors while inserting metrics collector into project', async() => {
             const request = {
                 sanitizeParams: () => 'goodProjectID',
                 sanitizeBody: () => true,
@@ -59,7 +59,7 @@ describe('metrics.controller.js', () => {
                             directory: 'projectDir',
                             projectType: 'unsupportedProjectType',
                         }),
-                        updateProject: () => {},
+                        updateProject: () => { throw new Error('we should not update the project.inf'); },
                     },
                 },
             };
@@ -71,7 +71,7 @@ describe('metrics.controller.js', () => {
             res.status.should.be.calledOnceWith(500);
             res.send.args[0][0].should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
         });
-        it('returns 500 if our server errors while removing metrics collector from project', async() => {
+        it('returns 500 and does not update the project.inf if our server errors while removing metrics collector from project', async() => {
             const request = {
                 sanitizeParams: () => 'goodProjectID',
                 sanitizeBody: () => false,
@@ -82,7 +82,7 @@ describe('metrics.controller.js', () => {
                             directory: 'projectDir',
                             projectType: 'unsupportedProjectType',
                         }),
-                        updateProject: () => {},
+                        updateProject: () => { throw new Error('we should not update the project.inf'); },
                     },
                 },
             };

--- a/test/src/unit/controllers/metrics.controller.test.js
+++ b/test/src/unit/controllers/metrics.controller.test.js
@@ -36,7 +36,7 @@ describe('metrics.controller.js', () => {
             await metricsController.inject(req, res);
 
             res.status.should.be.calledOnceWith(404);
-            res.send.should.be.calledOnceWith({ message: 'Unable to find project nonexistentProjectId' });
+            res.send.should.be.calledOnceWith('Unable to find project nonexistentProjectId');
         });
         it('returns 500 if our server errors', async() => {
             const request = {};
@@ -46,7 +46,7 @@ describe('metrics.controller.js', () => {
             await metricsController.inject(req, res);
 
             res.status.should.be.calledOnceWith(500);
-            res.send.args[0][0].message.should.equal('req.sanitizeParams is not a function');
+            res.send.args[0][0].should.equal('req.sanitizeParams is not a function');
         });
         it('returns 500 if our server errors while inserting metrics collector into project', async() => {
             const request = {
@@ -69,7 +69,7 @@ describe('metrics.controller.js', () => {
             await metricsController.inject(req, res);
 
             res.status.should.be.calledOnceWith(500);
-            res.send.args[0][0].message.should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
+            res.send.args[0][0].should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
         });
         it('returns 500 if our server errors while removing metrics collector from project', async() => {
             const request = {
@@ -92,7 +92,7 @@ describe('metrics.controller.js', () => {
             await metricsController.inject(req, res);
 
             res.status.should.be.calledOnceWith(500);
-            res.send.args[0][0].message.should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
+            res.send.args[0][0].should.equal('Injection of metrics collector is not supported for projects of type \'unsupportedProjectType\'');
         });
         it('returns 202 and injects metrics collector into project build container if we provide a good request', async() => {
             const request = {


### PR DESCRIPTION
Improves https://github.com/eclipse/codewind/issues/1290

Thanks @tetchel and @james-wallis for spotting the need for these:
* 500 response now returns error.message instead of entire error
* If we error while injecting or removing metrics, no longer update the project.inf

Change set has 100% unit test coverage

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>