### PR TITLE
Shuffle project types before running functional tests

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/functional.test.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/functional.test.ts
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 import mocha from "mocha";
+import * as _ from "lodash";
 import { expect } from "chai";
 import fs from "fs";
 import path from "path";
@@ -75,8 +76,8 @@ describe("PFE - functional test", () => {
 
 function runAllTests(): void {
   genericSuite.runTest();
-  for (const chosenTemplate of Object.keys(projectTypes)) {
-    for (const chosenProject of projectTypes[chosenTemplate]) {
+  for (const chosenTemplate of _.shuffle(Object.keys(projectTypes))) {
+    for (const chosenProject of _.shuffle(projectTypes[chosenTemplate])) {
       if (process.env.TURBINE_PERFORMANCE_TEST) {
         createDataFile(chosenTemplate, chosenProject);
       }


### PR DESCRIPTION
### Description

Shuffle project types before running functional tests allows us to not be biased on the order of the list of project types we use to run the test. This will run the tests in shuffled order of projects and let's us know that if something wrong with PFE is happening is not specific to the project type.

Signed-off-by: ssh24 <sakib@ibm.com>