### PR TITLE
Use container name for the snapshot ID

### DIFF
--- a/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
+++ b/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
@@ -82,8 +82,7 @@ class RunTestHistory extends Component {
      */
     async handleDeleteRow(rowID) {
         this.setState({ deleteInProgress: true });
-        const rowTime = formatDateToString(parseInt(rowID));
-        const result = await postDeleteTests(this.props.projectID, rowTime);
+        const result = await postDeleteTests(this.props.projectID, rowID);
         if (result.status && result.status === 200) {
             await this.props.dispatch(reloadMetricsData(this.props.projectID, this.props.projectMetricTypes.types));
         } else {

--- a/src/performance/dashboard/src/modules/MetricsUtils.js
+++ b/src/performance/dashboard/src/modules/MetricsUtils.js
@@ -241,6 +241,7 @@ let buildChartDataHTTP = function (params) {
  *
  * @param {*} metrics the loaded metrics from redux
  * @param {string} filteredUrl the URL path
+ * @return [{container,time}] an array of timestamps each containing a containerName and starttime
  */
 let getHTTPHitTimestamps = function (metrics, filteredUrl) {
 
@@ -256,7 +257,7 @@ let getHTTPHitTimestamps = function (metrics, filteredUrl) {
             return false;
         });
         if (foundUrlSamples) {
-            timestamps.push(snapshot.time);
+            timestamps.push({container: snapshot.container, time: snapshot.time});
         }
     });
     return timestamps;
@@ -273,15 +274,15 @@ let sortMetrics = function (metrics, filteredUrl) {
     let x = -1;
     let model = httpHitTimestamps.map(t => {
         x = x + 1;
-        return { 'id': t.toString(), 'time': t, 'plotNumber': x }
+        return { 'id': t.container, 'time': t.time, 'plotNumber': x }
     })
 
-    // merge all the metrics into the data model using a timestamp key
+    // merge all the metrics into the data model using the ID
     metrics.forEach(metricType => {
         metricType.metrics.forEach(snapshot => {
-            const timestamp = model.find(element => { return element['time'] === snapshot['time'] });
+            const timestamp = model.find(element => { return element['id'] === snapshot['container'] });
             if (timestamp) {
-                let metricsGroup = {}
+                let metricsGroup = {};
                 metricsGroup.type = metricType.type;
                 metricsGroup.value = snapshot;
                 timestamp[metricType.type] = metricsGroup;

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -289,6 +289,7 @@ module.exports = class Project {
       // If a file doesn't include the metrics of that type, skip the file
       if (metricsFile[metricsFileType] != undefined) {
         const metric = {
+          container: loadTestDirectories[i],
           time: metricsFile.time.data.start || metricsFile.time.data.startTime,
           endTime: metricsFile.time.data.end || metricsFile.time.data.endTime,
           value: metricsFile[metricsFileType] };


### PR DESCRIPTION
## Problem

Metrics can not be deleted from Performance Dashboard History view. This problem appears more often in Hybrid where the project container could run on a different node to the PFE container and were there may be a few millisecond delay between a metrics folder being created in PFE and the metrics being sampled in the project. 

Issue : https://github.com/eclipse/codewind/issues/1581

## Solution 

Rather than use the start time as the metrics snapshot ID,  use a directory name that is injected into the metrics by PFE when it serves the metrics data.

## Result 

Using an ID for the row that is EXACTLY the same as the container in PFE which holds the metrics.json (GREEN) rather than a time (RED)

![Screenshot 2019-12-18 at 12 06 37](https://user-images.githubusercontent.com/28102564/71088664-e17b8100-2196-11ea-96b6-b5c32dc6e307.png)



Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>