### PR TITLE
1560 delete by directory

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1700,6 +1700,7 @@ components:
       required:
         - timestamp
         - fileList
+        - directoryList
         - modifiedList
       properties:
         timestamp:
@@ -1710,6 +1711,10 @@ components:
           description: an array of all files the project contains
           type: array
           example: ["/project/file1", "/project/file2", "project/modifiedfile1"]
+        directoryList:
+          description: an array of all directories the project contains
+          type: array
+          example: ["/project"]
         modifiedList:
           description: an array of files that have been modified since the last project upload
           type: array

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -305,8 +305,8 @@ function getTopLevelDirectories(directoryArray) {
 }
 
 function compareDirectoryNames(string, prefix) {
-  string = path.join('/', string, '/');
-  prefix = path.join('/', prefix, '/');
+  string = path.normalize(string + '/');
+  prefix = path.normalize(prefix + '/');
   return string.startsWith(prefix);
 }
 

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -294,19 +294,20 @@ function fileIsProtected(filePath) {
 function getTopLevelDirectories(directoryArray) {
   let topLevelDirArray = [];
   directoryArray.forEach(dir => {
-    const existingTopLevelDirectories = topLevelDirArray.filter(rootDirectory => compareDirectoryNames(dir, rootDirectory));
+    const existingTopLevelDirectories = topLevelDirArray.filter(rootDirectory => isSubdirectory(dir, rootDirectory));
     if (existingTopLevelDirectories.length === 0) {
       // if there are subdirectories of "dir" already in the topLevelDirArray remove them
-      topLevelDirArray = topLevelDirArray.filter(finalDir => !compareDirectoryNames(finalDir, dir));
+      topLevelDirArray = topLevelDirArray.filter(finalDir => !isSubdirectory(finalDir, dir));
       topLevelDirArray.push(dir);
     }
   });
   return topLevelDirArray;
 }
 
-function compareDirectoryNames(string, prefix) {
-  string = path.normalize(string + '/');
-  prefix = path.normalize(prefix + '/');
+function isSubdirectory(dir1, dir2) {
+  // returns true if dir2 is a subdirectory of dir1 or they are the same
+  const string = path.normalize(dir1 + '/');
+  const prefix = path.normalize(dir2 + '/');
   return string.startsWith(prefix);
 }
 

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -29,7 +29,7 @@ const testDirectory = path.join(__dirname, 'remoteBindRouteTest');
 
 describe('remoteBind.route.js', () => {
     suppressLogOutput(RemoteBind);
-    describe('getFilesToDelete(existingFileArray, newFileArray)', () => {
+    describe('getPathsToDelete(existingPathArray, newPathArray)', () => {
         const getPathsToDelete = RemoteBind.__get__('getPathsToDelete');
         it('returns an array of files to be deleted', () => {
             const existingFileArray = ['package.json', 'package.lock'];

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -30,52 +30,88 @@ const testDirectory = path.join(__dirname, 'remoteBindRouteTest');
 describe('remoteBind.route.js', () => {
     suppressLogOutput(RemoteBind);
     describe('getFilesToDelete(existingFileArray, newFileArray)', () => {
-        const getFilesToDelete = RemoteBind.__get__('getFilesToDelete');
+        const getPathsToDelete = RemoteBind.__get__('getPathsToDelete');
         it('returns an array of files to be deleted', () => {
             const existingFileArray = ['package.json', 'package.lock'];
             const newFileArray = ['package.json'];
-            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            const filesToDelete = getPathsToDelete(existingFileArray, newFileArray);
             filesToDelete.length.should.equal(1);
             filesToDelete.should.deep.equal(['package.lock']);
         });
         it('returns an empty array of files to be deleted as both existing files are also in the new file array', () => {
             const existingFileArray = ['package.json', 'package.lock'];
-            const filesToDelete = getFilesToDelete(existingFileArray, existingFileArray);
+            const filesToDelete = getPathsToDelete(existingFileArray, existingFileArray);
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
         });
         it('returns an empty array as no files are given', () => {
-            const filesToDelete = getFilesToDelete([], []);
+            const filesToDelete = getPathsToDelete([], []);
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
         });
         it('returns an empty array as at least all the new files exist in the existingFileArray', () => {
             const existingFileArray = ['package.json'];
             const newFileArray = ['package.json', 'package.lock'];
-            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            const filesToDelete = getPathsToDelete(existingFileArray, newFileArray);
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
         });
         it('returns an empty array as at .odo should not be deleted', () => {
             const existingFileArray = ['package.json', '.odo/test'];
             const newFileArray = ['package.json', 'package.lock'];
-            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            const filesToDelete = getPathsToDelete(existingFileArray, newFileArray);
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
         });
         it('returns an empty array as at node_modules should not be deleted', () => {
             const existingFileArray = ['package.json', 'node_modules/test'];
             const newFileArray = ['package.json', 'package.lock'];
-            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            const filesToDelete = getPathsToDelete(existingFileArray, newFileArray);
             filesToDelete.length.should.equal(0);
             filesToDelete.should.deep.equal([]);
         });
         it('returns .odo in the array deleteme/.odo should be deleted as .odo is not top level in this case', () => {
             const existingFileArray = ['package.json', 'deleteme/.odo'];
             const newFileArray = ['package.json', 'package.lock'];
-            const filesToDelete = getFilesToDelete(existingFileArray, newFileArray);
+            const filesToDelete = getPathsToDelete(existingFileArray, newFileArray);
             filesToDelete.length.should.equal(1);
             filesToDelete.should.deep.equal(['deleteme/.odo']);
+        });
+        it('returns an empty array as both existing directories are also in the new directory array', () => {
+            const existingDirectoryArray = ['dir/', 'anotherdir/'];
+            const filesToDelete = getPathsToDelete(existingDirectoryArray, existingDirectoryArray);
+            filesToDelete.length.should.equal(0);
+            filesToDelete.should.deep.equal([]);
+        });
+        it('returns an array of directories to be deleted', () => {
+            const existingFileArray = ['dir/', 'dirthatdoesnotexist/'];
+            const newFileArray = ['dir/'];
+            const directoriesToDelete = getPathsToDelete(existingFileArray, newFileArray);
+            directoriesToDelete.length.should.equal(1);
+            directoriesToDelete.should.deep.equal(['dirthatdoesnotexist/']);
+        });
+    });
+    describe('getTopLevelDirectories(directoryArray)', () => {
+        const getTopLevelDirectories = RemoteBind.__get__('getTopLevelDirectories');
+        it('returns the given directories as they are the highest level', () => {
+            const directoryArray = ['nondir/', 'dir/something/'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(directoryArray);
+        });
+        it('returns the top level directories when given a list that contains subdirectories', () => {
+            const directoryArray = ['nondir/', 'dir/something/', 'dir/something/subdirectory', 'nondir/subdir/subsubdir'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(['nondir/', 'dir/something/']);
+        });
+        it('returns the top level directories when given a list that is not in the order of directory levels', () => {
+            const directoryArray = ['dir/something/subdirectory', 'nondir/subdir/subsubdir', 'dir/something/', 'nondir/'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(['dir/something/', 'nondir/']);
+        });
+        it('returns a single top level directory when its duplicated in the list', () => {
+            const directoryArray = ['nondir/', 'nondir/', 'nondir/'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(['nondir/']);
         });
     });
     describe('deleteFilesInArray(directory, arrayOfFiles)', () => {
@@ -102,6 +138,38 @@ describe('remoteBind.route.js', () => {
             await deleteFilesInArray(testDirectory, testFileArray);
             assertFilesDoNotExist(testDirectory, testFileArray);
             chaiDir(testDirectory).should.not.be.empty;
+        });
+    });
+    describe('recusivelyListDirectories(absolutePath, relativePath)', () => {
+        const recusivelyListDirectories = RemoteBind.__get__('recusivelyListDirectories');
+        const testDirArray = ['dir', 'dir/dirinanother', 'dir/dirinanother/anotherdirinanother', 'anotherdir', 'finaldir', 'finaldir/dirwithinfinal'];
+        const testFileArray = ['dir/file', 'dir/anotherfile', 'dir/dirinanother/file', 'dir/dirinanother/anotherdirinanother/file', 'anotherdir/file', 'anotherdir/anotherfile', 'finaldir/dirwithinfinal/file'];
+        beforeEach(async() => {
+            const promiseArray = testFileArray.map(file => {
+                return fs.ensureFile(path.join(testDirectory, file));
+            });
+            await Promise.all(promiseArray);
+        });
+        afterEach(() => {
+            fs.removeSync(testDirectory);
+        });
+        it('should recursively list all directories in testFileArray', async() => {
+            const filesInDirectory = await recusivelyListDirectories(testDirectory, '');
+            filesInDirectory.length.should.equal(testDirArray.length);
+            filesInDirectory.should.have.members(testDirArray);
+        });
+        it('should recursively list all directories in directory testDirectory/dir', async() => {
+            const filesInDirectory = await recusivelyListDirectories(path.join(testDirectory, 'dir'), '');
+            filesInDirectory.length.should.equal(2);
+            filesInDirectory.should.have.members(['dirinanother', 'dirinanother/anotherdirinanother']);
+        });
+        it('should be rejected as directory does not exist', () => {
+            return recusivelyListDirectories('', '').should.be.rejected;
+        });
+        it('should return an empty array as there are no subdirectories', async() => {
+            const filesInDirectory = await recusivelyListDirectories(path.join(testDirectory, 'anotherdir'), '');
+            filesInDirectory.length.should.equal(0);
+            filesInDirectory.should.have.members([]);
         });
     });
     describe('listFilesInDirectory(absolutePath, relativePath)', () => {

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -134,6 +134,18 @@ describe('remoteBind.route.js', () => {
             topLevelDirectories.should.deep.equal(['some']);
         });
     });
+    describe('compareDirs(string, prefix)', () => {
+        const compareDirs = RemoteBind.__get__('compareDirs');
+        it('returns true as relative the file paths are equivalent', async() => {
+            compareDirs('/filepath', 'filepath').should.be.true;
+        });
+        it('returns true as relative the file paths are equivalent', async() => {
+            compareDirs('/filepath', 'filepath/').should.be.true;
+        });
+        it('returns false as relative the file paths are different', async() => {
+            compareDirs('filepath', 'filepathextended').should.be.false;
+        });
+    });
     describe('deletePathsInArray(directory, arrayOfFiles)', () => {
         const deletePathsInArray = RemoteBind.__get__('deletePathsInArray');
         const testFileArray = ['package.json', 'server.js', 'dir/file', 'dir/anotherfile', 'anotherdir/file'];

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -113,9 +113,29 @@ describe('remoteBind.route.js', () => {
             const topLevelDirectories = getTopLevelDirectories(directoryArray);
             topLevelDirectories.should.deep.equal(['nondir/']);
         });
+        it('returns both given directories where one is a prefix other the other', () => {
+            const directoryArray = ['some', 'someother'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(directoryArray);
+        });
+        it('returns both given directories where one is a prefix other the other (reverse)', () => {
+            const directoryArray = ['someother', 'some'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(directoryArray);
+        });
+        it('returns one directory when one has a trailing slash and the other doesn\'t', () => {
+            const directoryArray = ['some/', 'some'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(['some/']);
+        });
+        it('returns one directory when one has a trailing slash and the other doesn\'t (reverse)', () => {
+            const directoryArray = ['some', 'some/'];
+            const topLevelDirectories = getTopLevelDirectories(directoryArray);
+            topLevelDirectories.should.deep.equal(['some']);
+        });
     });
-    describe('deleteFilesInArray(directory, arrayOfFiles)', () => {
-        const deleteFilesInArray = RemoteBind.__get__('deleteFilesInArray');
+    describe('deletePathsInArray(directory, arrayOfFiles)', () => {
+        const deletePathsInArray = RemoteBind.__get__('deletePathsInArray');
         const testFileArray = ['package.json', 'server.js', 'dir/file', 'dir/anotherfile', 'anotherdir/file'];
         beforeEach(async() => {
             await createFilesFromArray(testDirectory, testFileArray);
@@ -125,19 +145,26 @@ describe('remoteBind.route.js', () => {
         });
         it('should delete no files on disk as an empty array is given', async() => {
             assertFilesExist(testDirectory, testFileArray);
-            await deleteFilesInArray(testDirectory, []);
+            await deletePathsInArray(testDirectory, []);
             assertFilesExist(testDirectory, testFileArray);
         });
         it('should delete all files on disk as the whole testFileArray is given but leave the directory', async() => {
             assertFilesExist(testDirectory, testFileArray);
-            await deleteFilesInArray(testDirectory, testFileArray);
+            await deletePathsInArray(testDirectory, testFileArray);
             assertFilesDoNotExist(testDirectory, testFileArray);
         });
         it('should delete the files in the testFileArray but leave the directories in place', async() => {
             assertFilesExist(testDirectory, testFileArray);
-            await deleteFilesInArray(testDirectory, testFileArray);
+            await deletePathsInArray(testDirectory, testFileArray);
             assertFilesDoNotExist(testDirectory, testFileArray);
             chaiDir(testDirectory).should.not.be.empty;
+        });
+        it('should delete the directories in an array', async() => {
+            assertFilesExist(testDirectory, testFileArray);
+            await deletePathsInArray(testDirectory, ['dir', 'anotherdir']);
+            fs.pathExistsSync(path.join(testDirectory, 'dir')).should.be.false;
+            fs.pathExistsSync(path.join(testDirectory, 'anotherdir')).should.be.false;
+            fs.pathExistsSync(path.join(testDirectory, 'package.json')).should.be.true;
         });
     });
     describe('recusivelyListDirectories(absolutePath, relativePath)', () => {

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -134,28 +134,34 @@ describe('remoteBind.route.js', () => {
             topLevelDirectories.should.deep.equal(['some']);
         });
     });
-    describe('compareDirectoryNames(string, prefix)', () => {
-        const compareDirectoryNames = RemoteBind.__get__('compareDirectoryNames');
-        it('returns true as relative the file paths are equivalent', async() => {
-            compareDirectoryNames('filepath/', 'filepath').should.be.true;
+    describe('isSubdirectory(dir1, dir2)', () => {
+        const isSubdirectory = RemoteBind.__get__('isSubdirectory');
+        it('returns true as relative the file paths are equivalent (1)', async() => {
+            isSubdirectory('filepath/', 'filepath').should.be.true;
         });
-        it('returns true as relative the file paths are equivalent', async() => {
-            compareDirectoryNames('filepath', 'filepath/').should.be.true;
+        it('returns true as relative the file paths are equivalent (2)', async() => {
+            isSubdirectory('filepath', 'filepath/').should.be.true;
         });
-        it('returns true as relative the file paths are equivalent', async() => {
-            compareDirectoryNames('filepath', 'filepath').should.be.true;
+        it('returns true as relative the file paths are equivalent (3)', async() => {
+            isSubdirectory('filepath', 'filepath').should.be.true;
         });
-        it('returns false as relative the file paths are different', async() => {
-            compareDirectoryNames('filepath', 'filepathextended').should.be.false;
+        it('returns false as relative the file paths are different (1)', async() => {
+            isSubdirectory('filepath', 'filepathextended').should.be.false;
         });
-        it('returns false as relative the file paths are different', async() => {
-            compareDirectoryNames('filepathextended', 'filepath').should.be.false;
+        it('returns false as relative the file paths are different (2)', async() => {
+            isSubdirectory('filepathextended', 'filepath').should.be.false;
         });
-        it('returns false as relative the file paths are different', async() => {
-            compareDirectoryNames('.filepath', 'filepath').should.be.false;
+        it('returns false as relative the file paths are different (3)', async() => {
+            isSubdirectory('.filepath', 'filepath').should.be.false;
         });
         it('returns false as a relative path and an absolute path are different', async() => {
-            compareDirectoryNames('/filepath', 'filepath').should.be.false;
+            isSubdirectory('/filepath', 'filepath').should.be.false;
+        });
+        it('returns true as filepath/subdirectory is a subdirectory of filepath', async() => {
+            isSubdirectory('filepath/subdirectory', 'filepath').should.be.true;
+        });
+        it('returns false as filepath is not a subdirectory of filepath/subdirectory', async() => {
+            isSubdirectory('filepath', 'filepath/subdirectory').should.be.false;
         });
     });
     describe('deletePathsInArray(directory, arrayOfFiles)', () => {

--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -137,19 +137,25 @@ describe('remoteBind.route.js', () => {
     describe('compareDirectoryNames(string, prefix)', () => {
         const compareDirectoryNames = RemoteBind.__get__('compareDirectoryNames');
         it('returns true as relative the file paths are equivalent', async() => {
-            compareDirectoryNames('/filepath', 'filepath').should.be.true;
-        });
-        it('returns true as relative the file paths are equivalent', async() => {
-            compareDirectoryNames('/filepath', 'filepath/').should.be.true;
+            compareDirectoryNames('filepath/', 'filepath').should.be.true;
         });
         it('returns true as relative the file paths are equivalent', async() => {
             compareDirectoryNames('filepath', 'filepath/').should.be.true;
+        });
+        it('returns true as relative the file paths are equivalent', async() => {
+            compareDirectoryNames('filepath', 'filepath').should.be.true;
         });
         it('returns false as relative the file paths are different', async() => {
             compareDirectoryNames('filepath', 'filepathextended').should.be.false;
         });
         it('returns false as relative the file paths are different', async() => {
+            compareDirectoryNames('filepathextended', 'filepath').should.be.false;
+        });
+        it('returns false as relative the file paths are different', async() => {
             compareDirectoryNames('.filepath', 'filepath').should.be.false;
+        });
+        it('returns false as a relative path and an absolute path are different', async() => {
+            compareDirectoryNames('/filepath', 'filepath').should.be.false;
         });
     });
     describe('deletePathsInArray(directory, arrayOfFiles)', () => {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -762,7 +762,7 @@ describe('Templates.js', function() {
                 await templateController.deleteRepository(url);
                 templateController.repositoryList.should.deep.equal([]);
             });
-            it('attempts to delete a repo that does not exist', async function() {
+            it('attempts to delete a repo that does not exist', function() {
                 const mockRepoList = [sampleRepos.codewind];
                 const templateController = new Templates(testWorkspaceDir);
                 templateController.repositoryList = [...mockRepoList];


### PR DESCRIPTION
PFE part of https://github.com/eclipse/codewind/issues/1560
### Summary
* Added functionality in `upload/end` to delete by directory where possible before re-scanning the file system and deleting the files as we currently do.
  * Required added functionality to ensure only the highest level directory is deleted rather than attempting to delete its sub directories as well.
* Updated the API OpenApi docs to reflect the addition of a `directoryList` in `upload/end`
* Renamed `getFilesToDelete` to `getPathsToDelete` as its now used for files and directories.

### Testing
* Created unit tests for newly introduced functions
* Added directory tests to `path` functions (previously `file` functions)