### PR TITLE
Make statusPingTimeout configurable

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -476,8 +476,8 @@ function pingInTransitApplications(): void {
                                 let pingCount = pingCountMap.get(projectID);
                                 const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
                                 let pingCountLimit;
-                                if (projectInfo.pingTimeout) {
-                                    pingCountLimit = projectInfo.pingTimeout;
+                                if (projectInfo.statusPingTimeout) {
+                                    pingCountLimit = projectInfo.statusPingTimeout;
                                 } else if ( projectHandler.getDefaultPingTimeout ) {
                                     pingCountLimit = projectHandler.getDefaultPingTimeout();
                                 } else {

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -249,6 +249,12 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         projectInfo.ignoredPaths = selectedProjectHandler.defaultIgnoredPath;
     }
 
+    if (projInfo && projInfo.pingTimeout) {
+        projectInfo.pingTimeout = projInfo.pingTimeout;
+    } else if ( selectedProjectHandler.getDefaultPingTimeout ) {
+        projectInfo.pingTimeout = selectedProjectHandler.getDefaultPingTimeout();
+    }
+
     // Set isHttps to false by default, override if the isHttps settings key is found
     projectInfo.isHttps = false;
 
@@ -320,6 +326,13 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
                     // Default to http if we cannot get the isHttps settings
                     logger.logProjectInfo("Defaulting isHttps to false as the project setting isHttps is not a boolean", projectID, projectName);
                     projectInfo.isHttps = false;
+                }
+            }  else if (key == "pingTimeout") {
+                // pingTimeout in project setting file is a string, but is a number in projectInfo
+                const pingTimeout = parseInt(settings.pingTimeout);
+                if (pingTimeout) {
+                    logger.logProjectInfo("Setting pingTimeout from the project settings: " + pingTimeout, projectName);
+                    projectInfo.pingTimeout = pingTimeout;
                 }
             }
         }
@@ -1189,6 +1202,7 @@ export interface IProjectSettings {
     mavenProperties?: string[];
     ignoredPaths?: string[];
     isHttps?: boolean;
+    pingTimeout?: string;
 }
 
 export interface IProjectActionParams {

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -253,6 +253,8 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         projectInfo.statusPingTimeout = projInfo.statusPingTimeout;
     } else if ( selectedProjectHandler.getDefaultPingTimeout ) {
         projectInfo.statusPingTimeout = selectedProjectHandler.getDefaultPingTimeout();
+    } else {
+        projectInfo.statusPingTimeout = 30;
     }
 
     // Set isHttps to false by default, override if the isHttps settings key is found

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -249,10 +249,10 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         projectInfo.ignoredPaths = selectedProjectHandler.defaultIgnoredPath;
     }
 
-    if (projInfo && projInfo.pingTimeout) {
-        projectInfo.pingTimeout = projInfo.pingTimeout;
+    if (projInfo && projInfo.statusPingTimeout) {
+        projectInfo.statusPingTimeout = projInfo.statusPingTimeout;
     } else if ( selectedProjectHandler.getDefaultPingTimeout ) {
-        projectInfo.pingTimeout = selectedProjectHandler.getDefaultPingTimeout();
+        projectInfo.statusPingTimeout = selectedProjectHandler.getDefaultPingTimeout();
     }
 
     // Set isHttps to false by default, override if the isHttps settings key is found
@@ -327,12 +327,12 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
                     logger.logProjectInfo("Defaulting isHttps to false as the project setting isHttps is not a boolean", projectID, projectName);
                     projectInfo.isHttps = false;
                 }
-            }  else if (key == "pingTimeout") {
-                // pingTimeout in project setting file is a string, but is a number in projectInfo
-                const pingTimeout = parseInt(settings.pingTimeout);
-                if (pingTimeout) {
-                    logger.logProjectInfo("Setting pingTimeout from the project settings: " + pingTimeout, projectName);
-                    projectInfo.pingTimeout = pingTimeout;
+            }  else if (key == "statusPingTimeout") {
+                // statusPingTimeout in project setting file is a string, but is a number in projectInfo
+                const statusPingTimeout = parseInt(settings.statusPingTimeout);
+                if (statusPingTimeout) {
+                    logger.logProjectInfo("Setting statusPingTimeout from the project settings: " + statusPingTimeout, projectName);
+                    projectInfo.statusPingTimeout = statusPingTimeout;
                 }
             }
         }
