### PR TITLE
Refresh templates when a repo is enabled/disabled (PR #1428 for master)

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -170,6 +170,7 @@ module.exports = class Templates {
     try {
       const repo = await this.getRepository(url);
       repo.enabled = (value === 'true' || value === true);
+      this.projectTemplatesNeedsRefresh = true;
       return {
         status: 200
       };


### PR DESCRIPTION
**Fix for https://github.com/eclipse/codewind/issues/1351** for 0.7.0
### Summary
* Sets `projectTemplatesNeedsRefresh` to true when a template repository is enabled/disabled.
  * This fixes a bug where the templates list is not refreshed when a repo is enabled.

### Testing
* Added unit test to check that the template list is updated when a disabled repository is enabled.
* Added unit test to check that the repository list is updated when a disabled repository is enabled.
* Added a line to the `enableOrDisableRepository` function to check that `projectTemplatesNeedsRefresh` is set to true when a repository is enabled or disabled.

Signed-off-by: James Wallis <james.wallis1@ibm.com>