### PR TITLE
Remove detailedAppStatus on disable and use NSL for messages

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -437,13 +437,9 @@ function pingApplications(): void {
                                 };
                                 pingCountMap.delete(projectID);
                             } else if (shouldEmitMsg) {
-                                let translatedMsg;
-                                if (newMsg) {
-                                    translatedMsg = (newMsg.trim().length === 0) ? newMsg : await locale.getTranslation(newMsg);
-                                }
                                 data.detailedAppStatus = {
                                     severity: "ERROR",
-                                    message: translatedMsg,
+                                    message: newMsg,
                                     notify: false
                                 };
                             }
@@ -523,10 +519,6 @@ function pingInTransitApplications(): void {
                                         projectID: projectID,
                                         appStatus: newState
                                     };
-                                    let translatedMsg;
-                                    if (newMsg) {
-                                        translatedMsg = (newMsg.trim().length === 0) ? newMsg : await locale.getTranslation(newMsg);
-                                    }
                                     if (newState === AppState.started) {
                                         data.detailedAppStatus = {
                                             severity: "INFO",
@@ -537,13 +529,13 @@ function pingInTransitApplications(): void {
                                     } else if (newState === AppState.starting && pingCount == pingCountLimit) {
                                         data.detailedAppStatus = {
                                             severity: "WARN",
-                                            message: translatedMsg,
+                                            message: newMsg,
                                             notify: true
                                         };
                                     } else if (shouldEmitMsg) {
                                         data.detailedAppStatus = {
                                             severity: "ERROR",
-                                            message: translatedMsg,
+                                            message: newMsg,
                                             notify: false
                                         };
                                     }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -63,6 +63,8 @@ const isApplicationPodUpIntervalMap = new Map();
 
 export const firstTimePingArray = new Array();
 
+export let pingMessage: string;
+
 export interface ProjectEvent {
     operationId: string;
     projectID: string;
@@ -2135,15 +2137,18 @@ export async function updateDetailedAppStatus(projectID: string, ip: string, por
     const oldMsg = appStateMap.get(projectID).msg;
 
     let pingPathEvent: DetailedAppStatus;
-    pingPathEvent = {
-        severity: "INFO",
-        message: await locale.getTranslation("projectUtil.pingMessage", { ip: ip, port: port, path: path }),
-        notify: false
-    };
 
     if (isDefaultPath) {
-        pingPathEvent.message = await locale.getTranslation("projectUtil.defaultPingPathMessage", { ip: ip, port: port, path: path });
+        pingMessage = await locale.getTranslation("projectUtil.defaultPingPathMessage", { ip: ip, port: port, path: path });
+    } else {
+        pingMessage = await locale.getTranslation("projectUtil.pingMessage", { ip: ip, port: port, path: path });
     }
+
+    pingPathEvent = {
+        severity: "INFO",
+        message: pingMessage,
+        notify: false
+    };
 
     if (oldState === AppState.starting) {
         projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathEvent);

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -967,7 +967,7 @@ export async function isContainerActive(projectID: string, handler: any): Promis
             const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
             if (projectHandler.hasOwnProperty("getContainerStatus")) {
                 projectHandler.getContainerStatus(projectInfo, containerName, async (err: Error, state: ContainerStates) => {
-                    const errMsg = (err) ? await locale.getTranslation("appStatusError.errorGetContainerStatus", { errMsg: err.toString() }) : undefined;
+                    const errMsg = (err) ? await locale.getTranslation("projectUtil.appStatusError.errorGetContainerStatus", { errMsg: err.toString() }) : undefined;
                     handler({ state: state, error: errMsg });
                 });
             } else {
@@ -1002,7 +1002,7 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
 
         const containerInfo: kubeutil.PodInfo | dockerutil.ContainerInfo = await getContainerInfo(projectInfo, containerInfoForceRefreshMap.get(projectInfo.projectID));
         if (!containerInfo) {
-            handler({ error: await locale.getTranslation("appStatusError.errorGetContainerInfo") });
+            handler({ error: await locale.getTranslation("projectUtil.appStatusError.errorGetContainerInfo") });
             return;
         }
 
@@ -1010,15 +1010,15 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
 
         // If no ip or port then application is not running
         if (!port) {
-            handler({ error: await locale.getTranslation("appStatusError.errorGetPort") });
+            handler({ error: await locale.getTranslation("projectUtil.appStatusError.errorGetPort") });
             return;
         }
 
         if (process.env.IN_K8 !== "true" && !containerInfo.ip) {
-            handler({ error: await locale.getTranslation("appStatusError.errorGetIP") });
+            handler({ error: await locale.getTranslation("projectUtil.appStatusError.errorGetIP") });
             return;
         } else if (process.env.IN_K8 === "true" && !containerInfo.serviceName) {
-            handler({ error: await locale.getTranslation("appStatusError.errorGetHostname") });
+            handler({ error: await locale.getTranslation("projectUtil.appStatusError.errorGetHostname") });
             return;
         }
 
@@ -1094,29 +1094,29 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
                     isGoodStatusCode = statusCode >= 200 && statusCode < 400;
 
                     if (!isGoodStatusCode) {
-                        handler({ isAppUp: false, error: await locale.getTranslation("appStatusError.badStatusCode", { statusCode: statusCode}) });
+                        handler({ isAppUp: false, error: await locale.getTranslation("projectUtil.appStatusError.badStatusCode", { statusCode: statusCode}) });
                     } else {
                         handler({ isAppUp: true });
                     }
                 }).on("error", async (err) => {
-                    handler({ isAppUp: false, error: await locale.getTranslation("appStatusError.errorGetAppStatus", { errMsg: err.message }) });
+                    handler({ isAppUp: false, error: await locale.getTranslation("projectUtil.appStatusError.errorGetAppStatus", { errMsg: err.message }) });
                 }).on("timeout", async () => {
                     if (!statusCode) {
-                        handler({ isAppUp: false, error: await locale.getTranslation("appStatusError.httpRequestTimeout") });
+                        handler({ isAppUp: false, error: await locale.getTranslation("projectUtil.appStatusError.httpRequestTimeout") });
                     }
                 }).end();
             } else {
-                handler({ isAppUp: false, error: await locale.getTranslation("appStatusError.badStatusCode", { statusCode: statusCode}) });
+                handler({ isAppUp: false, error: await locale.getTranslation("projectUtil.appStatusError.badStatusCode", { statusCode: statusCode}) });
             }
         }).on("error", async (err) => {
-            handler({ isAppUp: false, error: await locale.getTranslation("appStatusError.errorGetAppStatus", { errMsg: err.message }) });
+            handler({ isAppUp: false, error: await locale.getTranslation("projectUtil.appStatusError.errorGetAppStatus", { errMsg: err.message }) });
         }).on("timeout", async () => {
             if (!statusCode) {
-                handler({ isAppUp: false, error: await locale.getTranslation("appStatusError.httpRequestTimeout") });
+                handler({ isAppUp: false, error: await locale.getTranslation("projectUtil.appStatusError.httpRequestTimeout") });
             }
         }).end();
     } catch (err) {
-        handler({ error: await locale.getTranslation("appStatusError.errorGetAppStatus", { errMsg: err.message }) });
+        handler({ error: await locale.getTranslation("projectUtil.appStatusError.errorGetAppStatus", { errMsg: err.message }) });
     }
 }
 
