### PR TITLE
{WIP} add last sync time to project data

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1791,6 +1791,7 @@ components:
         - pathToMonitor
         - ignoredPaths
         - projectWatchStateId
+        - lastSyncTime
       properties:
         projectID:
           $ref: '#/components/schemas/ProjectID'
@@ -1807,6 +1808,10 @@ components:
           type: string
           format: uuid
           example: "e3f3ba629b5a9e75ebb0818934575a66"
+        lastSyncTime:
+          description: the in millisconds since epoch that the project was last updated in codewind
+          type: number
+          example: 1576080088223
     FileChangeList:
         type: object
         required:

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -55,6 +55,7 @@ module.exports = class Project {
     this.language = args.language;
     this.validate = args.validate;
     this.creationTime = args.creationTime;
+    this.lastSyncTime = '';
 
     if (args.contextRoot) this.contextRoot = args.contextRoot;
     if (args.framework) this.framework = args.framework;


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

Adding the last time the project was synced to the project data.  The FWD can then use this value when it does its initial call to cwctl project sync for the time value.  We will return the information in output from the watchlist api call