### PR TITLE
[0.7.0] Handle empty namespace and invalid namespace

### DIFF
--- a/src/pfe/file-watcher/server/src/utils/workspaceSettings.ts
+++ b/src/pfe/file-watcher/server/src/utils/workspaceSettings.ts
@@ -98,11 +98,6 @@ export async function readWorkspaceSettings(): Promise<IWorkspaceSettingsSuccess
 }
 
 export async function writeWorkspaceSettings(address: string, namespace: string): Promise<IWorkspaceSettingsSuccess | IWorkspaceSettingsFailure> {
-    // Clean up namespace if user enters address/namespace in the UI
-    if (namespace.startsWith(address.replace(/\/\s*$/, "") + "/")) {
-        namespace = namespace.replace(address.replace(/\/\s*$/, "") + "/", "");
-    }
-
     const newWorkspaceSettings: any = {
         registryAddress: address,
         registryNamespace: namespace

--- a/src/pfe/file-watcher/server/src/utils/workspaceSettings.ts
+++ b/src/pfe/file-watcher/server/src/utils/workspaceSettings.ts
@@ -98,6 +98,11 @@ export async function readWorkspaceSettings(): Promise<IWorkspaceSettingsSuccess
 }
 
 export async function writeWorkspaceSettings(address: string, namespace: string): Promise<IWorkspaceSettingsSuccess | IWorkspaceSettingsFailure> {
+    // Clean up namespace if user enters address/namespace in the UI
+    if (namespace.startsWith(address.replace(/\/\s*$/, "") + "/")) {
+        namespace = namespace.replace(address.replace(/\/\s*$/, "") + "/", "");
+    }
+
     const newWorkspaceSettings: any = {
         registryAddress: address,
         registryNamespace: namespace
@@ -237,7 +242,13 @@ export async function getImagePushRegistry(): Promise<string> {
         return "";
     }
     logger.logInfo("WorkspaceSettingsInfo for project operations: " + JSON.stringify(workspaceSettingsInfo));
-    const imagePushRegistry = workspaceSettingsInfo.registryAddress.trim() + "/" + workspaceSettingsInfo.registryNamespace.trim();
+    let imagePushRegistry = workspaceSettingsInfo.registryAddress.trim();
+
+    // Only append if user entered a namespace
+    if (workspaceSettingsInfo.registryNamespace.length > 0) {
+        imagePushRegistry = imagePushRegistry + "/" + workspaceSettingsInfo.registryNamespace.trim();
+    }
+
     return imagePushRegistry;
 }
 

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -602,14 +602,16 @@ module.exports = class User {
       throw err;
     }
 
-    if (contents && contents.registryAddress && contents.registryAddress.length > 0 && contents.registryNamespace && contents.registryNamespace.length) {
-      log.debug(`Workspace settings registryAddress` + contents.registryAddress);
-      log.debug(`Workspace settings registryNamespace` + contents.registryNamespace);
+    if (contents && contents.registryAddress && contents.registryAddress.length > 0 && contents.registryNamespace != null) {
+      log.debug(`Workspace settings registryAddress: ` + contents.registryAddress);
+      log.debug(`Workspace settings registryNamespace: ` + contents.registryNamespace);
       isImagePushRegistrySet = true;
 
       // trigger the FW workspaceSettings.readWorkspaceSettings() function to load up the cache since it's valid
       log.info(`Workspace settings file present, reading the settings file`);
       await this.readWorkspaceSettings();
+    } else {
+      log.info("Registry address or registry namespace not found in the workspace settings file");
     }
     log.info(`Workspace settings image push registry status: ${isImagePushRegistrySet}`);
 

--- a/src/pfe/portal/routes/imagePushRegistry.route.js
+++ b/src/pfe/portal/routes/imagePushRegistry.route.js
@@ -46,6 +46,18 @@ router.post('/api/v1/imagepushregistry', validateReq, async function (req, res) 
     const namespace = req.sanitizeBody('namespace');
     const operation = req.sanitizeBody('operation');
 
+    // if user enters it as address/namespace in the UI, throw an error
+    if (namespace.startsWith(address.replace(/\/\s*$/, "") + "/")) {
+      const msg = "Namespace cannot be in the format address/namespace. Please enter a valid namespace.";
+      log.error(msg);
+      const workspaceSettings = {
+        imagePushRegistryTest: false,
+        msg: msg
+      }
+      res.status(400).send(workspaceSettings);
+      return;
+    }
+
     // The validateReq middleware will throw an error if operation is not test or set,
     // but it is optional and defaults to test.
     if (operation === undefined || operation === 'test') {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

This PR has the following issues:
- https://github.com/eclipse/codewind/issues/1484 If a user enters namespace as `address/namespace` in the UI, strip off address and write to workspace settings file
- https://github.com/eclipse/codewind/issues/1486 if a user enters an empty namespace `""`, handle the case in PFE as valid