### PR TITLE
fix: correctly parse summary with count before quantiles

### DIFF
--- a/src/performance/monitor/public/parse-prometheus-text-format.js
+++ b/src/performance/monitor/public/parse-prometheus-text-format.js
@@ -486,6 +486,8 @@
       if (sample.labels && sample.labels[keyName] && sample[valueName]) {
         if (!flattened) {
           flattened = {};
+        }
+        if (!flattened[groupName]) {
           flattened[groupName] = {};
         }
 


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Previously we would error when a Prometheus summary listed the `count` before the quantiles, e.g. with the Open Liberty template:
```
# TYPE application:io_openliberty_sample_system_system_resource_get_properties_time_seconds summary
# HELP application:io_openliberty_sample_system_system_resource_get_properties_time_seconds Time needed to get the properties of a system
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds_count 1
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds{quantile="0.5"} 0.002249032
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds{quantile="0.75"} 0.002249032
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds{quantile="0.95"} 0.002249032
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds{quantile="0.98"} 0.002249032
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds{quantile="0.99"} 0.002249032
application:io_openliberty_sample_system_system_resource_get_properties_time_seconds{quantile="0.999"} 0.002249032
```

This fixes that by parsing it correctly