### PR TITLE
Handle Docker Config if Secret create and/or Service Acc patch fails

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -667,7 +667,8 @@ module.exports = class User {
   }
 
   /**
-   * Function to setup the Docker config file and Kube secret
+   * Function to setup the Docker config file. In Kubernetes, the function also creates the Codewind secret from
+   * the Docker config and patches the Service Account with the created Codewind Secret. On local, this is skipped.
    */
   async setupRegistrySecret(credentials, address) {
     const credentialsJSON = JSON.parse(Buffer.from(credentials, "base64").toString());
@@ -737,8 +738,10 @@ module.exports = class User {
 
     // Only update the Kube secret when running in K8s
     let isServiceAccountPatched = false;
+    let serviceAccountPatchData;
     if (global.codewind.RUNNING_IN_K8S) {
-      isServiceAccountPatched = await this.updateServiceAccountWithDockerRegisrySecret();
+      serviceAccountPatchData = await this.updateServiceAccountWithDockerRegisrySecret();
+      isServiceAccountPatched = serviceAccountPatchData.isServiceAccountPatched;
     }
 
     if (isServiceAccountPatched || !global.codewind.RUNNING_IN_K8S) {
@@ -747,24 +750,25 @@ module.exports = class User {
       return registrySecretList;
     }
 
-    const msg = "Failed to create the Codewind Secret and/or patch the Service Account, reverting changes to the Docker Config";
+    const msg = "Reverting changes to the Docker Config";
     log.error(msg);
     
-    // Since patching the Service Account failed, we need to revert the update to the Docker Config
+    // Since patching the Service Account failed, we need to revert the update to the Docker Config and patch the Service Account again
     delete jsonObj.auths[address];
     await fs.writeJson(this.dockerConfigFile, jsonObj);
+    await this.updateServiceAccountWithDockerRegisrySecret();
 
-    throw new RegistrySecretsError("SERVICE_ACCOUNT_PATCH_FAILED", "for address " + address);
+    throw new RegistrySecretsError(serviceAccountPatchData.error, "for address " + address);
   }
 
   /**
-   * Function to create the Kubernetes secret and patch the Service Account
+   * Function to create the Kubernetes Secret and patch the Service Account with the created Secret
    */
   async updateServiceAccountWithDockerRegisrySecret() {
-    try {
-      log.info("Creating a Secret and patching the Service Account");
-      const isDockerConfigFilePresent = await cwUtils.fileExists(this.dockerConfigFile)
-      if (isDockerConfigFilePresent) {
+    log.info("Creating a Secret and patching the Service Account");
+    const isDockerConfigFilePresent = await cwUtils.fileExists(this.dockerConfigFile);
+    if (isDockerConfigFilePresent) {
+      try {
         log.info("The Docker config file exists, reading contents");
         const jsonObj = await fs.readJson(this.dockerConfigFile);
         const encodedDockerConfig = Buffer.from(JSON.stringify(jsonObj)).toString("base64");
@@ -807,9 +811,19 @@ module.exports = class User {
             ".dockerconfigjson": `${encodedDockerConfig}`
           }
         };
-        resp = await this.k8Client.api.v1.namespaces(process.env.KUBE_NAMESPACE).secret.post({body: secret});
+        await this.k8Client.api.v1.namespaces(process.env.KUBE_NAMESPACE).secret.post({body: secret});
+      } catch (err) {
+        log.error(err);
+        log.error("Failed to create the Codewind Secret");
+        const data = {
+          isServiceAccountPatched: false,
+          error: "SECRET_CREATE_FAILED"
+        };
+        return data;
+      }
 
-        // Patch the Service Account with the new secret
+      try {
+      // Patch the Service Account with the new secret
         const patch = {
           "imagePullSecrets": [
             {
@@ -817,21 +831,32 @@ module.exports = class User {
             }
           ]
         };
-        resp = await this.k8Client.api.v1.namespaces(process.env.KUBE_NAMESPACE).serviceaccounts(process.env.SERVICE_ACCOUNT_NAME).patch({body: patch});
+        await this.k8Client.api.v1.namespaces(process.env.KUBE_NAMESPACE).serviceaccounts(process.env.SERVICE_ACCOUNT_NAME).patch({body: patch});
         log.info("The Service Account has been patched with the created Secret");
-      } else {
-        // updateServiceAccountWithDockerRegisrySecret was called but there was no Docker Config, error out
-        const msg = "No Docker Config found but was requested to patch Service Account.";
-        log.error(msg);
-        return false;
+      } catch (err) {
+        log.error(err);
+        log.error("Failed to patch the Service Account");
+        const data = {
+          isServiceAccountPatched: false,
+          error: "SERVICE_ACCOUNT_PATCH_FAILED"
+        };
+        return data;
       }
-    } catch (err) {
-      log.error(err);
-      log.error("Failed to create the Codewind Secret and/or patch the Service Account");
-      return false;
+    } else {
+      // updateServiceAccountWithDockerRegisrySecret was called but there was no Docker Config, error out
+      const msg = "No Docker Config found but was requested to patch Service Account.";
+      log.error(msg);
+      const data = {
+        isServiceAccountPatched: false,
+        error: "NO_DOCKER_CONFIG"
+      };
+      return data;
     }
 
-    return true;
+    const data = {
+      isServiceAccountPatched: true
+    };
+    return data;
   }
 
   /**
@@ -867,7 +892,8 @@ module.exports = class User {
   }
 
   /**
-   * Function to remove the docker registries from PFE
+   * Function to remove the registry secret from the Docker Config. In Kubernetes, the function also creates the Codewind secret from
+   * the Docker config and patches the Service Account with the created Codewind Secret. On local, this is skipped.
    */
   async removeRegistrySecret(address) {
     const registrySecretList = [];
@@ -921,8 +947,10 @@ module.exports = class User {
 
     // Only update the Kube secret when running in K8s
     let isServiceAccountPatched = false;
+    let serviceAccountPatchData;
     if (global.codewind.RUNNING_IN_K8S) {
-      isServiceAccountPatched = await this.updateServiceAccountWithDockerRegisrySecret();
+      serviceAccountPatchData = await this.updateServiceAccountWithDockerRegisrySecret();
+      isServiceAccountPatched = serviceAccountPatchData.isServiceAccountPatched;
     }
 
     if (isServiceAccountPatched || !global.codewind.RUNNING_IN_K8S) {
@@ -931,14 +959,15 @@ module.exports = class User {
       return registrySecretList;
     }
 
-    const msg = "Failed to create the Codewind Secret and/or patch the Service Account, reverting changes to the Docker Config";
+    const msg = "Reverting changes to the Docker Config";
     log.error(msg);
 
-    // Since patching the Service Account failed, we need to revert the delete from the Docker Config
+    // Since patching the Service Account failed, we need to revert the delete from the Docker Config and patch the Service Account again
     jsonObj.auths[address] = registrySecretToBeDeleted;
     await fs.writeJson(this.dockerConfigFile, jsonObj);
+    await this.updateServiceAccountWithDockerRegisrySecret();
 
-    throw new RegistrySecretsError("SERVICE_ACCOUNT_PATCH_FAILED", "for address " + address);
+    throw new RegistrySecretsError(serviceAccountPatchData.error, "for address " + address);
   }
 
   /**

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -747,7 +747,7 @@ module.exports = class User {
       return registrySecretList;
     }
 
-    const msg = "Failed to patch the Service Account";
+    const msg = "Failed to create the Codewind Secret and/or patch the Service Account, reverting changes to the Docker Config";
     log.error(msg);
     
     // Since patching the Service Account failed, we need to revert the update to the Docker Config
@@ -827,7 +827,7 @@ module.exports = class User {
       }
     } catch (err) {
       log.error(err);
-      log.error("Failed to create the Secret and patch the Service Account");
+      log.error("Failed to create the Codewind Secret and/or patch the Service Account");
       return false;
     }
 
@@ -931,7 +931,7 @@ module.exports = class User {
       return registrySecretList;
     }
 
-    const msg = "Failed to patch the Service Account";
+    const msg = "Failed to create the Codewind Secret and/or patch the Service Account, reverting changes to the Docker Config";
     log.error(msg);
 
     // Since patching the Service Account failed, we need to revert the delete from the Docker Config

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -669,6 +669,7 @@ module.exports = class User {
   /**
    * Function to setup the Docker config file. In Kubernetes, the function also creates the Codewind secret from
    * the Docker config and patches the Service Account with the created Codewind Secret. On local, this is skipped.
+   * This API function is needed in local because some project stacks pull images from private registries like Appsody.
    */
   async setupRegistrySecret(credentials, address) {
     const credentialsJSON = JSON.parse(Buffer.from(credentials, "base64").toString());
@@ -737,14 +738,12 @@ module.exports = class User {
     }
 
     // Only update the Kube secret when running in K8s
-    let isServiceAccountPatched = false;
     let serviceAccountPatchData;
     if (global.codewind.RUNNING_IN_K8S) {
       serviceAccountPatchData = await this.updateServiceAccountWithDockerRegisrySecret();
-      isServiceAccountPatched = serviceAccountPatchData.isServiceAccountPatched;
     }
 
-    if (isServiceAccountPatched || !global.codewind.RUNNING_IN_K8S) {
+    if (serviceAccountPatchData === undefined || !global.codewind.RUNNING_IN_K8S) {
       // when either the service account is patched successfully or we are in local Codewind, we can return
       log.debug("Codewind Docker Registry List: " + JSON.stringify(registrySecretList));
       return registrySecretList;
@@ -758,7 +757,7 @@ module.exports = class User {
     await fs.writeJson(this.dockerConfigFile, jsonObj);
     await this.updateServiceAccountWithDockerRegisrySecret();
 
-    throw new RegistrySecretsError(serviceAccountPatchData.error, "for address " + address);
+    throw new RegistrySecretsError(serviceAccountPatchData, "for address " + address);
   }
 
   /**
@@ -815,11 +814,7 @@ module.exports = class User {
       } catch (err) {
         log.error(err);
         log.error("Failed to create the Codewind Secret");
-        const data = {
-          isServiceAccountPatched: false,
-          error: "SECRET_CREATE_FAILED"
-        };
-        return data;
+        return "SECRET_CREATE_FAILED";
       }
 
       try {
@@ -836,27 +831,16 @@ module.exports = class User {
       } catch (err) {
         log.error(err);
         log.error("Failed to patch the Service Account");
-        const data = {
-          isServiceAccountPatched: false,
-          error: "SERVICE_ACCOUNT_PATCH_FAILED"
-        };
-        return data;
+        return "SERVICE_ACCOUNT_PATCH_FAILED";
       }
     } else {
       // updateServiceAccountWithDockerRegisrySecret was called but there was no Docker Config, error out
       const msg = "No Docker Config found but was requested to patch Service Account.";
       log.error(msg);
-      const data = {
-        isServiceAccountPatched: false,
-        error: "NO_DOCKER_CONFIG"
-      };
-      return data;
+      return "NO_DOCKER_CONFIG";
     }
 
-    const data = {
-      isServiceAccountPatched: true
-    };
-    return data;
+    return undefined;
   }
 
   /**
@@ -893,7 +877,8 @@ module.exports = class User {
 
   /**
    * Function to remove the registry secret from the Docker Config. In Kubernetes, the function also creates the Codewind secret from
-   * the Docker config and patches the Service Account with the created Codewind Secret. On local, this is skipped.
+   * the Docker config and patches the Service Account with the created Codewind Secret. On local, this is skipped. 
+   * This API function is needed in local because some project stacks pull images from private registries like Appsody.
    */
   async removeRegistrySecret(address) {
     const registrySecretList = [];
@@ -946,14 +931,12 @@ module.exports = class User {
     }
 
     // Only update the Kube secret when running in K8s
-    let isServiceAccountPatched = false;
     let serviceAccountPatchData;
     if (global.codewind.RUNNING_IN_K8S) {
       serviceAccountPatchData = await this.updateServiceAccountWithDockerRegisrySecret();
-      isServiceAccountPatched = serviceAccountPatchData.isServiceAccountPatched;
     }
 
-    if (isServiceAccountPatched || !global.codewind.RUNNING_IN_K8S) {
+    if (serviceAccountPatchData === undefined || !global.codewind.RUNNING_IN_K8S) {
       // when either the service account is patched successfully or we are in local Codewind, we can return
       log.debug("Codewind Docker Registry List: " + JSON.stringify(registrySecretList));
       return registrySecretList;
@@ -967,7 +950,7 @@ module.exports = class User {
     await fs.writeJson(this.dockerConfigFile, jsonObj);
     await this.updateServiceAccountWithDockerRegisrySecret();
 
-    throw new RegistrySecretsError(serviceAccountPatchData.error, "for address " + address);
+    throw new RegistrySecretsError(serviceAccountPatchData, "for address " + address);
   }
 
   /**

--- a/src/pfe/portal/modules/utils/errors/RegistrySecretsError.js
+++ b/src/pfe/portal/modules/utils/errors/RegistrySecretsError.js
@@ -21,6 +21,7 @@ module.exports = class RegistrySecretsError extends BaseError {
 // Error codes
 module.exports.INVALID_ENCODED_CREDENTIALS = "INVALID_ENCODED_CREDENTIALS";
 module.exports.REGISTRY_DUPLICATE_URL = "REGISTRY_DUPLICATE_URL";
+module.exports.SECRET_CREATE_FAILED = "SECRET_CREATE_FAILED";
 module.exports.SERVICE_ACCOUNT_PATCH_FAILED = "SERVICE_ACCOUNT_PATCH_FAILED";
 module.exports.NO_DOCKER_CONFIG = "NO_DOCKER_CONFIG";
 module.exports.SECRET_DELETE_MISSING = "SECRET_DELETE_MISSING";
@@ -39,8 +40,11 @@ function constructMessage(code, message) {
   case "REGISTRY_DUPLICATE_URL":
     output = `Cannot have multiple docker registries with the same url. Please delete the previous registry and try again`;
     break;
+  case "SECRET_CREATE_FAILED":
+    output = `Failed to create the Codewind Secret`;
+    break;
   case "SERVICE_ACCOUNT_PATCH_FAILED":
-    output = `Failed to create the Codewind Secret and/or patch the Service Account`;
+    output = `Failed to patch the Service Account`;
     break;
   case "NO_DOCKER_CONFIG":
     output = `Unable to find the Codewind Docker Config`;

--- a/src/pfe/portal/modules/utils/errors/RegistrySecretsError.js
+++ b/src/pfe/portal/modules/utils/errors/RegistrySecretsError.js
@@ -40,7 +40,7 @@ function constructMessage(code, message) {
     output = `Cannot have multiple docker registries with the same url. Please delete the previous registry and try again`;
     break;
   case "SERVICE_ACCOUNT_PATCH_FAILED":
-    output = `Failed to patch the Service Account after updating the Codewind Secret`;
+    output = `Failed to create the Codewind Secret and/or patch the Service Account`;
     break;
   case "NO_DOCKER_CONFIG":
     output = `Unable to find the Codewind Docker Config`;

--- a/src/pfe/portal/routes/imagePushRegistry.route.js
+++ b/src/pfe/portal/routes/imagePushRegistry.route.js
@@ -16,27 +16,6 @@ const { validateReq } = require('../middleware/reqValidator');
 const log = new Logger(__filename);
 
 /**
- * Temp API Function to bypass current IDE design for testing
- */
-router.get('/api/v1/registry', function (req, res) {
-  let retval;
-  try {
-    // let user = req.cw_user;
-    log.debug(`GET /api/v1/imagepushregistry called`);
-    retval = {
-      deploymentRegistry: true
-    }
-    res.status(200).send(retval);
-  } catch (error) {
-    log.error(error);
-    const workspaceSettings = {
-      imagePushRegistry: false
-    }
-    res.status(500).send(workspaceSettings);
-  }
-});
-
-/**
  * API Function to get status of Image Push Registry in Workspace Settings
  */
 router.get('/api/v1/imagepushregistry', async function (req, res) {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

Issue #1412 
If Secret create and/or Service Account patch fails, revert changes made to the Docker Config

Issue https://github.com/eclipse/codewind/issues/1300
Removes the temp API `GET /api/v1/registry` which always returned True