### PR TITLE
Fix windows test image to point to eclipse/codewind-pfe-amd64

### DIFF
--- a/src/pfe/file-watcher/server/test/cronjob/cronjob-win.sh
+++ b/src/pfe/file-watcher/server/test/cronjob/cronjob-win.sh
@@ -21,7 +21,7 @@ cd /c
 TEST_WD=$(pwd)
 
 CW_CONTAINER="codewind-pfe"
-DEFAULT_IMG="codewind-pfe-amd64"
+DEFAULT_IMG="eclipse/codewind-pfe-amd64"
 IN_CONTAINER_PATH="/file-watcher/server"
 
 IMAGE_TAG=""
@@ -131,7 +131,7 @@ if [[ ! -z "$IMAGE_TAG" ]]; then
 	docker pull $IMAGE_TAG
 	checkExitCode $? "Failed to pull down custom image."
 	
-	echo -e "${BLUE}>> Tagging custom image: $IMAGE_TAG -> codewind-pfe-amd64  ... ${RESET}"
+	echo -e "${BLUE}>> Tagging custom image: $IMAGE_TAG -> $DEFAULT_IMG  ... ${RESET}"
 	docker tag $IMAGE_TAG $DEFAULT_IMG
 	checkExitCode $? "Failed to tag custom image."
 fi


### PR DESCRIPTION
Related to https://github.com/eclipse/codewind/pull/1580

Signed-off-by: ssh24 <sakib@ibm.com>