### PR TITLE
Return error response if project unbind fails

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -503,6 +503,8 @@ paths:
             description: if the project with id was not found
           409:
             description: if unbind was already in progress
+          500:
+            description: internal error, includes an error message string if available
 
   /api/v1/projects/{id}/compare:
     get:

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -490,6 +490,7 @@ router.post('/api/v1/projects/:id/unbind', validateReq, async function (req, res
     }
     user.uiSocket.emit('projectDeletion', data);
     log.error(`Error deleting project: ${util.inspect(data)}`);
+    res.status(500).send(data.error);
   }
 });
 


### PR DESCRIPTION
##Problem: 

If project unbind fails Portal fails to return a reason or status code.  As reported in issue #1054

## Solution

Returns HTTPError 500 and an error message

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>