### PR TITLE
1533 - don't delete protectedPaths on sync [0.7.0]

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -263,7 +263,24 @@ router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
 function getFilesToDelete(existingFileArray, newFileArray) {
   const filesToDeleteSet = new Set(existingFileArray);
   newFileArray.forEach((f) => filesToDeleteSet.delete(f));
+  // if file is in a protected dir, do not delete it
+  filesToDeleteSet.forEach((f) => {
+    if (fileIsProtected(f)) {
+      filesToDeleteSet.delete(f)
+    }
+  })
+
   return Array.from(filesToDeleteSet);
+}
+
+function fileIsProtected(filePath) {
+  const protectedPrefixes = [".odo/", "node_modules/"];
+  protectedPrefixes.forEach((prefix) => {
+    if (filePath.startsWith(prefix)){
+      return true;
+    };
+  });
+  return false;
 }
 
 function deleteFilesInArray(directory, arrayOfFiles) {

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -275,12 +275,7 @@ function getFilesToDelete(existingFileArray, newFileArray) {
 
 function fileIsProtected(filePath) {
   const protectedPrefixes = [".odo/", "node_modules/"];
-  protectedPrefixes.forEach((prefix) => {
-    if (filePath.startsWith(prefix)){
-      return true;
-    };
-  });
-  return false;
+  return protectedPrefixes.some((prefix) => filePath.startsWith(prefix));
 }
 
 function deleteFilesInArray(directory, arrayOfFiles) {

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -27,7 +27,7 @@ const { file: chaiFile, dir: chaiDir } = chaiFiles;
 
 const testDirectory = path.join(__dirname, 'remoteBindRouteTest');
 
-describe('remoteBind.route.js', () => {
+describe.only('remoteBind.route.js', () => {
     suppressLogOutput(RemoteBind);
     describe('getFilesToDelete(existingFileArray, newFileArray)', () => {
         const getFilesToDelete = RemoteBind.__get__('getFilesToDelete');
@@ -35,7 +35,7 @@ describe('remoteBind.route.js', () => {
             const existingFileArray = ['package.json', 'package.lock'];
             const newFileArray = ['package.json'];
             const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
-            filesToDelete.length.should.equal(1);
+            filesToDelete.lenlsgth.should.equal(1);
             filesToDelete.should.deep.equal(['package.lock']);
         });
         it('returns an empty array of files to be deleted as both existing files are also in the new file array', () => {
@@ -118,6 +118,24 @@ describe('remoteBind.route.js', () => {
             filesInDirectory.length.should.equal(1);
             filesInDirectory.should.have.members(['file']);
         });
+    });
+    describe('fileIsProtected(filePath)', () => {
+        const fileIsProtected = RemoteBind.__get__('fileIsProtected')
+        it('should return true when file is inside .odo dir', () => {
+            const filePath = ".odo/test";
+            const isProtected = fileIsProtected(filePath);
+            isProtected.should.equal(true)
+        });
+        it('should return true when file is inside .odo dir', () => {
+            const filePath = 'node_modules/test'
+            const isProtected = fileIsProtected(filePath)
+            isProtected.should.equal(true)
+        })
+        it('should return false when file is not inside a protected dir', () => {
+            const filePath = 'src/test';
+            const isProtected = fileIsProtected(filePath);
+            isProtected.should.equal(true);
+        })
     });
 });
 

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -27,7 +27,7 @@ const { file: chaiFile, dir: chaiDir } = chaiFiles;
 
 const testDirectory = path.join(__dirname, 'remoteBindRouteTest');
 
-describe.only('remoteBind.route.js', () => {
+describe('remoteBind.route.js', () => {
     suppressLogOutput(RemoteBind);
     describe('getFilesToDelete(existingFileArray, newFileArray)', () => {
         const getFilesToDelete = RemoteBind.__get__('getFilesToDelete');
@@ -35,7 +35,7 @@ describe.only('remoteBind.route.js', () => {
             const existingFileArray = ['package.json', 'package.lock'];
             const newFileArray = ['package.json'];
             const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
-            filesToDelete.lenlsgth.should.equal(1);
+            filesToDelete.length.should.equal(1);
             filesToDelete.should.deep.equal(['package.lock']);
         });
         it('returns an empty array of files to be deleted as both existing files are also in the new file array', () => {
@@ -49,12 +49,33 @@ describe.only('remoteBind.route.js', () => {
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
         });
-        it('returns an empty array as atleast all the new files exist in the existingFileArray', () => {
+        it('returns an empty array as at least all the new files exist in the existingFileArray', () => {
             const existingFileArray = ['package.json'];
             const newFileArray = ['package.json', 'package.lock'];
             const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
+        });
+        it('returns an empty array as at .odo should not be deleted', () => {
+            const existingFileArray = ['package.json', '.odo/test'];
+            const newFileArray = ['package.json', 'package.lock'];
+            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            filesToDelete.length.should.equal(0);
+            filesToDelete.should.deep.equal([]);
+        });
+        it('returns an empty array as at node_modules should not be deleted', () => {
+            const existingFileArray = ['package.json', 'node_modules/test'];
+            const newFileArray = ['package.json', 'package.lock'];
+            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            filesToDelete.length.should.equal(0);
+            filesToDelete.should.deep.equal([]);
+        });
+        it('returns .odo in the array deleteme/.odo should be deleted as .odo is not top level in this case', () => {
+            const existingFileArray = ['package.json', 'deleteme/.odo'];
+            const newFileArray = ['package.json', 'package.lock'];
+            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            filesToDelete.length.should.equal(1);
+            filesToDelete.should.deep.equal(['deleteme/.odo']);
         });
     });
     describe('deleteFilesInArray(directory, arrayOfFiles)', () => {
@@ -120,22 +141,22 @@ describe.only('remoteBind.route.js', () => {
         });
     });
     describe('fileIsProtected(filePath)', () => {
-        const fileIsProtected = RemoteBind.__get__('fileIsProtected')
+        const fileIsProtected = RemoteBind.__get__('fileIsProtected');
         it('should return true when file is inside .odo dir', () => {
-            const filePath = ".odo/test";
+            const filePath = '.odo/test';
             const isProtected = fileIsProtected(filePath);
-            isProtected.should.equal(true)
+            isProtected.should.equal(true);
         });
         it('should return true when file is inside .odo dir', () => {
-            const filePath = 'node_modules/test'
-            const isProtected = fileIsProtected(filePath)
-            isProtected.should.equal(true)
-        })
+            const filePath = 'node_modules/test';
+            const isProtected = fileIsProtected(filePath);
+            isProtected.should.equal(true);
+        });
         it('should return false when file is not inside a protected dir', () => {
             const filePath = 'src/test';
             const isProtected = fileIsProtected(filePath);
-            isProtected.should.equal(true);
-        })
+            isProtected.should.equal(false);
+        });
     });
 });
 


### PR DESCRIPTION
for #1533 (and associated issues)

### Summary

Paths that are generated inside a projects container, e.g. `.odo/*` and `node_modules/*` (for Appsody) are being deleted upon the next sync. This is because they are not on the users filesystem and therefore added to the list of diffs to delete. 

This is currently causing .odo projects to fail building (#1533) and the connection to be lost after editing an Appsody project (#1472).

This fix removes paths that start with `.odo` or `node_modules` from the list to delete. Longer term solution, for future releases, are being discussed in the issues.


### Testing 

Adds unit tests for the extra functions (getFilesToDelete() and fileIsProtected()). 

Added `.odo` folder for the project inside the codewind-workspace in the PFE container. On project rebuild this isn't deleted. 

We haven't been able to recreate the issue on our Openshift cluster, and so weren't able to verify #1533 as fixed, if someone else could try this that would be great!