### PR TITLE
 When in Kube, Loadrunner should use project service to determine endpoint

### DIFF
--- a/src/performance/dashboard/package.json
+++ b/src/performance/dashboard/package.json
@@ -12,6 +12,7 @@
     "carbon-components": "10.2.0",
     "carbon-components-react": "7.2.0",
     "carbon-icons": "7.0.7",
+    "keycloak-js": "^8.0.1",
     "query-string": "^6.5.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/performance/dashboard/src/App.js
+++ b/src/performance/dashboard/src/App.js
@@ -28,10 +28,18 @@ let socketURL = `${AppConstants.API_SERVER}/default`;
 
 const socket = io(socketURL, { timeout: '5000' });
 
+// Authenticate socket after connecting
+socket.on('connect', function(){
+  const accessToken = localStorage.getItem("cw-access-token");
+  if (accessToken) {
+    socket.emit('authentication', {  token:  accessToken});
+  }
+});
+
 function App() {
 
   const projectID = ProjectIDChecker.projectID();
- 
+
   return (
     <SocketContext.Provider value={socket}>
       <div className="App">

--- a/src/performance/dashboard/src/index.js
+++ b/src/performance/dashboard/src/index.js
@@ -14,9 +14,82 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import { Provider } from 'react-redux';
 import configureStore from './store/store';
+import Keycloak from 'keycloak-js'
+import * as AppConstants from './AppConstants';
 
-ReactDOM.render(
-    <Provider store={configureStore}>
-        <App />
-    </Provider>
-    , document.getElementById('root'));
+// fetch the authentication details from gatekeeper
+async function fetchAuthInfo() {
+    try {
+        const result = await fetch(`${AppConstants.API_SERVER}/api/v1/gatekeeper/environment`, {
+            method: 'get',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            }
+        });
+        const reply = await result.json();
+        if (result.status == 200) {
+            return {
+                url: reply.auth_url + "/auth",
+                realm: reply.realm,
+                clientId: reply.client_id,
+                onLoad: 'login-required'
+            }
+        }
+        return { hasError: true, status: result.status };
+    } catch (err) {
+        return { hasError: true, status: 500, message: err }
+    }
+}
+
+
+async function init() {
+    let initOptions = await fetchAuthInfo();
+    console.log(initOptions)
+    if (initOptions.hasError) {
+        console.warn("No Auth service available")
+        ReactDOM.render(
+            <Provider store={configureStore}>
+                <App />
+            </Provider>
+            , document.getElementById('root')
+        );
+    } else {
+        let keycloak = Keycloak(initOptions)
+        keycloak.init({ onLoad: initOptions.onLoad }).success((auth) => {
+            if (!auth) {
+                window.location.reload();
+            } else {
+                console.info(`Dashboard - authenticated`);
+            }
+            ReactDOM.render(
+                <Provider store={configureStore}>
+                    <App />
+                </Provider>
+                , document.getElementById('root'));
+
+            localStorage.setItem("cw-access-token", keycloak.token);
+            localStorage.setItem("cw-refresh-token", keycloak.refreshToken);
+
+            // Access token refresh
+            setTimeout(() => {
+                // if the access token is due to expire within the next 80 seconds refresh it
+                keycloak.updateToken(80).success((refreshed) => {
+                    if (refreshed) {
+                        console.debug(`Dashboard access-token refreshed`);
+                    } else {
+                        console.warn(`Dashboard refresh-token refreshed`);
+                    }
+                }).error(() => {
+                    console.error(`Dashboard Failed to refresh authentication tokens`);
+                });
+            }, 60 * 1000)
+
+        }).error(err => {
+            console.error("Authenticated Failed");
+            console.error(err);
+        });
+    }
+}
+
+init();

--- a/src/performance/package-lock.json
+++ b/src/performance/package-lock.json
@@ -207,6 +207,11 @@
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
@@ -1800,6 +1805,20 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
+    "keycloak-js": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-8.0.1.tgz",
+      "integrity": "sha512-1ABx6ZCk1jrmn9wAX8oMw175M75JHhpKq2bKSmplkhQXErkp0r8Lf+e+91Gr8DixVtT4/IyH9mc/JQuwbkvRbA==",
+      "requires": {
+        "base64-js": "1.3.1",
+        "js-sha256": "0.9.0"
+      }
     },
     "kind-of": {
       "version": "6.0.2",

--- a/src/performance/package.json
+++ b/src/performance/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.4",
     "express-async-errors": "^3.1.1",
+    "keycloak-js": "^8.0.1",
     "loadtest": "^3.0.0",
     "nodemon": "^1.19.3",
     "parse-prometheus-text-format": "^1.1.1",

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -236,8 +236,6 @@ module.exports = class LoadRunner {
       // eslint-disable-next-line no-await-in-loop
       await cwUtils.timeout(5000);
       try {
-        // eslint-disable-next-line no-await-in-loop
-
         let options = {
           host: this.project.host,
           port: this.project.getPort(),
@@ -249,8 +247,9 @@ module.exports = class LoadRunner {
         if (this.project.kubeServiceHost && this.project.kubeServicePort ) {
           options.host = this.project.kubeServiceHost;
           options.port = this.project.kubeServicePort;
-      }
+        }
 
+        // eslint-disable-next-line no-await-in-loop
         let httpCheckHealth = await cwUtils.asyncHttpRequest(options);
 
         log.info(`httpCheckHealth ${httpCheckHealth.statusCode}`);


### PR DESCRIPTION
## Problem: 

Performance dashboard does not work in hybrid as documented in Issue https://github.com/eclipse/codewind/issues/1508. Caused by PFE being unable to access the running project container using http://master:nodeport

## Solution

This PR changes how Codewind communicates with a project container.  Now PFE when running in Kube (including CHE) will : 

Discover project endpoint by querying the project service
Make LoadRunner apply load pressure to project directly rather than through ingress
Make metrics controller gather metrics from project directly rather than ingress

**And in performance dashboard :** 
When PFE is secured, send authentication token to access the protected UISocket
