### PR TITLE
Prevent the .m2 folder from getting deleted upon Spring project changes

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -273,7 +273,7 @@ function getFilesToDelete(existingFileArray, newFileArray) {
 }
 
 function fileIsProtected(filePath) {
-  const protectedPrefixes = [".odo/", "node_modules/"];
+  const protectedPrefixes = [".odo/", "node_modules/", ".m2/"];
   return protectedPrefixes.some((prefix) => filePath.startsWith(prefix));
 }
 


### PR DESCRIPTION
Fixes #1574 on Che

This PR adds the .m2 folder to the list of protected folders on project sync, preventing it from getting deleted and causing the issue seen in #1574.

**DO NOT MERGE** if https://github.com/eclipse/codewind/pull/1595 is merged