@@ -1202,7 +1202,7 @@ export interface IProjectSettings {
     mavenProperties?: string[];
     ignoredPaths?: string[];
     isHttps?: boolean;
-    pingTimeout?: string;
+    statusPingTimeout?: string;
 }
 
 export interface IProjectActionParams {

--- a/src/pfe/file-watcher/server/src/projects/DockerProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/DockerProject.ts
@@ -171,4 +171,14 @@ export class DockerProject implements ProjectExtension {
 
         validator.sendResult();
     }
+
+    /**
+     * @function
+     * @description Get the default ping timeout of a docker project.
+     *
+     * @returns number
+     */
+    getDefaultPingTimeout(): number {
+        return 30;
+    }
 }

--- a/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
@@ -347,4 +347,14 @@ export class OdoExtensionProject implements IExtensionProject {
 
         return appBaseURL;
     }
+
+    /**
+     * @function
+     * @description Get the default ping timeout of an odo project.
+     *
+     * @returns number
+     */
+    getDefaultPingTimeout(): number {
+        return 30;
+    }
 }

--- a/src/pfe/file-watcher/server/src/projects/Project.ts
+++ b/src/pfe/file-watcher/server/src/projects/Project.ts
@@ -35,6 +35,7 @@ export interface ProjectInfo {
     isHttps?: boolean;
     appBaseURL?: string;
     compositeAppName?: string;
+    pingTimeout?: number;
 }
 
 export interface ProjectMetadata {

--- a/src/pfe/file-watcher/server/src/projects/Project.ts
+++ b/src/pfe/file-watcher/server/src/projects/Project.ts
@@ -96,7 +96,7 @@ export interface ProjectSettingsEvent {
     mavenProfiles?: string[];
     mavenProperties?: string[];
     isHttps?: boolean;
-    statusPingTimeout?: string;
+    statusPingTimeout?: number;
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/Project.ts
+++ b/src/pfe/file-watcher/server/src/projects/Project.ts
@@ -35,7 +35,7 @@ export interface ProjectInfo {
     isHttps?: boolean;
     appBaseURL?: string;
     compositeAppName?: string;
-    pingTimeout?: number;
+    statusPingTimeout?: number;
 }
 
 export interface ProjectMetadata {
@@ -96,6 +96,7 @@ export interface ProjectSettingsEvent {
     mavenProfiles?: string[];
     mavenProperties?: string[];
     isHttps?: boolean;
+    statusPingTimeout?: string;
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -364,4 +364,14 @@ export class ShellExtensionProject implements IExtensionProject {
 
         return name;
     }
+
+    /**
+     * @function
+     * @description Get the default ping timeout of an appsody project.
+     *
+     * @returns number
+     */
+    getDefaultPingTimeout(): number {
+        return 90;
+    }
 }

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -320,6 +320,16 @@ export function getDefaultDebugPort(): string {
 
 /**
  * @function
+ * @description Get the default ping timeout of a liberty project.
+ *
+ * @returns number
+ */
+export function getDefaultPingTimeout(): number {
+    return 30;
+}
+
+/**
+ * @function
  * @description Stop a liberty project.
  *
  * @param projectInfo <Required | ProjectInfo> - The metadata information for a project.

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -216,6 +216,16 @@ export function getDefaultDebugPort(): string {
 
 /**
  * @function
+ * @description Get the default ping timeout of a node project.
+ *
+ * @returns number
+ */
+export function getDefaultPingTimeout(): number {
+    return 30;
+}
+
+/**
+ * @function
  * @description Stop a nodejs project.
  *
  * @param projectInfo <Required | ProjectInfo> - The metadata information for a project.

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -825,7 +825,10 @@ const changeStatusPingTimeout = async function (statusPingTimeout: string, opera
         };
         operation.projectInfo = await projectsController.updateProjectInfo(projectID, keyValuePair);
 
-        resetisFirstTimePing(projectID);
+        const oldProjectState: ProjectState = appStateMap.get(projectID);
+        if (oldProjectState) {
+            appStateMap.set(projectID, new ProjectState(oldProjectState.state, oldProjectState.msg, oldProjectState.lastbuild, oldProjectState.appImageLastBuild, oldProjectState.buildImageLastBuild, oldProjectState.detailedAppStatus));
+        }
         projectStatusController.pingCountMap.delete(projectID);
 
         const data: ProjectSettingsEvent = {
@@ -840,13 +843,6 @@ const changeStatusPingTimeout = async function (statusPingTimeout: string, opera
         logger.logProjectInfo("The statusPingTimeout is already set to: " + pingTimeoutInt, projectID);
     }
 
-};
-
-const resetisFirstTimePing = function (projectID: string): any {
-    const oldProjectState: ProjectState = appStateMap.get(projectID);
-    if (oldProjectState) {
-        appStateMap.set(projectID, new ProjectState(oldProjectState.state, oldProjectState.msg, oldProjectState.lastbuild, oldProjectState.appImageLastBuild, oldProjectState.buildImageLastBuild, oldProjectState.detailedAppStatus, oldProjectState.isFirstTimePing));
-    }
 };
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -845,7 +845,7 @@ const changeStatusPingTimeout = async function (statusPingTimeout: string, opera
         const data: ProjectSettingsEvent = {
             operationId: operation.operationId,
             projectID: projectID,
-            statusPingTimeout: statusPingTimeout,
+            statusPingTimeout: pingTimeoutInt,
             status: "success"
         };
         io.emitOnListener("projectSettingsChanged", data);

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -804,7 +804,6 @@ const changeStatusPingTimeout = async function (statusPingTimeout: string, opera
     const projectInfo: ProjectInfo = operation.projectInfo;
     const projectID = projectInfo.projectID;
     const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
-
     // make sure the value we saved in projectinfo is an integer
     let pingTimeoutInt: number = parseInt(statusPingTimeout);
 
@@ -818,7 +817,7 @@ const changeStatusPingTimeout = async function (statusPingTimeout: string, opera
         logger.logProjectInfo("The pingTimeout is empty, setting to the default statusPingTimeout: " + pingTimeoutInt, projectID);
     }
 
-    if (projectInfo.pingTimeoutInt !== pingTimeoutInt) {
+    if (projectInfo.statusPingTimeout !== pingTimeoutInt) {
         const keyValuePair: UpdateProjectInfoPair = {
                 key: "statusPingTimeout",
                 value: pingTimeoutInt,
@@ -845,7 +844,9 @@ const changeStatusPingTimeout = async function (statusPingTimeout: string, opera
 
 const resetisFirstTimePing = function (projectID: string): any {
     const oldProjectState: ProjectState = appStateMap.get(projectID);
-    appStateMap.set(projectID, new ProjectState(oldProjectState.state, oldProjectState.msg, oldProjectState.lastbuild, oldProjectState.appImageLastBuild, oldProjectState.buildImageLastBuild, oldProjectState.detailedAppStatus, oldProjectState.isFirstTimePing));
+    if (oldProjectState) {
+        appStateMap.set(projectID, new ProjectState(oldProjectState.state, oldProjectState.msg, oldProjectState.lastbuild, oldProjectState.appImageLastBuild, oldProjectState.buildImageLastBuild, oldProjectState.detailedAppStatus, oldProjectState.isFirstTimePing));
+    }
 };
 
 /**
@@ -872,9 +873,6 @@ export async function projectSpecificationHandler(projectID: string, settings: a
 
     // Create operation
     const operation = new Operation("", projectInfo);
-    specificationSettingMap.forEach( item => {
-        console.log("TEST!!! specificationSettingMap has: " + item.name);
-    });
 
     for (const key in settings) {
         if (!specificationSettingMap.has(key)) {

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -61,8 +61,6 @@ const projectList: Array<string> = [];
 
 const isApplicationPodUpIntervalMap = new Map();
 
-// export const firstTimePingArray = new Array();
-
 export let pingMessage: string;
 
 export interface ProjectEvent {

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -82,7 +82,7 @@ export interface ProjectEvent {
     isHttps?: boolean;
     appBaseURL?: string;
     compositeAppName?: string;
-    pingTimeout?: string;
+    statusPingTimeout?: string;
 }
 
 export interface ProjectLog {
@@ -353,8 +353,8 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
     if (typeof operation.projectInfo.isHttps == "boolean") {
         projectInfo.isHttps = operation.projectInfo.isHttps;
     }
-    if (operation.projectInfo.pingTimeout) {
-        projectInfo.pingTimeout = operation.projectInfo.pingTimeout.toString();
+    if (operation.projectInfo.statusPingTimeout) {
+        projectInfo.statusPingTimeout = operation.projectInfo.statusPingTimeout.toString();
     }
 
     const projectMetadata = projectsController.getProjectMetadataById(projectID);
@@ -1316,8 +1316,8 @@ export async function buildAndRun(operation: Operation, command: string): Promis
     if (typeof operation.projectInfo.isHttps == "boolean") {
         projectEvent.isHttps = operation.projectInfo.isHttps;
     }
-    if (operation.projectInfo.pingTimeout) {
-        projectEvent.pingTimeout = operation.projectInfo.pingTimeout.toString();
+    if (operation.projectInfo.statusPingTimeout) {
+        projectEvent.statusPingTimeout = operation.projectInfo.statusPingTimeout.toString();
     }
     const buildInfo: BuildRequest = {
         projectLocation: projectLocation,

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -63,6 +63,8 @@ const isApplicationPodUpIntervalMap = new Map();
 
 export let pingMessage: string;
 
+export const firstTimePingArray = new Array();
+
 export interface ProjectEvent {
     operationId: string;
     projectID: string;
@@ -1040,8 +1042,8 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
             path = projectInfo.healthCheck;
         }
         // only update the detailed status on first time ping
-        const isFirstTimePing = appStateMap.get(projectID).isFirstTimePing;
-        if (isFirstTimePing != false) {
+        if (firstTimePingArray.indexOf(projectID) < 0) {
+            firstTimePingArray.push(projectID);
             if (isDefaultPath) {
                 updateDetailedAppStatus(projectID, containerInfo.ip, port, path, isDefaultPath);
             } else {
@@ -2156,6 +2158,6 @@ export async function updateDetailedAppStatus(projectID: string, ip: string, por
     };
 
     if (oldState === AppState.starting) {
-        projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathEvent, false);
+        projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathEvent);
     }
 }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -61,7 +61,7 @@ const projectList: Array<string> = [];
 
 const isApplicationPodUpIntervalMap = new Map();
 
-export const firstTimePingArray = new Array();
+// export const firstTimePingArray = new Array();
 
 export let pingMessage: string;
 
@@ -82,6 +82,7 @@ export interface ProjectEvent {
     isHttps?: boolean;
     appBaseURL?: string;
     compositeAppName?: string;
+    pingTimeout?: string;
 }
 
 export interface ProjectLog {
@@ -351,6 +352,9 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
     }
     if (typeof operation.projectInfo.isHttps == "boolean") {
         projectInfo.isHttps = operation.projectInfo.isHttps;
+    }
+    if (operation.projectInfo.pingTimeout) {
+        projectInfo.pingTimeout = operation.projectInfo.pingTimeout.toString();
     }
 
     const projectMetadata = projectsController.getProjectMetadataById(projectID);
@@ -1038,8 +1042,8 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
             path = projectInfo.healthCheck;
         }
         // only update the detailed status on first time ping
-        if (firstTimePingArray.indexOf(projectID) < 0) {
-            firstTimePingArray.push(projectID);
+        const isFirstTimePing = appStateMap.get(projectID).isFirstTimePing;
+        if (isFirstTimePing != false) {
             if (isDefaultPath) {
                 updateDetailedAppStatus(projectID, containerInfo.ip, port, path, isDefaultPath);
             } else {
@@ -1311,6 +1315,9 @@ export async function buildAndRun(operation: Operation, command: string): Promis
     }
     if (typeof operation.projectInfo.isHttps == "boolean") {
         projectEvent.isHttps = operation.projectInfo.isHttps;
+    }
+    if (operation.projectInfo.pingTimeout) {
+        projectEvent.pingTimeout = operation.projectInfo.pingTimeout.toString();
     }
     const buildInfo: BuildRequest = {
         projectLocation: projectLocation,
@@ -2151,6 +2158,6 @@ export async function updateDetailedAppStatus(projectID: string, ip: string, por
     };
 
     if (oldState === AppState.starting) {
-        projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathEvent);
+        projectStatusController.updateProjectStatus(STATE_TYPES.appState, projectID, AppState.starting, oldMsg, undefined, undefined, oldMsg, pingPathEvent, false);
     }
 }

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -208,6 +208,16 @@ export function getDefaultDebugPort(): string {
 
 /**
  * @function
+ * @description Get the default ping timeout of a spring project.
+ *
+ * @returns number
+ */
+export function getDefaultPingTimeout(): number {
+    return 30;
+}
+
+/**
+ * @function
  * @description Stop a spring project.
  *
  * @param projectInfo <Required | ProjectInfo> - The metadata information for a project.

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -155,3 +155,13 @@ export async function getLogs(type: string, logDirectory: string, projectID: str
 export function getDefaultAppPort(): string {
     return "8080";
 }
+
+/**
+ * @function
+ * @description Get the default ping timeout of a swift project.
+ *
+ * @returns number
+ */
+export function getDefaultPingTimeout(): number {
+    return 30;
+}

--- a/src/pfe/file-watcher/server/test/unit-test/tests/projectSettings.module.test.ts
+++ b/src/pfe/file-watcher/server/test/unit-test/tests/projectSettings.module.test.ts
@@ -27,7 +27,7 @@ export function projectSettingsTestModule(): void {
     let internalDebugPortStatus = "";
     let internalPortStatus = "";
     let projectSettingsStatus = "";
-
+    let statusPingTimeoutValue = "";
     let internalPortValue = "";
 
     socket.registerListener({
@@ -52,6 +52,8 @@ export function projectSettingsTestModule(): void {
                         internalPortValue = data.ports.internalPort;
                         internalPortStatus = data.status;
                     }
+                } else if (data.statusPingTimeout) {
+                    statusPingTimeoutValue = data.statusPingTimeout;
                 } else {
                     projectSettingsStatus = data.status;
                 }
@@ -290,6 +292,55 @@ export function projectSettingsTestModule(): void {
             });
         }
     });
+
+    describe("combinational testing of changeStatusPingTimeout function", () => {
+
+        const projectMetadataPath = path.join(app_configs.projectDataDir, "dummynodeproject");
+        const originalProjectMetadata = path.join(app_configs.projectDataDir, "dummynodeproject.json");
+        const testProjectMetadata = path.join(projectMetadataPath, "dummynodeproject.json");
+
+        before("create test directories", async () => {
+            if (!(await existsAsync(projectMetadataPath))) {
+                await mkdirAsync(projectMetadataPath);
+                await copyAsync(originalProjectMetadata, testProjectMetadata);
+            }
+        });
+
+        after("remove test directories", async () => {
+            if ((await existsAsync(projectMetadataPath))) {
+                await unlinkAsync(testProjectMetadata);
+                await rmdirAsync(projectMetadataPath);
+            }
+        });
+
+        const combinations: any = {
+            "combo1": {
+                "statusPingTimeoutSettings": {
+                    "statusPingTimeout": "10"
+                },
+                "result": 10
+            },
+            "combo2": {
+                "statusPingTimeoutSettings": {
+                    "statusPingTimeout": "test"
+                },
+                "result": 30
+            }
+        };
+
+        for (const combo of Object.keys(combinations)) {
+            const statusPingTimeoutSettings = combinations[combo]["statusPingTimeoutSettings"];
+            const expectedResult = combinations[combo]["result"];
+
+            it(combo + " => statusPingTimeoutSettings: " + JSON.stringify(statusPingTimeoutSettings), async () => {
+                const projectID: string = "dummynodeproject";
+
+                await projectSettings.projectSpecificationHandler(projectID, statusPingTimeoutSettings);
+                expect(statusPingTimeoutValue).to.equal(expectedResult);
+            });
+        }
+    });
+
 
     describe("combinational testing of changeMavenProfiles function", () => {
 

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -429,7 +429,7 @@ module.exports = class FileWatcher {
         let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
         await this.handleFWProjectEvent(event, projectUpdate);
         WebSocket.watchListChanged(data);
-      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || fwProject.pingTimeout || typeof fwProject.isHttps == "boolean") {
+      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || fwProject.statusPingTimeout || typeof fwProject.isHttps == "boolean") {
         // Update the project.inf on project settings change
         await this.handleFWProjectEvent(event, fwProject);
       }

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -429,7 +429,7 @@ module.exports = class FileWatcher {
         let projectUpdate = { projectID: projectID, projectWatchStateId: projectWatchStateId, ignoredPaths: ignoredPaths };
         await this.handleFWProjectEvent(event, projectUpdate);
         WebSocket.watchListChanged(data);
-      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || typeof fwProject.isHttps == "boolean") {
+      } else if (fwProject.contextRoot || fwProject.ports || fwProject.mavenProfiles || fwProject.mavenProperties || fwProject.pingTimeout || typeof fwProject.isHttps == "boolean") {
         // Update the project.inf on project settings change
         await this.handleFWProjectEvent(event, fwProject);
       }

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -36,7 +36,7 @@ const STATES = {
 const METRIC_TYPES = ['cpu', 'gc', 'memory', 'http']
 
 const CW_SETTINGS_PROPERTIES = [
-  "contextRoot", "internalPort", "internalDebugPort",
+  "contextRoot", "internalPort", "internalDebugPort", "pingTimeout",
   "healthCheck", "isHttps", "ignoredPaths", "mavenProfiles", "mavenProperties"
 ];
 

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -36,7 +36,7 @@ const STATES = {
 const METRIC_TYPES = ['cpu', 'gc', 'memory', 'http']
 
 const CW_SETTINGS_PROPERTIES = [
-  "contextRoot", "internalPort", "internalDebugPort", "pingTimeout",
+  "contextRoot", "internalPort", "internalDebugPort", "statusPingTimeout",
   "healthCheck", "isHttps", "ignoredPaths", "mavenProfiles", "mavenProperties"
 ];
 

--- a/test/utils/default-cw-settings.js
+++ b/test/utils/default-cw-settings.js
@@ -7,6 +7,7 @@ const defaultSpringSettings = {
     mavenProfiles: [''],
     mavenProperties: [''],
     isHttps: false,
+    pingTimeout: '',
 };
 
 const defaultLibertySettings = {
@@ -18,6 +19,7 @@ const defaultLibertySettings = {
     mavenProfiles: [''],
     mavenProperties: [''],
     isHttps: false,
+    pingTimeout: '',
 };
 
 const defaultNodeSettings = {
@@ -27,6 +29,7 @@ const defaultNodeSettings = {
     healthCheck: '',
     ignoredPaths: [''],
     isHttps: false,
+    pingTimeout: '',
 };
 
 const defaultSwiftSettings = {
@@ -35,6 +38,7 @@ const defaultSwiftSettings = {
     healthCheck: '',
     ignoredPaths: [''],
     isHttps: false,
+    pingTimeout: '',
 };
 
 const defaultDockerSettings = {
@@ -43,6 +47,7 @@ const defaultDockerSettings = {
     healthCheck: '',
     ignoredPaths: [''],
     isHttps: false,
+    pingTimeout: '',
 };
 
 module.exports = {

--- a/test/utils/default-cw-settings.js
+++ b/test/utils/default-cw-settings.js
@@ -7,7 +7,7 @@ const defaultSpringSettings = {
     mavenProfiles: [''],
     mavenProperties: [''],
     isHttps: false,
-    pingTimeout: '',
+    statusPingTimeout: '',
 };
 
 const defaultLibertySettings = {
@@ -19,7 +19,7 @@ const defaultLibertySettings = {
     mavenProfiles: [''],
     mavenProperties: [''],
     isHttps: false,
-    pingTimeout: '',
+    statusPingTimeout: '',
 };
 
 const defaultNodeSettings = {
@@ -29,7 +29,7 @@ const defaultNodeSettings = {
     healthCheck: '',
     ignoredPaths: [''],
     isHttps: false,
-    pingTimeout: '',
+    statusPingTimeout: '',
 };
 
 const defaultSwiftSettings = {
@@ -38,7 +38,7 @@ const defaultSwiftSettings = {
     healthCheck: '',
     ignoredPaths: [''],
     isHttps: false,
-    pingTimeout: '',
+    statusPingTimeout: '',
 };
 
 const defaultDockerSettings = {
@@ -47,7 +47,7 @@ const defaultDockerSettings = {
     healthCheck: '',
     ignoredPaths: [''],
     isHttps: false,
-    pingTimeout: '',
+    statusPingTimeout: '',
 };
 
 module.exports = {


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for issue https://github.com/eclipse/codewind/issues/1299

make `statusPingTimeout` configurable

Also added unit test for the new project specification setting:
```
      combinational testing of changeStatusPingTimeout function
        ✓ combo1 => statusPingTimeoutSettings: {"statusPingTimeout":"10"}
        ✓ combo2 => statusPingTimeoutSettings: {"statusPingTimeout":"test"}
```
