### PR TITLE
Allow users to update the push registry without having to re-bind their project

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -112,12 +112,10 @@ export async function containerCreate(operation: Operation, script: string, comm
     const projectID = operation.projectInfo.projectID;
     const projectName = projectLocation.split("/").pop();
     const projectType = operation.projectInfo.projectType;
-    const projectImagePushRegistry = operation.projectInfo.deploymentRegistry;
     if (projectList.indexOf(projectID) === -1)
         projectList.push(projectID);
 
     logger.logProjectInfo("Creating container for " + operation.projectInfo.projectType + " project " + projectLocation, projectID, projectName);
-    logger.logProjectInfo("projectInfo.deploymentRegistry: " + projectImagePushRegistry, projectID);
     operation.containerName = await getContainerName(operation.projectInfo);
     // Refer to the comment in getLogName function for this usage
     const logName = getLogName(operation.projectInfo.projectID, projectLocation);
@@ -137,14 +135,6 @@ export async function containerCreate(operation: Operation, script: string, comm
     if (process.env.IN_K8 === "true" && operation.projectInfo.extensionID === undefined ) {
         imagePushRegistry = await workspaceSettings.getImagePushRegistry();
         logger.logProjectInfo("Image Push Registry: " + imagePushRegistry, projectID);
-
-        if (projectImagePushRegistry && projectImagePushRegistry != imagePushRegistry) {
-            logger.logProjectError(projectEventErrorMsgs.wrongImagePushRegistry, projectID, projectName);
-            projectEvent.error = projectEventErrorMsgs.wrongImagePushRegistry;
-            await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, projectID, BuildState.failed, "buildscripts.wrongImagePushRegistry");
-            io.emitOnListener(event, projectEvent);
-            return;
-        }
 
         if (!imagePushRegistry.length) {
             logger.logProjectError(projectEventErrorMsgs.missingImagePushRegistry, projectID, projectName);
@@ -224,9 +214,7 @@ export async function containerUpdate(operation: Operation, script: string, comm
     const projectID = operation.projectInfo.projectID;
     const projectName = projectLocation.split("/").pop();
     const projectType = operation.projectInfo.projectType;
-    const projectImagePushRegistry = operation.projectInfo.deploymentRegistry;
     logger.logProjectInfo("Updating container for " + operation.projectInfo.projectType + " project " + projectLocation, projectID, projectName);
-    logger.logProjectInfo("projectInfo.deploymentRegistry " + projectImagePushRegistry, projectID);
     operation.containerName = await getContainerName(operation.projectInfo);
     // Refer to the comment in getLogName function for this usage
     const logName = getLogName(operation.projectInfo.projectID, projectLocation);
@@ -248,14 +236,6 @@ export async function containerUpdate(operation: Operation, script: string, comm
     if (process.env.IN_K8 === "true" && operation.projectInfo.extensionID === undefined ) {
         imagePushRegistry = await workspaceSettings.getImagePushRegistry();
         logger.logProjectInfo("Image Push Registry: " + imagePushRegistry, projectID);
-
-        if (projectImagePushRegistry && projectImagePushRegistry != imagePushRegistry) {
-            logger.logProjectError(projectEventErrorMsgs.wrongImagePushRegistry, projectID, projectName);
-            projectEvent.error = projectEventErrorMsgs.wrongImagePushRegistry;
-            await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, projectID, BuildState.failed, "buildscripts.wrongImagePushRegistry");
-            io.emitOnListener(event, projectEvent);
-            return;
-        }
 
         if (!imagePushRegistry.length) {
             logger.logProjectError(projectEventErrorMsgs.missingImagePushRegistry, projectID, projectName);

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -92,7 +92,6 @@ export interface ProjectLog {
 const projectEventErrorMsgs = {
     missingImagePushRegistry: "The project will not build due to missing Image Push Registry. Run the Set Deployment Registry command to set a new Image Push Registry to build projects.",
     invalidImagePushRegistry: "Codewind cannot build projects with the current Image Push Registry. Please make sure it is a valid Image Push Registry with the appropriate permissions.",
-    wrongImagePushRegistry: "The project will not build with the new Image Push Registry. Please remove and re-add the project to deploy to the new Image Push Registry."
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1551

This PR removes the restriction that required users to re-bind their project after changing the image push registry in Codewind.

Because we're not tagging the image as @maysunfaisal pointed out, the concern around images with outdated tags sticking around no longer exists, so we can safely remove that restriction.