@@ -2128,21 +2128,21 @@ export async function restartProject(operation: Operation, startMode: string, ev
  * @param port <Required | String> - The project port that Turbine pings.
  * @param path <Required | String> - The project path that Turbine pings.
  *
- * @returns void
+ * @returns Promise<void>
  */
-export function updateDetailedAppStatus(projectID: string, ip: string, port: string, path: string, isDefaultPath?: boolean): void {
+export async function updateDetailedAppStatus(projectID: string, ip: string, port: string, path: string, isDefaultPath?: boolean): Promise<void> {
     const oldState = appStateMap.get(projectID).state;
     const oldMsg = appStateMap.get(projectID).msg;
 
     let pingPathEvent: DetailedAppStatus;
     pingPathEvent = {
         severity: "INFO",
-        message: `Pinging http://${ip}:${port}${path}`,
+        message: await locale.getTranslation("projectUtil.pingMessage", { ip: ip, port: port, path: path }),
         notify: false
     };
 
     if (isDefaultPath) {
-        pingPathEvent.message = `${pingPathEvent.message} and http://${ip}:${port}/`;
+        pingPathEvent.message = await locale.getTranslation("projectUtil.defaultPingPathMessage", { ip: ip, port: port, path: path });
     }
 
     if (oldState === AppState.starting) {

--- a/src/pfe/file-watcher/server/src/utils/locale.ts
+++ b/src/pfe/file-watcher/server/src/utils/locale.ts
@@ -140,7 +140,7 @@ export async function getTranslation(key: string, options?: i18next.TOptions): P
     // Fail-safe. Incase if for some reason, FW cannot fetch translation after
     // i18next is initialized successfully, parse it from the English translation file
     if (translatedMsg == key) {
-        logger.logTrace("File-watcher could not fetch the translation using the translation service");
+        logger.logError("File-watcher could not fetch the translation using the translation service");
         logger.logTrace("Attempting to parse the translation file");
         translatedMsg = await getMessageFromFile(key, "en");
     }
@@ -211,12 +211,12 @@ export async function getMessageFromFile(key: string, backupLang?: string): Prom
         for (const element in keyArray) {
             message = message[keyArray[element]];
             if (!message || message == "") {
-                logger.logTrace("File watcher was unable to find the key in the translation file, the key will be used as the translation value: " + key);
+                logger.logError("File watcher was unable to find the key in the translation file, the key will be used as the translation value: " + key);
                 return key;
             }
         }
     } catch (err) {
-        logger.logTrace("Error parsing the translation file, the key will be used as the translation value: " + key);
+        logger.logError("Error parsing the translation file, the key will be used as the translation value: " + key);
         return key;
     }
 

--- a/src/pfe/file-watcher/server/src/utils/locale.ts
+++ b/src/pfe/file-watcher/server/src/utils/locale.ts
@@ -140,7 +140,7 @@ export async function getTranslation(key: string, options?: i18next.TOptions): P
     // Fail-safe. Incase if for some reason, FW cannot fetch translation after
     // i18next is initialized successfully, parse it from the English translation file
     if (translatedMsg == key) {
-        logger.logError("File-watcher could not fetch the translation using the translation service");
+        logger.logTrace("File-watcher could not fetch the translation using the translation service");
         logger.logTrace("Attempting to parse the translation file");
         translatedMsg = await getMessageFromFile(key, "en");
     }
@@ -211,12 +211,12 @@ export async function getMessageFromFile(key: string, backupLang?: string): Prom
         for (const element in keyArray) {
             message = message[keyArray[element]];
             if (!message || message == "") {
-                logger.logError("File watcher was unable to find the key in the translation file, the key will be used as the translation value: " + key);
+                logger.logTrace("File watcher was unable to find the key in the translation file, the key will be used as the translation value: " + key);
                 return key;
             }
         }
     } catch (err) {
-        logger.logError("Error parsing the translation file, the key will be used as the translation value: " + key);
+        logger.logTrace("Error parsing the translation file, the key will be used as the translation value: " + key);
         return key;
     }
 

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -73,7 +73,19 @@
     "generateMissingFilesDescription": "Generate missing required files."
   },
   "projectUtil": {
-    "projectInfoError": "could not retrieve project info"
+    "projectInfoError": "could not retrieve project info",
+    "pingMessage": "Pinging http://{{ip}}:{{port}}{{- path}}",
+    "defaultPingPathMessage": "Pinging http://{{ip}}:{{port}}{{- path}} and http://{{ip}}:{{port}}/",
+    "appStatusError": {
+      "errorGetContainerStatus": "Failed to get container status: {{errMsg}}",
+      "errorGetAppStatus": "Failed to get application status: {{errMsg}}",
+      "httpRequestTimeout": "Http request is failed due to timeout error",
+      "errorGetContainerInfo": "Could not retrieve container info for the project",
+      "errorGetPort": "Could not retrieve the port for the project",
+      "errorGetIP": "Could not retrieve the ip for the project",
+      "errorGetHostname": "Could not retrieve the hostname for the project service",
+      "badStatusCode": "Received response, but with bad status code {{statusCode}} when pinging project"
+    }
   },
   "validator": {
     "requiredFiles": {
@@ -136,15 +148,5 @@
         "details": "This project's pom.xml specifies an invalid packaging for its output. Only Spring projects with jar packaging are supported for this project type."
       }
     }
-  },
-  "appStatusError": {
-    "errorGetContainerStatus": "Failed to get container status: {{errMsg}}",
-    "errorGetAppStatus": "Failed to get application status: {{errMsg}}",
-    "httpRequestTimeout": "Http request is failed due to timeout error",
-    "errorGetContainerInfo": "Could not retrieve container info for the project",
-    "errorGetPort": "Could not retrieve the port for the project",
-    "errorGetIP": "Could not retrieve the ip for the project",
-    "errorGetHostname": "Could not retrieve the hostname for the project service",
-    "badStatusCode": "Received response, but with bad status code {{statusCode}} when pinging project"
   }
 }

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -66,7 +66,8 @@
     "buildRank": "Rank {{- rank}}",
     "buildStarted": "Build started",
     "appErrorWhenStopping": "An error occurred while the application was stopping. Check the application logs for details.",
