### PR TITLE
don't unzip the cache at install time

### DIFF
--- a/src/pfe/file-watcher/idc/artifacts/build_server.sh
+++ b/src/pfe/file-watcher/idc/artifacts/build_server.sh
@@ -28,7 +28,7 @@ if [ ! -d $HOME/$MAVEN_M2_CACHE ]; then
 	cd $HOME
 
 	echo "Extracting maven m2 cache to $HOME"
-	$JAVA_HOME/bin/jar -xf $APP_DIR/localm2cache.zip
+	$JAVA_HOME/bin/jar -xf $APP_DIR/ .zip
 	rm -rf $APP_DIR/localm2cache.zip
 	echo "Finished extracting maven m2 cache to $HOME"
 fi

--- a/src/pfe/file-watcher/idc/artifacts/build_server.sh
+++ b/src/pfe/file-watcher/idc/artifacts/build_server.sh
@@ -28,7 +28,7 @@ if [ ! -d $HOME/$MAVEN_M2_CACHE ]; then
 	cd $HOME
 
 	echo "Extracting maven m2 cache to $HOME"
-	$JAVA_HOME/bin/jar -xf $APP_DIR/ .zip
+	$JAVA_HOME/bin/jar -xf $APP_DIR/localm2cache.zip
 	rm -rf $APP_DIR/localm2cache.zip
 	echo "Finished extracting maven m2 cache to $HOME"
 fi

--- a/src/pfe/file-watcher/scripts/spring-container.sh
+++ b/src/pfe/file-watcher/scripts/spring-container.sh
@@ -92,18 +92,6 @@ function create() {
 					cp $mnt/cache/localm2cache.zip .
 					buildah rm $CACHE_CONTAINER_ID
 					echo "Finished downloading maven m2 cache to $ROOT"
-
-					echo "Extracting maven m2 cache to $ROOT"
-					unzip -q localm2cache.zip
-					rm -rf localm2cache.zip
-					echo "Finished extracting maven m2 cache to $ROOT"
-
-					# Verify maven m2 cache
-					if [ -d $MAVEN_M2_CACHE ]; then
-						echo "Maven m2 cache is set up for $ROOT"
-					else
-						echo "Maven m2 cache is not set up for $ROOT"
-					fi
 				else
 					echo "Maven m2 cache cannot be retrieved for spring project $ROOT because the cache image could not be pulled using buildah"
 				fi
@@ -113,26 +101,13 @@ function create() {
 				dockerPullExitCode=$?
 
 				if [ $dockerPullExitCode -eq 0 ]; then
-					echo "Finished pulling maven m2 cache image for $ROOT using docker"
-					echo "Maven m2 cache will be used for spring project $ROOT"
+					echo "Finished pulling cache image for $ROOT using docker"
+					echo "Cache will be used for spring project $ROOT"
 					CACHE_CONTAINER_ID=$(docker create ibmcom/codewind-java-project-cache)
-
 					echo "Downloading maven m2 cache to $ROOT"
 					docker cp $CACHE_CONTAINER_ID:/cache/localm2cache.zip .
+					echo "Finished downloading maven m2 cache to $ROOT"	
 					docker rm -f $CACHE_CONTAINER_ID
-					echo "Finished downloading maven m2 cache to $ROOT"
-
-					echo "Extracting maven m2 cache to $ROOT"
-					unzip -q localm2cache.zip
-					rm -rf localm2cache.zip
-					echo "Finished extracting maven m2 cache to $ROOT"
-
-					# Verify maven m2 cache
-					if [ -d $MAVEN_M2_CACHE ]; then
-						echo "Maven m2 cache is set up for $ROOT"
-					else
-						echo "Maven m2 cache is not set up for $ROOT"
-					fi
 				else
 					echo "Maven m2 cache cannot be retrieved for spring project $ROOT because the cache image could not be pulled using docker"
 				fi

--- a/src/pfe/file-watcher/scripts/springScripts/spring-build.sh
+++ b/src/pfe/file-watcher/scripts/springScripts/spring-build.sh
@@ -16,6 +16,14 @@ pkill java
 
 # Run a maven build to generate the new jar
 cd /root/app
+
+if [ -f localm2cache.zip ]; then
+    echo "Extracting maven m2 cache for $PROJECT_NAME"
+    $JAVA_HOME/bin/jar -xf localm2cache.zip
+    rm -f localm2cache.zip
+    echo "Finished extracting maven m2 cache for $PROJECT_NAME"	
+fi
+
 echo "Running Maven build for $PROJECT_NAME"
 echo "mvn -Dmaven.repo.local=/root/app/.m2/repository -f ./pom.xml package -Dmaven.test.skip=true $MAVEN_SETTINGS --log-file "/root/logs/$MAVEN_BUILD.log""
 mvn -Dmaven.repo.local=/root/app/.m2/repository -f ./pom.xml package -Dmaven.test.skip=true $MAVEN_SETTINGS --log-file "/root/logs/$MAVEN_BUILD.log"


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

changed the spring-container.sh script to work the same as the liberty-container script and not unzip the cache file