### PR TITLE
Ensure pathtomonitor is always unix style

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -415,8 +415,10 @@ module.exports = class FileWatcher {
         // Send all file watcher clients project related data when a new project is added or ignored paths has changed
         const ignoredPaths = fwProject.ignoredPaths;
         let pathToMonitor = project.locOnDisk;
-        if (process.env.HOST_OS === "windows") {
-          pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
+        const isWindowsPath = cwUtils.isWindowsAbsolutePath(pathToMonitor);
+        if (isWindowsPath) {
+          project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
+          log.debug(`Converted path to unix style ` + project.pathToMonitor);
         }
         const projectWatchStateId = crypto.randomBytes(16).toString("hex");
         const data = {
@@ -449,10 +451,11 @@ module.exports = class FileWatcher {
       // Send all file watcher clients project related data when a new project is added or ignored paths has changed
       const ignoredPaths = fwProject.ignoredPaths;
       let pathToMonitor = project.locOnDisk;
-      if (process.env.HOST_OS === "windows") {
-        pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
+      const isWindowsPath = cwUtils.isWindowsAbsolutePath(pathToMonitor);
+      if (isWindowsPath) {
+        project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
+        log.debug(`Converted path to unix style ` + project.pathToMonitor);
       }
-
       let time = Date.now()
       if (project.creationTime) {
         time = project.creationTime

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -417,8 +417,8 @@ module.exports = class FileWatcher {
         let pathToMonitor = project.locOnDisk;
         const isWindowsPath = cwUtils.isWindowsAbsolutePath(pathToMonitor);
         if (isWindowsPath) {
-          project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
-          log.debug(`Converted path to unix style ` + project.pathToMonitor);
+          pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
+          log.debug(`Converted path to unix style ` + pathToMonitor);
         }
         const projectWatchStateId = crypto.randomBytes(16).toString("hex");
         const data = {
@@ -453,8 +453,8 @@ module.exports = class FileWatcher {
       let pathToMonitor = project.locOnDisk;
       const isWindowsPath = cwUtils.isWindowsAbsolutePath(pathToMonitor);
       if (isWindowsPath) {
-        project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
-        log.debug(`Converted path to unix style ` + project.pathToMonitor);
+        pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
+        log.debug(`Converted path to unix style ` + pathToMonitor);
       }
       let time = Date.now()
       if (project.creationTime) {

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -229,8 +229,8 @@ module.exports = class User {
           const project = {};
           const projName = projFile.name;
           project.pathToMonitor = projFile.locOnDisk;
-          //project.pathToMonitor = path.join(projFile.workspace, projFile.directory);
-          if (process.env.HOST_OS === "windows") {
+          const isWindowsPath = cwUtils.isWindowsAbsolutePath(project.pathToMonitor);
+          if (isWindowsPath) {
             project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(project.pathToMonitor);
           }
           project.projectID = projFile.projectID;

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -146,6 +146,18 @@ module.exports.forceRemove = async function forceRemove(path) {
   }
 }
 
+/** C:\helloThere -> /c/helloThere */
+function convertFromWindowsDriveLetter(windowsPath) {
+  if (!isWindowsAbsolutePath(windowsPath)) {
+    return windowsPath;
+  }
+  let linuxPath = convertBackSlashesToForwardSlashes(windowsPath);
+  const char0 = linuxPath.charAt(0);
+  linuxPath = linuxPath.substring(2);
+  linuxPath = "/" + char0.toLowerCase() + linuxPath;
+  return linuxPath;
+}
+
 function convertBackSlashesToForwardSlashes(str) {
   return str.split("\\").join("/");
 }
@@ -201,4 +213,7 @@ module.exports.getProjectSourceRoot = function getProjectSourceRoot(project) {
 }
 
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+
+module.exports.convertFromWindowsDriveLetter = convertFromWindowsDriveLetter;
+module.exports.isWindowsAbsolutePath = isWindowsAbsolutePath;
 module.exports.deepClone = deepClone;


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

This PR back ports https://github.com/eclipse/codewind/pull/1500 to the 0.7.0 branch and also fixes the pathToMonitor value sent in any socket messages to the FW daemon.