### PR TITLE
Set the correct pathToMonitor on windows

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -414,10 +414,7 @@ module.exports = class FileWatcher {
       if (fwProject.ignoredPaths || event == "newProjectAdded") {
         // Send all file watcher clients project related data when a new project is added or ignored paths has changed
         const ignoredPaths = fwProject.ignoredPaths;
-        let pathToMonitor = project.locOnDisk;
-        if (process.env.HOST_OS === "windows") {
-          pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
-        }
+        const pathToMonitor = project.pathToMonitor;
         const projectWatchStateId = crypto.randomBytes(16).toString("hex");
         const data = {
           changeType: "update",
@@ -448,11 +445,8 @@ module.exports = class FileWatcher {
       const project = this.user.projectList.retrieveProject(projectID);
       // Send all file watcher clients project related data when a new project is added or ignored paths has changed
       const ignoredPaths = fwProject.ignoredPaths;
-      let pathToMonitor = project.locOnDisk;
-      if (process.env.HOST_OS === "windows") {
-        pathToMonitor = cwUtils.convertFromWindowsDriveLetter(pathToMonitor);
-      }
-
+      const pathToMonitor = project.pathToMonitor;
+  
       let time = Date.now()
       if (project.creationTime) {
         time = project.creationTime

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -17,7 +17,6 @@ const FilewatcherError = require('./utils/errors/FilewatcherError');
 const ProjectListError = require('./utils/errors/ProjectListError');
 const WebSocket = require('./WebSocket');
 const crypto = require('crypto');
-const cwUtils = require('./utils/sharedFunctions');
 const fw = require('file-watcher');
 const log = new Logger('FileWatcher.js');
 const filewatcher = new fw();

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -48,7 +48,6 @@ const CW_SETTINGS_PROPERTIES = [
 module.exports = class Project {
 
   constructor(args, workspace) {
-    // TODO evaluate use of just .id instead of .projectID
     this.projectID = args.projectID || uuidv1();
     this.name = args.name;
     this.codewindVersion = args.codewindVersion || process.env.CODEWIND_VERSION;
@@ -65,6 +64,17 @@ module.exports = class Project {
 
     // locOnDisk is used by the UI and needs to match what it sees.
     if (args.locOnDisk) this.locOnDisk = args.locOnDisk;
+
+    // Set up the pathToMonitor, this must always be unix style
+    if (args.pathToMonitor) { 
+      this.pathToMonitor = args.pathToMonitor;
+    } else {
+      this.pathToMonitor = this.locOnDisk;
+      const isWindowsPath = cwUtils.isWindowsAbsolutePath(this.pathToMonitor);
+      if (isWindowsPath) {
+        this.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(this.pathToMonitor);
+      } 
+    }
     
     // Project status information
     this.host = args.host || '';

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -217,22 +217,22 @@ module.exports = class User {
       projects: []
     };
     let projectArray = this.projectList.getAsArray();
-    for (let i = 0; i < projectArray.length; i++) {
+    for (const project of projectArray) {
       // Only include enabled projects
-      if (projectArray[i].isOpen()) {
-        if (projectArray[i].projectWatchStateId == undefined) {
-          let watchStateId = crypto.randomBytes(16).toString("hex");
-          let projectUpdate = { projectID: projectArray[i].projectID, projectWatchStateId: watchStateId };
+      if (project.isOpen()) {
+        if (project.projectWatchStateId == undefined) {
+          const watchStateId = crypto.randomBytes(16).toString("hex");
+          const projectUpdate = { projectID: project.projectID, projectWatchStateId: watchStateId };
           await this.projectList.updateProject(projectUpdate);
         } 
-        let project = {
-          projectID: projectArray[i].projectID,
-          projectWatchStateId: projectArray[i].projectWatchStateId,
-          pathToMonitor: projectArray[i].pathToMonitor,
-          ignoredPaths: projectArray[i].ignoredPaths,
-          projectCreationTime: projectArray[i].creationTime
+        let projectUpdate = {
+          projectID: project.projectID,
+          projectWatchStateId: project.projectWatchStateId,
+          pathToMonitor: project.pathToMonitor,
+          ignoredPaths: project.ignoredPaths,
+          projectCreationTime: project.creationTime
         }
-        watchList.projects.push(project);
+        watchList.projects.push(projectUpdate);
       }
     }
     log.debug("The watch list: " + JSON.stringify(watchList));

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -213,49 +213,28 @@ module.exports = class User {
    * Function to get watchList for all open projects
    */
   async getWatchList() {
-    let fileNameList = await fs.readdir(this.directories.projects);
     let watchList = {
       projects: []
     };
-    await Promise.all(fileNameList.map(async (fileName) => {
-      let file = path.join(this.directories.projects, fileName);
-      if (!fileName.startsWith('.')) {
-        try {
-          const projFile = await fs.readJson(file);
-          // do not add closed project in the list
-          if (projFile.state == Project.STATES.closed) {
-            return;
-          }
-          const project = {};
-          const projName = projFile.name;
-          project.pathToMonitor = projFile.locOnDisk;
-          const isWindowsPath = cwUtils.isWindowsAbsolutePath(project.pathToMonitor);
-          if (isWindowsPath) {
-            project.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(project.pathToMonitor);
-          }
-          project.projectID = projFile.projectID;
-          project.ignoredPaths = projFile.ignoredPaths;
-          if (projFile.projectWatchStateId == undefined) {
-            project.projectWatchStateId = crypto.randomBytes(16).toString("hex");
-            let projectUpdate = { projectID: projFile.projectID, projectWatchStateId: project.projectWatchStateId };
-            await this.projectList.updateProject(projectUpdate);
-          } else {
-            project.projectWatchStateId = projFile.projectWatchStateId;
-          }
-          project.projectCreationTime = projFile.creationTime;
-          log.debug("Find project " + projName + " with info: " + JSON.stringify(project));
-          watchList.projects.push(project);
-        } catch (err) {
-          // Corrupt project inf file
-          if (err instanceof SyntaxError) {
-            log.error('Failed to parse project file ' + fileName);
-          } else {
-            log.error(err);
-          }
+    let projectArray = this.projectList.getAsArray();
+    for (let i = 0; i < projectArray.length; i++) {
+      // Only include enabled projects
+      if (projectArray[i].isOpen()) {
+        if (projectArray[i].projectWatchStateId == undefined) {
+          let watchStateId = crypto.randomBytes(16).toString("hex");
+          let projectUpdate = { projectID: projectArray[i].projectID, projectWatchStateId: watchStateId };
+          await this.projectList.updateProject(projectUpdate);
+        } 
+        let project = {
+          projectID: projectArray[i].projectID,
+          projectWatchStateId: projectArray[i].projectWatchStateId,
+          pathToMonitor: projectArray[i].pathToMonitor,
+          ignoredPaths: projectArray[i].ignoredPaths,
+          projectCreationTime: projectArray[i].creationTime
         }
+        watchList.projects.push(project);
       }
-    }));
-
+    }
     log.debug("The watch list: " + JSON.stringify(watchList));
     return watchList;
   }


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

This is a reworking of the fixes for turning Windows style paths into unix style for the 'pathToMonitor' value which is included in the watchlist rest API and socket messages sent to the daemon. I have moved this to the project constructor so we are only doing the conversion in one place.  I've also reworked the get watchlist API to use the project list rather than reading inf files from disk. 