### PR TITLE
Inject for docker projects; java dash error check

### DIFF
--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -215,6 +215,9 @@
       const httpRequestData = { time };
       for (const metric of metrics) {
         const metricsObj = metric.metrics[0];
+        if (metricsObj === undefined) {
+          continue;
+        }
         const metricValue = metricsObj.value;
         if (['base:cpu_process_cpu_load_percent', 'base_cpu_processCpuLoad_percent', 'process_cpu_used_ratio '].includes(metric.name)) {
           cpuData.process = metricValue;

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -35,19 +35,21 @@ const metricsCollectorRemovalFunctions = {
 }
 
 async function injectMetricsCollectorIntoProject(projectType, projectDir) {
-  if (!metricsCollectorInjectionFunctions.hasOwnProperty(projectType)) {
-    throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
+  const projtype = (projectType === 'docker') ? 'liberty' : projectType
+  if (!metricsCollectorInjectionFunctions.hasOwnProperty(projtype)) {
+    throw new Error(`Injection of metrics collector is not supported for projects of type '${projtype}'`);
   }
-  await metricsCollectorInjectionFunctions[projectType](projectDir);
-  log.debug(`Successfully injected metrics collector into ${projectType} project`);
+  await metricsCollectorInjectionFunctions[projtype](projectDir);
+  log.debug(`Successfully injected metrics collector into ${projtype} project`);
 }
 
 async function removeMetricsCollectorFromProject(projectType, projectDir) {
-  if (!metricsCollectorRemovalFunctions.hasOwnProperty(projectType)) {
-    throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
+  const projtype = (projectType === 'docker') ? 'liberty' : projectType
+  if (!metricsCollectorRemovalFunctions.hasOwnProperty(projtype)) {
+    throw new Error(`Injection of metrics collector is not supported for projects of type '${projtype}'`);
   }
-  await metricsCollectorRemovalFunctions[projectType](projectDir);
-  log.debug(`Successfully removed metrics collector from ${projectType} project`);
+  await metricsCollectorRemovalFunctions[projtype](projectDir);
+  log.debug(`Successfully removed metrics collector from ${projtype} project`);
 }
 
 const getPathToPomXml = (projectDir) => path.join(projectDir, 'pom.xml');


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This PR allows injection of metrics into Open Liberty (docker) projects, and adds a check to a dashboard process that can throw errros otherwise.

@rwalle61 