### PR TITLE
Allow build queue to apply on update scenarios

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -23,6 +23,7 @@ import * as projectSpecifications  from "../projects/projectSpecifications";
 import AsyncLock from "async-lock";
 import * as workspaceSettings from "../utils/workspaceSettings";
 import * as utils from "../utils/utils";
+import { changedFilesMap, IFileChangeEvent } from "../utils/fileChanges";
 const lock = new AsyncLock();
 
 const fileStatAsync = promisify(fs.stat);
@@ -34,7 +35,6 @@ const fileStatAsync = promisify(fs.stat);
  * value: timer
  */
 export const timerMap: Map<string, NodeJS.Timer> = new Map<string, NodeJS.Timer>();
-export const changedFilesMap: Map<string, IFileChangeEvent[]> = new Map<string, IFileChangeEvent[]>();
 export const chunkRemainingMap: Map <string, ChunkRemainingMapValue[]> = new Map<string, ChunkRemainingMapValue[]>();
 
 const workspaceSettingsInfo =  workspaceSettings.workspaceSettingsInfoCache ? JSON.parse(workspaceSettings.workspaceSettingsInfoCache) : undefined;
@@ -304,13 +304,7 @@ export interface IUpdateProjectFailure {
     error: { msg: string };
 }
 
-export interface IFileChangeEvent {
-    path: string;
-    timestamp: number;
-    type: string;
-    directory: boolean;
-    content?: string;
-}
+
 export interface ChunkRemainingMapValue {
     timestamp: number;
     chunkRemaining: number;

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -229,7 +229,8 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                                 operation: operation,
                                 handler: projectHandler
                             };
-                            await projectsController.addProjectToBuildQueue(project, changedFilesMap.get(projectInfo.projectID));
+                            // for update operation
+                            await projectsController.addProjectToBuildQueue(project);
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);
                             const keyValuePair: UpdateProjectInfoPair = {
@@ -258,7 +259,8 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                                 operation: operation,
                                 handler: projectHandler
                             };
-                            await projectsController.addProjectToBuildQueue(project, changedFilesMap.get(projectInfo.projectID));
+                            // for update operation
+                            await projectsController.addProjectToBuildQueue(project);
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);
                             const keyValuePair: UpdateProjectInfoPair = {

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -230,6 +230,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                                 handler: projectHandler
                             };
                             // for update operation
+                            await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, projectID, statusController.BuildState.inProgress, "action.calculateDifference");
                             await projectsController.addProjectToBuildQueue(project);
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);
@@ -260,6 +261,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                                 handler: projectHandler
                             };
                             // for update operation
+                            await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, projectID, statusController.BuildState.inProgress, "action.calculateDifference");
                             await projectsController.addProjectToBuildQueue(project);
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -230,7 +230,7 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                                 handler: projectHandler
                             };
                             // for update operation
-                            await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, projectID, statusController.BuildState.inProgress, "action.calculateDifference");
+                            await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, projectID, statusController.BuildState.inProgress, "");
                             await projectsController.addProjectToBuildQueue(project);
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);

