### PR TITLE
Watchlist API, correctly convert windows path

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -229,8 +229,8 @@ module.exports = class User {
           const project = {};
           const projName = projFile.name;
           project.pathToMonitor = projFile.locOnDisk;
-          //project.pathToMonitor = path.join(projFile.workspace, projFile.directory);
-          if (process.env.HOST_OS === "windows") {
+          const isWindowsPath = cwUtils.isWindowsAbsolutePath(project.pathToMonitor);
+          if (isWindowsPath) {
             project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(project.pathToMonitor);
           }
           project.projectID = projFile.projectID;

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -131,15 +131,12 @@ module.exports.forceRemove = async function forceRemove(path) {
 }
 
 /** C:\helloThere -> /c/helloThere */
-function convertFromWindowsDriveLetter(absolutePath) {
-  if (!isWindowsAbsolutePath(absolutePath)) {
-    return absolutePath;
+function convertFromWindowsDriveLetter(windowsPath) {
+  if (!isWindowsAbsolutePath(windowsPath)) {
+    return windowsPath;
   }
-  let linuxPath;
-  // Replace \ with /
-  linuxPath = convertBackSlashesToForwardSlashes(absolutePath);
+  let linuxPath = convertBackSlashesToForwardSlashes(windowsPath);
   const char0 = linuxPath.charAt(0);
-  // Strip first two characters
   linuxPath = linuxPath.substring(2);
   linuxPath = "/" + char0.toLowerCase() + linuxPath;
   return linuxPath;

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -115,22 +115,6 @@ module.exports.copyProject = async function copyFile(fromProjectPath, toProjectP
   await module.exports.forceRemove(fromProjectPath)
 }
 
-/** C:\helloThere -> /c/helloThere */
-module.exports.convertFromWindowsDriveLetter = function convertFromWindowsDriveLetter(absolutePath) {
-  if (!isWindowsAbsolutePath(absolutePath)) {
-    return absolutePath;
-  }
-  let temp;
-  // Replace \ with /
-  temp = convertBackSlashesToForwardSlashes(absolutePath);
-  const char0 = temp.charAt(0);
-  // Strip first two characters
-  temp = temp.substring(2);
-  temp = "/" + char0.toLowerCase() + temp;
-  return temp;
-
-}
-
 /**
  * Force remove a path, regardless of whether it exists, or it's file or directory that may or may not be empty.
  * Better than fs-extra fs.remove as it won't recurse down each directory tree and take over the event loop
@@ -144,6 +128,21 @@ module.exports.forceRemove = async function forceRemove(path) {
   catch (err) {
     log.warn(err.message);
   }
+}
+
+/** C:\helloThere -> /c/helloThere */
+function convertFromWindowsDriveLetter(absolutePath) {
+  if (!isWindowsAbsolutePath(absolutePath)) {
+    return absolutePath;
+  }
+  let linuxPath;
+  // Replace \ with /
+  linuxPath = convertBackSlashesToForwardSlashes(absolutePath);
+  const char0 = linuxPath.charAt(0);
+  // Strip first two characters
+  linuxPath = linuxPath.substring(2);
+  linuxPath = "/" + char0.toLowerCase() + linuxPath;
+  return linuxPath;
 }
 
 function convertBackSlashesToForwardSlashes(str) {
@@ -201,4 +200,7 @@ module.exports.getProjectSourceRoot = function getProjectSourceRoot(project) {
 }
 
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+
+module.exports.convertFromWindowsDriveLetter = convertFromWindowsDriveLetter;
+module.exports.isWindowsAbsolutePath = isWindowsAbsolutePath;
 module.exports.deepClone = deepClone;

--- a/test/src/unit/modules/utils/sharedFunctions.test.js
+++ b/test/src/unit/modules/utils/sharedFunctions.test.js
@@ -64,4 +64,33 @@ describe('sharedFunctions.js', () => {
             return fs.pathExists(testFile).should.eventually.be.false;
         });
     });
+    describe('convertFromWindowsDriveLetter(absolutePath)', () => {
+        it('returns a converted linux path from a windows path', () => {
+            const filePath = 'C:\\folder\\anotherfolder\\javaproject';
+            const convertedPath = sharedFunctions.convertFromWindowsDriveLetter(filePath);
+            convertedPath.should.equal('/c/folder/anotherfolder/javaproject');
+        });
+        it('returns a the original linux path', () => {
+            const filePath = '/some/random/path';
+            const convertedPath = sharedFunctions.convertFromWindowsDriveLetter(filePath);
+            convertedPath.should.equal(filePath);
+        });
+    });
+    describe('isWindowsAbsolutePath(absolutePath)', () => {
+        it('returns true as filePath is windows', () => {
+            const filePath = 'C:\\folder\\anotherfolder\\javaproject';
+            const isWindowsPath = sharedFunctions.isWindowsAbsolutePath(filePath);
+            isWindowsPath.should.be.true;
+        });
+        it('returns false as filePath is linux', () => {
+            const filePath = '/some/random/path';
+            const isWindowsPath = sharedFunctions.isWindowsAbsolutePath(filePath);
+            isWindowsPath.should.be.false;
+        });
+        it('returns false as filePath is not absolute', () => {
+            const filePath = '..\\Publications\\TravelBrochure.pdf';
+            const isWindowsPath = sharedFunctions.isWindowsAbsolutePath(filePath);
+            isWindowsPath.should.be.false;
+        });
+    });
 });

--- a/test/src/unit/modules/utils/sharedFunctions.test.js
+++ b/test/src/unit/modules/utils/sharedFunctions.test.js
@@ -70,7 +70,7 @@ describe('sharedFunctions.js', () => {
             const convertedPath = sharedFunctions.convertFromWindowsDriveLetter(filePath);
             convertedPath.should.equal('/c/folder/anotherfolder/javaproject');
         });
-        it('returns a the original linux path', () => {
+        it('returns the original linux path', () => {
             const filePath = '/some/random/path';
             const convertedPath = sharedFunctions.convertFromWindowsDriveLetter(filePath);
             convertedPath.should.equal(filePath);


### PR DESCRIPTION
**Fixes https://github.com/eclipse/codewind/issues/1458**
### Summary 
* In remote I believe that the `process.env.HOST_OS === "windows"` is not being set and therefore a path is not being converted on windows system causing 1458.
* This change converts the path in question when it is detected to be an absolute windows path.

### Testing
* Added unit tests for `convertFromWindowsDriveLetter`
* Added unit tests for `isWindowsAbsolutePath`
* Manually tested to check it does not effect current linux systems (Mac used).
* **Needs manual test on windows to ensure that this is the fix.**

Signed-off-by: James Wallis <james.wallis1@ibm.com>