-    "pingTimeout": "The application is taking longer than expected to start. Please check the application logs for problems and ensure the project's 'healthCheck' setting is correct."
+    "pingTimeout": "Timeout: {{- pingMessage}}. The application is taking longer than expected to start. Please check the application logs for problems and ensure the project's 'healthCheck' setting is correct. Last error message received: {{- errMsg}}", 
+    "pingTimeoutDefaultMessage": "Failed to ping application."
   },
   "quickfix": {
     "generateMissingFilesName": "Generate missing files",

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -136,5 +136,15 @@
         "details": "This project's pom.xml specifies an invalid packaging for its output. Only Spring projects with jar packaging are supported for this project type."
       }
     }
+  },
+  "appStatusError": {
+    "errorGetContainerStatus": "Failed to get container status: {{errMsg}}",
+    "errorGetAppStatus": "Failed to get application status: {{errMsg}}",
+    "httpRequestTimeout": "Http request is failed due to timeout error",
+    "errorGetContainerInfo": "Could not retrieve container info for the project",
+    "errorGetPort": "Could not retrieve the port for the project",
+    "errorGetIP": "Could not retrieve the ip for the project",
+    "errorGetHostname": "Could not retrieve the hostname for the project service",
+    "badStatusCode": "Received response, but with bad status code {{statusCode}} when pinging project"
   }
 }

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -522,7 +522,8 @@ module.exports = class FileWatcher {
         ports: '',
         buildStatus: 'unknown',
         appStatus: 'unknown',
-        state: Project.STATES.closed
+        state: Project.STATES.closed,
+        detailedAppStatus: undefined
       }
       // Set the container key to '' as the container has stopped.
       const containerKey = (global.codewind.RUNNING_IN_K8S ? 'podName' : 'containerId');


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

1. When disabling the project,  clears the detailedAppStatus in project.inf. 
2.  Only set the project status to be `stopped` if the application is not up, and it's not in `starting` state. 
otherwise we are going to see the status flipped .

3. use NLS for messages that would display in ui


```
[06/12/19 00:03:53 spring111] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "8c511700-17b7-11ea-aeca-97eae60ed202",
  "appStatus": "starting",
  "detailedAppStatus": {
    "severity": "INFO",
    "message": "Pinging http://172.18.0.4:8080/heii",
    "notify": false
  }
}
[06/12/19 00:04:51 spring111] [INFO] Emitting event 
 message: projectStatusChanged
 data: {
  "projectID": "8c511700-17b7-11ea-aeca-97eae60ed202",
  "appStatus": "starting",
  "detailedAppStatus": {
    "severity": "WARN",
    "message": "Timeout: Pinging http://172.18.0.4:8080/heii. The application is taking longer than expected to start. Please check the application logs for problems and ensure the project's 'healthCheck' setting is correct. Last error message received: Received response, but with bad status code 404 when pinging project",
    "notify": true
  }
}
```