--- a/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts
@@ -225,7 +225,11 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                     if (projectInfo.autoBuildEnabled) {
                         if (!statusController.isBuildInProgressOrQueued(projectID)) {
                             const operation = new projectOperation.Operation("update", projectInfo);
-                            projectHandler.update(operation, changedFilesMap.get(projectInfo.projectID));
+                            const project: projectsController.BuildQueueType = {
+                                operation: operation,
+                                handler: projectHandler
+                            };
+                            await projectsController.addProjectToBuildQueue(project, changedFilesMap.get(projectInfo.projectID));
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);
                             const keyValuePair: UpdateProjectInfoPair = {
@@ -250,7 +254,11 @@ export async function updateProjectForNewChange(projectID: string, timestamp: nu
                     if (projectInfo.autoBuildEnabled) {
                         if (!statusController.isBuildInProgressOrQueued(projectID)) {
                             const operation = new projectOperation.Operation("update", projectInfo);
-                            projectHandler.update(operation, changedFilesMap.get(projectInfo.projectID));
+                            const project: projectsController.BuildQueueType = {
+                                operation: operation,
+                                handler: projectHandler
+                            };
+                            await projectsController.addProjectToBuildQueue(project, changedFilesMap.get(projectInfo.projectID));
                         } else {
                             logger.logProjectInfo("Project "  + projectID + " build is in progress, set build request flag to true", projectID);
                             const keyValuePair: UpdateProjectInfoPair = {

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -27,10 +27,10 @@ import * as projectUtil from "../projects/projectUtil";
 import * as logHelper from "../projects/logHelper";
 import * as logger from "../utils/logger";
 import * as statusController from "./projectStatusController";
-import * as projectEventsController from "./projectEventsController";
 import * as projectExtensions from "../extensions/projectExtensions";
 import * as processManager from "../utils/processManager";
 import { Validator } from "../projects/Validator";
+import { changedFilesMap } from "../utils/fileChanges";
 
 
 interface ProjectInfoCache {
@@ -543,7 +543,7 @@ async function triggerBuild(project: BuildQueueType): Promise<void> {
 
         // Hand off operation to appropriate handler for execution
         logger.logProjectInfo(`Handing ${operationType} operation to the selected project handler`, projectID);
-        selectedProjectHandler.update(operation, projectEventsController.changedFilesMap.get(projectID));
+        selectedProjectHandler.update(operation, changedFilesMap.get(projectID));
     } else {
         return;
     }

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -521,11 +521,11 @@ async function triggerBuild(project: BuildQueueType): Promise<void> {
             }
         }
 
-        logger.logProjectInfo("Build began for " + projectID, projectID);
+        logger.logProjectInfo(`${operationType} build began for ${projectID}`, projectID);
         await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, project.operation.projectInfo.projectID, statusController.BuildState.inProgress, "projectStatusController.buildStarted");
 
         // Hand off operation to appropriate handler for execution
-        logger.logProjectInfo("Handing create operation to the selected project handler", projectID);
+        logger.logProjectInfo(`Handing ${operationType} operation to the selected project handler`, projectID);
         selectedProjectHandler.create(operation);
 
         // To notify filewatcher daemon that the project has been added
@@ -538,6 +538,11 @@ async function triggerBuild(project: BuildQueueType): Promise<void> {
         }
         io.emitOnListener("newProjectAdded", eventData);
     } else if (operationType.toLowerCase() === "update") {
+        logger.logProjectInfo(`${operationType} build began for ${projectID}`, projectID);
+        await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, project.operation.projectInfo.projectID, statusController.BuildState.inProgress, "projectStatusController.buildStarted");
+
+        // Hand off operation to appropriate handler for execution
+        logger.logProjectInfo(`Handing ${operationType} operation to the selected project handler`, projectID);
         selectedProjectHandler.update(operation, projectEventsController.changedFilesMap.get(projectID));
     } else {
         return;

--- a/src/pfe/file-watcher/server/src/extensions/IExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/extensions/IExtensionProject.ts
@@ -12,7 +12,7 @@
 
 import { Operation } from "../projects/operation";
 import { ProjectInfo, BuildLog, AppLog, ProjectCapabilities } from "../projects/Project";
-import * as projectEventsController from "../controllers/projectEventsController";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 /**
  * @interface
@@ -35,9 +35,9 @@ export interface IExtensionProject {
      * @description Update operation for the project.
      *
      * @param operation <Required | Operation> - The update operation.
-     * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+     * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
      */
-    update(operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void;
+    update(operation: Operation, changedFiles?: IFileChangeEvent[]): void;
 
     /**
      * @function

--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -20,6 +20,7 @@ import * as workspaceSettings from "./utils/workspaceSettings";
 import * as socket from "./utils/socket";
 import fs from "fs";
 import * as constants from "./projects/constants";
+import { IFileChangeEvent } from "./utils/fileChanges";
 
 const existsAsync = promisify(fs.exists);
 const mkDirAsync = promisify(fs.mkdir);
@@ -678,7 +679,7 @@ export default class Filewatcher {
      *  @property 500: Retrieving start modes failed due to an internal error
      *
      */
-    updateProjectForNewChange: (projectID: string, timestamp: number, chunk: number, chunk_total: number, eventArray: projectEventsController.IFileChangeEvent[]) => Promise<projectEventsController.IUpdateProjectSuccess | projectEventsController.IUpdateProjectFailure>;
+    updateProjectForNewChange: (projectID: string, timestamp: number, chunk: number, chunk_total: number, eventArray: IFileChangeEvent[]) => Promise<projectEventsController.IUpdateProjectSuccess | projectEventsController.IUpdateProjectFailure>;
 
     constructor() {
         this.createProjectsDataDir();

--- a/src/pfe/file-watcher/server/src/projects/DockerProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/DockerProject.ts
@@ -18,11 +18,12 @@ import { ProjectInfo, BuildLog, AppLog } from "./Project";
 import { Validator } from "./Validator";
 import * as logHelper from "./logHelper";
 import * as projectEventsController from "../controllers/projectEventsController";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 interface ProjectExtension {
     supportedType: string;
     create(operation: Operation): void;
-    update(operation: Operation, changedFiles: projectEventsController.IFileChangeEvent[]): void;
+    update(operation: Operation, changedFiles: IFileChangeEvent[]): void;
     typeMatches(location: string): Promise<boolean>;
     getLogs(type: string, logDirectory: string, projectID: string, containerName: string): Promise<Array<AppLog | BuildLog>>;
     validate(operation: Operation): void;
@@ -99,11 +100,11 @@ export class DockerProject implements ProjectExtension {
      * @description Update operation for docker projects.
      *
      * @param operation <Required | Operation> - The update operation.
-     * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+     * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
      *
      * @returns Promise<void>
      */
-    async update(operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): Promise<void> {
+    async update(operation: Operation, changedFiles?: IFileChangeEvent[]): Promise<void> {
         try {
             await projectUtil.buildAndRun(operation, "update");
         } catch (err) {

--- a/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
@@ -16,12 +16,12 @@ import * as path from "path";
 import * as projectUtil from "./projectUtil";
 import * as processManager from "../utils/processManager";
 import * as logHelper from "./logHelper";
-import * as projectEventsController from "../controllers/projectEventsController";
 import * as logger from "../utils/logger";
 import { Operation } from "./operation";
 import { ProjectInfo, BuildLog, AppLog, ProjectCapabilities, defaultProjectCapabilities } from "./Project";
 import { Validator } from "./Validator";
 import { IExtensionProject } from "../extensions/IExtensionProject";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 // skeleton for the logs originated from the extension json
 const logsOrigin: logHelper.ILogTypes = {
@@ -111,9 +111,9 @@ export class OdoExtensionProject implements IExtensionProject {
      * @description Update operation for the project.
      *
      * @param operation <Required | Operation> - The update operation.
-     * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+     * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
      */
-    update = (operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void => {
+    update = (operation: Operation, changedFiles?: IFileChangeEvent[]): void => {
         projectUtil.containerUpdate(operation, path.join(this.fullPath, "odo-extension-entrypoint.sh"), "update");
     }
 

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -18,11 +18,11 @@ import { Operation } from "./operation";
 import { ProjectInfo, BuildLog, AppLog, ProjectCapabilities, defaultProjectCapabilities } from "./Project";
 import { Validator } from "./Validator";
 import * as logHelper from "./logHelper";
-import * as projectEventsController from "../controllers/projectEventsController";
 import { IExtensionProject } from "../extensions/IExtensionProject";
 import * as processManager from "../utils/processManager";
 import * as logger from "../utils/logger";
 import { projectConstants, StartModes } from "./constants";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 /**
  * @interface
@@ -179,9 +179,9 @@ export class ShellExtensionProject implements IExtensionProject {
      * @description Update operation for the project.
      *
      * @param operation <Required | Operation> - The update operation.
-     * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+     * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
      */
-    update = (operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void => {
+    update = (operation: Operation, changedFiles?: IFileChangeEvent[]): void => {
 
         // detectChangeByExtension may contain a list of files that should trigger a REBUILD
         if (changedFiles && Array.isArray(this.detectChangeByExtension)) {

--- a/src/pfe/file-watcher/server/src/projects/actions.ts
+++ b/src/pfe/file-watcher/server/src/projects/actions.ts
@@ -23,6 +23,7 @@ import * as statusController from "../controllers/projectStatusController";
 import * as utils from "../utils/utils";
 import { IProjectActionParams } from "../controllers/projectsController";
 import * as projectEventsController from "../controllers/projectEventsController";
+import { changedFilesMap } from "../utils/fileChanges";
 
 export const actionMap = new Map<string, (args: any) => any>();
 import AsyncLock from "async-lock";
@@ -158,7 +159,7 @@ async function enableAndBuild(projectInfo: ProjectInfo): Promise<void> {
                         };
                         // for update operation
                         await projectsController.addProjectToBuildQueue(project);
-                        projectEventsController.changedFilesMap.delete(projectID);
+                        changedFilesMap.delete(projectID);
                         clearInterval(intervaltimer);
                         done();
                     }, () => {
@@ -251,7 +252,7 @@ export const build = async function (args: IProjectActionParams): Promise<{ oper
                 await projectsController.addProjectToBuildQueue(project);
                 statusController.buildRequired(args.projectID, false);
                 // delete cache from the map, since a build is triggerred
-                projectEventsController.changedFilesMap.delete(args.projectID);
+                changedFilesMap.delete(args.projectID);
                 clearInterval(intervaltimer);
                 done();
             }, () => {

--- a/src/pfe/file-watcher/server/src/projects/actions.ts
+++ b/src/pfe/file-watcher/server/src/projects/actions.ts
@@ -144,20 +144,20 @@ async function enableAndBuild(projectInfo: ProjectInfo): Promise<void> {
                 logger.logProjectInfo("Start build on switch to auto build enabled", projectID, projectName);
                 const operation = new Operation("update", projectInfo);
                 await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, projectID, statusController.BuildState.inProgress, "action.calculateDifference");
-                const intervaltimer = setInterval(async () => {
+                const intervaltimer = setInterval(() => {
                     // wait till no expected incoming chunks in order to get a full fileChanged array
-                    await lock.acquire(["chunkRemainingLock", "changedFilesLock"], async done => {
+                    lock.acquire(["chunkRemainingLock", "changedFilesLock"], async done => {
                         const chunkRemainingArray = projectEventsController.chunkRemainingMap.get(projectID);
                         if (chunkRemainingArray && chunkRemainingArray.length > 0) {
                             done();
                             return;
                         }
-                        const changedFiles = projectEventsController.changedFilesMap.get(projectID);
                         const project: projectsController.BuildQueueType = {
                             operation: operation,
                             handler: projectHandler
                         };
-                        await projectsController.addProjectToBuildQueue(project, changedFiles);
+                        // for update operation
+                        await projectsController.addProjectToBuildQueue(project);
                         projectEventsController.changedFilesMap.delete(projectID);
                         clearInterval(intervaltimer);
                         done();
@@ -233,9 +233,9 @@ export const build = async function (args: IProjectActionParams): Promise<{ oper
     if (!statusController.isBuildInProgressOrQueued(args.projectID)) {
         await statusController.updateProjectStatus(statusController.STATE_TYPES.buildState, args.projectID, statusController.BuildState.inProgress, "action.calculateDifference");
         const operation = new Operation("update", projectInfo);
-        const intervaltimer = setInterval(async () => {
+        const intervaltimer = setInterval(() => {
             // wait till no expected incoming chunks in order to get a full fileChanged array
-            await lock.acquire(["chunkRemainingLock", "changedFilesLock"], async done => {
+            lock.acquire(["chunkRemainingLock", "changedFilesLock"], async done => {
                 const chunkRemainingArray = projectEventsController.chunkRemainingMap.get(args.projectID);
                 if (chunkRemainingArray && chunkRemainingArray.length > 0) {
                     done();
@@ -243,12 +243,12 @@ export const build = async function (args: IProjectActionParams): Promise<{ oper
                 }
                 const projectHandler = await projectExtensions.getProjectHandler(projectInfo);
                 projectInfo.forceAction = "REBUILD";
-                const changedFiles = projectEventsController.changedFilesMap.get(args.projectID);
                 const project: projectsController.BuildQueueType = {
                     operation: operation,
                     handler: projectHandler
                 };
-                await projectsController.addProjectToBuildQueue(project, changedFiles);
+                // for update operation
+                await projectsController.addProjectToBuildQueue(project);
                 statusController.buildRequired(args.projectID, false);
                 // delete cache from the map, since a build is triggerred
                 projectEventsController.changedFilesMap.delete(args.projectID);

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -26,8 +26,8 @@ import * as locale from "../utils/locale";
 import * as logger from "../utils/logger";
 import * as logHelper from "./logHelper";
 import * as kubeutil from "../utils/kubeutil";
-import * as projectEventsController from "../controllers/projectEventsController";
 import { ProcessResult } from "../utils/processManager";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 
 const readFileAsync = promisify(fs.readFile);
@@ -111,11 +111,11 @@ export function create(operation: Operation): void {
  * @description Update operation for a liberty project.
  *
  * @param operation <Required | Operation> - The update operation.
- * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+ * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
  *
  * @returns void
  */
-export function update(operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void {
+export function update(operation: Operation, changedFiles?: IFileChangeEvent[]): void {
     projectUtil.containerUpdate(operation, "/file-watcher/scripts/liberty-container.sh", "update");
 }
 

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -20,7 +20,7 @@ import { ContainerStates } from "./constants";
 import { ProjectCapabilities, defaultProjectCapabilities } from  "./Project";
 import { StartModes, ControlCommands } from "./constants";
 import * as logHelper from "./logHelper";
-import * as projectEventsController from "../controllers/projectEventsController";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 export const requiredFiles = [ "/Dockerfile", "/package.json"];
 const capabilities = new ProjectCapabilities([StartModes.run, StartModes.debugNoInit], [ControlCommands.restart]);
@@ -84,11 +84,11 @@ export function create(operation: Operation): void {
  * @description Update operation for a nodejs project.
  *
  * @param operation <Required | Operation> - The update operation.
- * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+ * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
  *
  * @returns void
  */
-export function update(operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void {
+export function update(operation: Operation, changedFiles?: IFileChangeEvent[]): void {
     projectUtil.containerUpdate(operation, "/file-watcher/scripts/nodejs-container.sh", "update");
 }
 

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -23,7 +23,7 @@ import { StartModes, ControlCommands } from "./constants";
 import * as locale from "../utils/locale";
 import * as logger from "../utils/logger";
 import * as logHelper from "./logHelper";
-import * as projectEventsController from "../controllers/projectEventsController";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 const readFileAsync = promisify(fs.readFile);
 
@@ -92,11 +92,11 @@ export function create(operation: Operation): void {
  * @description Update operation for a spring project.
  *
  * @param operation <Required | Operation> - The update operation.
- * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+ * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
  *
  * @returns void
  */
-export function update(operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void {
+export function update(operation: Operation, changedFiles?: IFileChangeEvent[]): void {
     projectUtil.containerUpdate(operation, "/file-watcher/scripts/spring-container.sh", "update");
 }
 

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -16,7 +16,7 @@ import { Operation } from "./operation";
 import { ProjectInfo, BuildLog, AppLog } from "./Project";
 import * as path from "path";
 import * as logHelper from "./logHelper";
-import * as projectEventsController from "../controllers/projectEventsController";
+import { IFileChangeEvent } from "../utils/fileChanges";
 
 export const requiredFiles = [ "/Dockerfile", "/Dockerfile-tools", "/Package.swift" ];
 
@@ -84,11 +84,11 @@ export function create(operation: Operation): void {
  * @description Update operation for a swift project.
  *
  * @param operation <Required | Operation> - The update operation.
- * @param changedFiles <Optional | projectEventsController.IFileChangeEvent[]> - The file changed event array.
+ * @param changedFiles <Optional | IFileChangeEvent[]> - The file changed event array.
  *
  * @returns void
  */
-export function update(operation: Operation, changedFiles?: projectEventsController.IFileChangeEvent[]): void {
+export function update(operation: Operation, changedFiles?: IFileChangeEvent[]): void {
     projectUtil.containerUpdate(operation, "/file-watcher/scripts/swift-container.sh", "update");
 }
 

--- a/src/pfe/file-watcher/server/src/utils/fileChanges.ts
+++ b/src/pfe/file-watcher/server/src/utils/fileChanges.ts
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+export const changedFilesMap: Map<string, IFileChangeEvent[]> = new Map<string, IFileChangeEvent[]>();
+
+export interface IFileChangeEvent {
+    path: string;
+    timestamp: number;
+    type: string;
+    directory: boolean;
+    content?: string;
+}

--- a/src/pfe/file-watcher/server/test/functional-test/lib/project.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/lib/project.ts
@@ -12,6 +12,7 @@ import * as project from "../../../src/projects/Project";
 import * as projectsController from "../../../src/controllers/projectsController";
 import * as projectStatusController from "../../../src/controllers/projectStatusController";
 import * as projectEventsController from "../../../src/controllers/projectEventsController";
+import { IFileChangeEvent } from "../../../src/utils/fileChanges";
 
 import * as dockerUtil from "../../../src/utils/dockerutil";
 import * as kubeUtil from "../../../src/utils/kubeutil";
@@ -65,6 +66,6 @@ export async function checkNewLogFile(projectID: string, type: string): Promise<
   return await filewatcher.checkNewLogFile(projectID, type);
 }
 
-export async function updateProjectForNewChange(projectID: string, timestamp: number,  chunkNum: number, chunk_total: number, eventArray: projectEventsController.IFileChangeEvent[]): Promise<projectEventsController.IUpdateProjectSuccess | projectEventsController.IUpdateProjectFailure> {
+export async function updateProjectForNewChange(projectID: string, timestamp: number,  chunkNum: number, chunk_total: number, eventArray: IFileChangeEvent[]): Promise<projectEventsController.IUpdateProjectSuccess | projectEventsController.IUpdateProjectFailure> {
   return await filewatcher.updateProjectForNewChange(projectID, timestamp, chunkNum, chunk_total, eventArray);
 }


### PR DESCRIPTION
### Description

Before we only allowed queuing of builds on turbine restart or project creation scenarios. This PR enhances the build queue by also applying to update scenario. Similar to the create case, update now also runs MAX_BUILDS (i.e 3 builds) concurrently while putting the rest of the projects in the queue.

The screenshot below depicts build queue updating queue ranks as projects are rebuilt
<img width="1017" alt="Screen Shot 2019-12-31 at 12 57 33 PM" src="https://user-images.githubusercontent.com/15173354/71629740-1e9b3680-2bcd-11ea-9c2f-aa281ee5977c.png">


Closes https://github.com/eclipse/codewind/issues/1563