### PR TITLE
Fix: Max call stack exceeded after viewing logs on a project

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -225,7 +225,7 @@ module.exports = class FileWatcher {
       location: project.projectPath(false),
       applicationPort: project.applicationPort,
       settings: settingsFileContents,
-      language: project.language 
+      language: project.language
     };
 
     log.info(`Calling createProject() for project ${project.name} ${JSON.stringify(projectAction)}`);
@@ -468,7 +468,7 @@ module.exports = class FileWatcher {
       }
       let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
       await this.handleFWProjectEvent(event, projectUpdate);
-      WebSocket.watchListChanged(data);      
+      WebSocket.watchListChanged(data);
     } catch (err) {
       log.error(err);
     }
@@ -498,7 +498,8 @@ module.exports = class FileWatcher {
         results.error = error;
       }
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
-      this.user.uiSocket.emit(event, {...results , ...updatedProject});
+      const { logStreams, ...uiProjectInfo } = updatedProject
+      this.user.uiSocket.emit(event, { ...results, ...uiProjectInfo })
       if (fwProject.buildStatus === 'inProgress') {
         // Reset build logs.
         updatedProject.resetLogStream('build');
@@ -666,7 +667,7 @@ function logEvent(event, projectData) {
   }
   log.debug(`${msg} ${projectData.projectID})`);
   log.trace(`${msg}: ${JSON.stringify(projectData, null, 2)})`);
-  
+
   if(updateTimerStart > 0 && event == "projectStatusChanged" && projectData.buildStatus && status == 'success'){
     let updateBuildTimerEnd = Date.now()
     log.info(`${projectData.projectID} update->build end time: ${ updateBuildTimerEnd }`)
@@ -680,5 +681,5 @@ function logEvent(event, projectData) {
     log.info(`${msg} ${projectData.projectID}) total time for update->run: ${ totalUpdateTime } seconds`)
     updateTimerStart = 0;
   }
-  
+
 }

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -534,7 +534,8 @@ module.exports = class FileWatcher {
     // We have to emit the full project state *and* the operation status.
     // (Storing the status in the project object is bad as it is
     // only about this close operation.)
-    this.user.uiSocket.emit('projectClosed', {...updatedProject, status: fwProject.status});
+    const { logStreams, ...uiProjectInfo } = updatedProject;
+    this.user.uiSocket.emit('projectClosed', {...uiProjectInfo, status: fwProject.status});
     log.debug('project ' + fwProject.projectID + ' successfully closed');
   }
 

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -498,8 +498,9 @@ module.exports = class FileWatcher {
         results.error = error;
       }
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
-      const { logStreams, ...uiProjectInfo } = updatedProject
-      this.user.uiSocket.emit(event, { ...results, ...uiProjectInfo })
+      // remove fields which are not required by the UI
+      const { logStreams, ...projectInfoForUI } = updatedProject
+      this.user.uiSocket.emit(event, { ...results, ...projectInfoForUI })
       if (fwProject.buildStatus === 'inProgress') {
         // Reset build logs.
         updatedProject.resetLogStream('build');
@@ -534,8 +535,9 @@ module.exports = class FileWatcher {
     // We have to emit the full project state *and* the operation status.
     // (Storing the status in the project object is bad as it is
     // only about this close operation.)
-    const { logStreams, ...uiProjectInfo } = updatedProject;
-    this.user.uiSocket.emit('projectClosed', {...uiProjectInfo, status: fwProject.status});
+    // remove fields which are not required by the UI
+    const { logStreams, ...projectInfoForUI } = updatedProject;
+    this.user.uiSocket.emit('projectClosed', {...projectInfoForUI, status: fwProject.status});
     log.debug('project ' + fwProject.projectID + ' successfully closed');
   }
 


### PR DESCRIPTION
Resolves #1284

## Summary

The field `logStreams` is included in the object that is sent over the uiSocket on a `FWProjectEvent`. This object contains a reference to `project`, which in turn references `logStreams`, introducing a circular dependancy. 

This causes socket.io to intermittently error (with `max call stack exceeded`), when an action is requested on a project for which logs have been requested (which is what adds the `logStreams` field to the project). This error causes PFE to hang,  requiring a restart to become functional again.

This PR strips out `logStreams` before sending the project over socket.io.

## Testing

All tests pass locally. 

Having requested logs on a project, can successfully interact with that project without a recreation of this bug.

