### PR TITLE
[0.7.0] hijack creationTime variable for now, improve fix in master

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1791,7 +1791,7 @@ components:
         - pathToMonitor
         - ignoredPaths
         - projectWatchStateId
-        - lastSyncTime
+        - projectCreationTime
       properties:
         projectID:
           $ref: '#/components/schemas/ProjectID'
@@ -1808,7 +1808,7 @@ components:
           type: string
           format: uuid
           example: "e3f3ba629b5a9e75ebb0818934575a66"
-        lastSyncTime:
+        projectCreationTime:
           description: the time in millisconds since epoch that the project was last updated in codewind
           type: number
           example: 1576080088223

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -55,7 +55,7 @@ module.exports = class Project {
     this.language = args.language;
     this.validate = args.validate;
     this.creationTime = args.creationTime;
-    this.lastSyncTime =  this.creationTime;
+
 
     if (args.contextRoot) this.contextRoot = args.contextRoot;
     if (args.framework) this.framework = args.framework;

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -242,7 +242,7 @@ module.exports = class User {
           } else {
             project.projectWatchStateId = projFile.projectWatchStateId;
           }
-          project.lastSyncTime = projFile.lastSyncTime;
+          project.projectCreationTime = projFile.creationTime;
           log.debug("Find project " + projName + " with info: " + JSON.stringify(project));
           watchList.projects.push(project);
         } catch (err) {

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -94,7 +94,6 @@ async function bindStart(req, res) {
 
     if (creationTime) {
       projectDetails.creationTime = creationTime;
-      projectDetails.lastSyncTime = creationTime;
     }
 
     if (projectType) {
@@ -246,7 +245,7 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
         timersyncstart = 0;
         let updatedProject = {
           projectID,
-          lastSyncTime: timeStamp
+          creationTime: timeStamp
         }
         await user.projectList.updateProject(updatedProject);
 


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

For #1471 We need to be able to pass to the filewatcher, the time of the last sync.  Currently we have a variable that stores the time the project was created.  To minimise impact to 0.7.0, we will use this value (without changing name) so that changes are at a bare minimum.  For master branch, we will put another PR up that properly sorts the names out etc