### PR TITLE
Check if ignoredPaths actually exist in the project info first

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -421,7 +421,7 @@ const reconfigIgnoredFilesForDaemon = async function (ignoredPaths: string[], op
         ignoredPaths = projectHandler.defaultIgnoredPath;
     }
 
-    if (projectInfo.ignoredPaths.length == ignoredPaths.length
+    if (projectInfo.ignoredPaths && projectInfo.ignoredPaths.length == ignoredPaths.length
         && projectInfo.ignoredPaths.every((element, index) => {
             return element === ignoredPaths[index];
         })


### PR DESCRIPTION
### Description

We should be checking if `ignoredPaths` keyword actually exist in the project info first before checking the length of it.

For example on this log, this project's info does not have the `ignoredPaths` keyword:
```
[34m[13/12/19 16:56:32 Turbine] [TRACE][39m odo-nodejs-1576249317571: {"/file-watcher/fwdata/projects/odo-nodejs-1576249317571/odo-nodejs-1576249317571.json":"{\"projectID\":\"odo-nodejs-1576249317571\",\"projectType\":\"odo\",\"location\":\"/codewind-workspace/turbinetest-odo-nodejs\",\"autoBuildEnabled\":true,\"startMode\":\"run\",\"appPorts\":[],\"extensionID\":\"/codewind-workspace/.extensions/codewind-odo-extension\",\"language\":\"nodejs\",\"isHttps\":false,\"appBaseURL\":\"http://cw-turbinetest-odo-nodejs-app-che.9.46.125.238.nip.io\",\"compositeAppName\":\"app\",\"sentProjectInfo\":true,\"forceAction\":\"REBUILD\",\"contextRoot\":\"/\",\"healthCheck\":\"/\"}"}
```

And hence, when we try to change the ignoredPath from turbine, it fails here:
```
[32m[13/12/19 16:56:57 turbinetest-odo-nodejs] [INFO][39m Attempting to set the ignored path list for file watching with: */node_modules*,*/.git/*,*/.DS_Store,*/.dockerignore,*/.gitignore
[91m[13/12/19 16:56:57 turbinetest-odo-nodejs] [ERROR][39m An error occurred while reconfig the project specification setting:
 {"projectID":"odo-nodejs-1576249317571","settings":{"ignoredPaths":["*/node_modules*","*/.git/*","*/.DS_Store","*/.dockerignore","*/.gitignore"]}}
 500: Cannot read property 'length' of undefined
```

This PR would fix it by checking for the ignoredPaths key first and then checking for its length.

Related to https://github.com/eclipse/codewind/issues/1527

Signed-off-by: ssh24 <sakib@ibm.com>