### PR TITLE
Remove log directory mounting for liberty and spring projects

### DIFF
--- a/src/pfe/file-watcher/idc/artifacts/run_docker.sh
+++ b/src/pfe/file-watcher/idc/artifacts/run_docker.sh
@@ -60,8 +60,8 @@ if [[ $MICROCLIMATE_WS_ORIGIN &&  "$APPDIR" == '/codewind-workspace'* ]]
 		LOGSDIR=$MICROCLIMATE_WS_ORIGIN/.logs/"$LOGFOLDER"
 		echo "Log path used for volume mounting is: "$LOGSDIR""
 
-# on liberty the docker run checks for the output of the the command - check ContainerRunTask.java line 77 https://github.com/eclipse/codewind/blob/deebc7bdf94d8a27f8ff1756e7ba63c6030d87c8/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/tasks/ContainerRunTask.java#L77
-		OUTPUT_DOCKER_RUN="$(docker run -dt --entrypoint "/home/default/artifacts/new_entrypoint.sh" --name $CONTAINER_NAME -v "$LOGSDIR":/logs --network=codewind_network $PORT_MAPPING_PARAMS $CONTAINER_IMAGE_NAME)"
+		# on liberty the docker run checks for the output of the the command - check ContainerRunTask.java line 77 https://github.com/eclipse/codewind/blob/deebc7bdf94d8a27f8ff1756e7ba63c6030d87c8/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/tasks/ContainerRunTask.java#L77
+		OUTPUT_DOCKER_RUN="$(docker run -dt --entrypoint "/home/default/artifacts/new_entrypoint.sh" --name $CONTAINER_NAME --network=codewind_network $PORT_MAPPING_PARAMS $CONTAINER_IMAGE_NAME)"
 		if [ $? -eq 0 ]; then
 			echo -e "Copying over source files"
 			docker cp "$APP_DIRECTORY"/. $CONTAINER_NAME:$HOME/app
@@ -70,7 +70,7 @@ if [[ $MICROCLIMATE_WS_ORIGIN &&  "$APPDIR" == '/codewind-workspace'* ]]
 
 	else
 		# on liberty the docker run checks for the output of the the command - check ContainerRunTask.java line 77 https://github.com/eclipse/codewind/blob/deebc7bdf94d8a27f8ff1756e7ba63c6030d87c8/src/pfe/iterative-dev/idc-java/IDC/src/org/eclipse/codewind/iterdev/tasks/ContainerRunTask.java#L77
-		OUTPUT_DOCKER_RUN="$(docker run -dt --name $CONTAINER_NAME -v "$LOGSDIR":$HOME/logs $PORT_MAPPING_PARAMS $CONTAINER_IMAGE_NAME)"
+		OUTPUT_DOCKER_RUN="$(docker run -dt --name $CONTAINER_NAME $PORT_MAPPING_PARAMS $CONTAINER_IMAGE_NAME)"
 		if [ $? -eq 0 ]; then
 			echo -e "Copying over source files"
 			docker cp "$APP_DIRECTORY"/. $CONTAINER_NAME:$HOME/app

--- a/src/pfe/file-watcher/scripts/spring-container.sh
+++ b/src/pfe/file-watcher/scripts/spring-container.sh
@@ -293,7 +293,6 @@ function dockerRun() {
 	$IMAGE_COMMAND run --network=codewind_network \
 		--entrypoint "/scripts/new_entrypoint.sh" \
 		--name $project \
-		-v "$workspace/.logs":/root/logs \
 		--expose 8080 -p 127.0.0.1::$DEBUG_PORT -P -dt $project
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"

--- a/src/pfe/file-watcher/scripts/springScripts/new_entrypoint.sh
+++ b/src/pfe/file-watcher/scripts/springScripts/new_entrypoint.sh
@@ -42,8 +42,6 @@ if [[ "$IN_K8" == "true" ]]; then
     ln -s /codewind-workspace/$PROJECT_NAME /root/app
 fi
 
-# Create symlinks to /root/logs and /root/app on the Liberty app container / pod
-# Note that $PROJECT_NAME is an env-var defined and set in the liberty app's deployment.yaml
 mkdir -p /root/logs
 
 # ------ keep old new entry point logic the same ------

--- a/src/pfe/file-watcher/scripts/springScripts/new_entrypoint.sh
+++ b/src/pfe/file-watcher/scripts/springScripts/new_entrypoint.sh
@@ -39,11 +39,12 @@ if [[ "$IN_K8" == "true" ]]; then
         exit 1;
     fi
 
-    # Create symlinks to /root/logs and /root/app on the Liberty app container / pod
-    # Note that $PROJECT_NAME is an env-var defined and set in the liberty app's deployment.yaml
-    mkdir -p /root/logs
     ln -s /codewind-workspace/$PROJECT_NAME /root/app
 fi
+
+# Create symlinks to /root/logs and /root/app on the Liberty app container / pod
+# Note that $PROJECT_NAME is an env-var defined and set in the liberty app's deployment.yaml
+mkdir -p /root/logs
 
 # ------ keep old new entry point logic the same ------
 


### PR DESCRIPTION
### Description

We should not be mounting the log directories for liberty and spring projects anymore because we now support log streaming directly based on workspace or containers. This PR removes the log directory mounting for the two project types. Also note, Node.js or Swift didn't have the log directory mounting and thus was not causing issues.

Related to https://github.com/eclipse/codewind/issues/1576

After the fix, both liberty and spring projects build and start correctly and the logs streaming also works
![Screen Shot 2019-12-18 at 1 22 48 PM](https://user-images.githubusercontent.com/15173354/71114502-ed1e7600-219d-11ea-8972-51a9647b31fe.png)


Signed-off-by: ssh24 <sakib@ibm.com>