### PR TITLE
fix: normalise java-metrics cpu data points to within 0-100

### DIFF
--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -325,8 +325,15 @@
     //       };
     //       break;
     //   }
+    const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+    const normalisationFactor = 0.6;
     function processCPUData(data, totalProcessCPULoad, totalSystemCPULoad, numCPULoadSamples) {
+      ['system', 'process'].forEach(category => {
+        const dataValue = parseFloat(data[category], 10);
+        data[category] = (dataValue < 0) ? 0 : dataValue * normalisationFactor;
+      });
       updateCPUData(JSON.stringify(data));
+
       totalProcessCPULoad += data.process;
       totalSystemCPULoad += data.system;
       numCPULoadSamples++;

--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -325,9 +325,14 @@
     //       };
     //       break;
     //   }
-    const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
     const normalisationFactor = 0.6;
-    function processCPUData(data, totalProcessCPULoad, totalSystemCPULoad, numCPULoadSamples) {
+
+    function deepClone(obj) {
+      return JSON.parse(JSON.stringify(obj));
+    }
+
+    function processCPUData(originalData, totalProcessCPULoad, totalSystemCPULoad, numCPULoadSamples) {
+      const data = deepClone(originalData);
       ['system', 'process'].forEach(category => {
         const dataValue = parseFloat(data[category], 10);
         data[category] = (dataValue < 0) ? 0 : dataValue * normalisationFactor;


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Previously, the cpu data points on the javametrics graph could go above 100 and below 0. 

This change helps ensure that the values stay within the correct range of 0-100