### PR TITLE
Allow users to update the image push registry without re-binding their project

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -1409,8 +1409,6 @@ async function containerBuildAndRun(event: string, buildInfo: BuildRequest, oper
     const projectName = normalizedProjectLocation.split("/").reverse()[0];
     const logDir = await logHelper.getLogDir(buildInfo.projectID, projectName);
     const dockerBuildLog = path.resolve(buildInfo.projectLocation + "/../.logs/" + logDir, logHelper.buildLogs.dockerBuild + logHelper.logExtension);
-    const projectImagePushRegistry = operation.projectInfo.deploymentRegistry;
-    logger.logProjectInfo("projectInfo.deploymentRegistry: " + projectImagePushRegistry, buildInfo.projectID);
     if (process.env.IN_K8 === "true") {
         // Kubernetes environment
 
@@ -1422,14 +1420,6 @@ async function containerBuildAndRun(event: string, buildInfo: BuildRequest, oper
 
         const imagePushRegistry: string = await workspaceSettings.getImagePushRegistry();
         logger.logProjectInfo("Image Push Registry: " + imagePushRegistry, buildInfo.projectID);
-
-        if (projectImagePushRegistry && projectImagePushRegistry != imagePushRegistry) {
-            logger.logProjectError(projectEventErrorMsgs.wrongImagePushRegistry, buildInfo.projectID, projectName);
-            projectEvent.error = projectEventErrorMsgs.wrongImagePushRegistry;
-            await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, buildInfo.projectID, BuildState.failed, "buildscripts.wrongImagePushRegistry");
-            io.emitOnListener(event, projectEvent);
-            return;
-        }
 
         if (!imagePushRegistry.length) {
             logger.logProjectError(projectEventErrorMsgs.missingImagePushRegistry, buildInfo.projectID, projectName);

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -112,12 +112,10 @@ export async function containerCreate(operation: Operation, script: string, comm
     const projectID = operation.projectInfo.projectID;
     const projectName = projectLocation.split("/").pop();
     const projectType = operation.projectInfo.projectType;
-    const projectImagePushRegistry = operation.projectInfo.deploymentRegistry;
     if (projectList.indexOf(projectID) === -1)
         projectList.push(projectID);
 
     logger.logProjectInfo("Creating container for " + operation.projectInfo.projectType + " project " + projectLocation, projectID, projectName);
-    logger.logProjectInfo("projectInfo.deploymentRegistry: " + projectImagePushRegistry, projectID);
     operation.containerName = await getContainerName(operation.projectInfo);
     // Refer to the comment in getLogName function for this usage
     const logName = getLogName(operation.projectInfo.projectID, projectLocation);
@@ -137,14 +135,6 @@ export async function containerCreate(operation: Operation, script: string, comm
     if (process.env.IN_K8 === "true" && operation.projectInfo.extensionID === undefined ) {
         imagePushRegistry = await workspaceSettings.getImagePushRegistry();
         logger.logProjectInfo("Image Push Registry: " + imagePushRegistry, projectID);
-
-        if (projectImagePushRegistry && projectImagePushRegistry != imagePushRegistry) {
-            logger.logProjectError(projectEventErrorMsgs.wrongImagePushRegistry, projectID, projectName);
-            projectEvent.error = projectEventErrorMsgs.wrongImagePushRegistry;
-            await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, projectID, BuildState.failed, "buildscripts.wrongImagePushRegistry");
-            io.emitOnListener(event, projectEvent);
-            return;
-        }
 
         if (!imagePushRegistry.length) {
             logger.logProjectError(projectEventErrorMsgs.missingImagePushRegistry, projectID, projectName);
@@ -224,9 +214,7 @@ export async function containerUpdate(operation: Operation, script: string, comm
     const projectID = operation.projectInfo.projectID;
     const projectName = projectLocation.split("/").pop();
     const projectType = operation.projectInfo.projectType;
-    const projectImagePushRegistry = operation.projectInfo.deploymentRegistry;
     logger.logProjectInfo("Updating container for " + operation.projectInfo.projectType + " project " + projectLocation, projectID, projectName);
-    logger.logProjectInfo("projectInfo.deploymentRegistry " + projectImagePushRegistry, projectID);
     operation.containerName = await getContainerName(operation.projectInfo);
     // Refer to the comment in getLogName function for this usage
     const logName = getLogName(operation.projectInfo.projectID, projectLocation);
@@ -248,14 +236,6 @@ export async function containerUpdate(operation: Operation, script: string, comm
     if (process.env.IN_K8 === "true" && operation.projectInfo.extensionID === undefined ) {
         imagePushRegistry = await workspaceSettings.getImagePushRegistry();
         logger.logProjectInfo("Image Push Registry: " + imagePushRegistry, projectID);
-
-        if (projectImagePushRegistry && projectImagePushRegistry != imagePushRegistry) {
-            logger.logProjectError(projectEventErrorMsgs.wrongImagePushRegistry, projectID, projectName);
-            projectEvent.error = projectEventErrorMsgs.wrongImagePushRegistry;
-            await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, projectID, BuildState.failed, "buildscripts.wrongImagePushRegistry");
-            io.emitOnListener(event, projectEvent);
-            return;
-        }
 
         if (!imagePushRegistry.length) {
             logger.logProjectError(projectEventErrorMsgs.missingImagePushRegistry, projectID, projectName);

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -92,7 +92,6 @@ export interface ProjectLog {
 const projectEventErrorMsgs = {
     missingImagePushRegistry: "The project will not build due to missing Image Push Registry. Run the Set Deployment Registry command to set a new Image Push Registry to build projects.",
     invalidImagePushRegistry: "Codewind cannot build projects with the current Image Push Registry. Please make sure it is a valid Image Push Registry with the appropriate permissions.",
-    wrongImagePushRegistry: "The project will not build with the new Image Push Registry. Please remove and re-add the project to deploy to the new Image Push Registry."
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1551

This PR removes the restriction that projects have to be rebound after the user changes the image push registry in Codewind. As @maysunfaisal pointed out, we're no longer separately tagging the project images after builds, so the concern around images with outdated tags lingering around no longer exists.

To test:
1) Deploy PFE with the `johncollier/codewind-pfe-amd64:latest` image
2) Create and deploy some project with the registry set to `docker.io/some-namespace-a`
3) Set the push registry to `docker.io/some-namespace-b`
4) Rebuild the project
5) The project should rebuild fine without issue.

@maysunfaisal Please review