### PR TITLE
Add workspace ID to Gatekeeper environment api 

### DIFF
--- a/src/gatekeeper/server.js
+++ b/src/gatekeeper/server.js
@@ -141,6 +141,7 @@ async function main() {
         const environment = {
             auth_url: auth_url,
             client_id: client_id,
+            workspace_id: workspaceID,
             realm: realm,
             codewind_version: codewindVersion,
             image_build_time: imageBuildTime,


### PR DESCRIPTION
## Enhancement 

Make the workspaceID more obvious in the Gatekeeper environment api. 

## Solution

cwctl already sends the Workspace ID to the Gatekeeper and exposes it via the client_id field. This PR adds a new field "workspace_id" to call out the value explicitly.

## Results

After change the workspace_id can be clearly seen : 

```javascript
{
  "auth_url": "https://codewind-keycloak-k411f3lp.apps.mycluster.x.x.x.x.nip.io",
  "client_id": "codewind-k411f3lp",
  "workspace_id": "k411f3lp",
  "realm": "codewind",
  "codewind_version": "x.x.dev",
  "image_build_time": "20191211-081952"
}
```

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>