### PR TITLE
fix: populate app monitor summary http request hit count

### DIFF
--- a/src/performance/monitor/public/scripts/manageMetricsDash.js
+++ b/src/performance/monitor/public/scripts/manageMetricsDash.js
@@ -154,7 +154,7 @@ function updateGraphs(metrics) {
       aggregateDataAboutHttpsRequestsSentDuringSnapshot.url = metricsObj.labels.url;
       aggregateDataAboutHttpsRequestsSentDuringSnapshot.longest = metricsObj.value;
 
-    } else if (metric.name.includes('alltime')) {
+    } else if (metric.name.includes('alltime') || metric.name === 'http_requests_total') {
       for (const metricsObj of metric.metrics) {
         const { handler, method } = metricsObj.labels;
         const endpoint = `${method.toUpperCase()} ${handler}`;
@@ -164,7 +164,7 @@ function updateGraphs(metrics) {
           };
         }
         const alltimeData = alltimeDataAboutHttpRequests[endpoint];
-        if (metric.name === 'http_requests_alltime_total') {
+        if (metric.name === 'http_requests_total') {
           alltimeData.hits = metricsObj.value;
         } else if (metric.name === 'http_requests_alltime_duration_average_microseconds') {
           alltimeData.averageResponseTime = metricsObj.value;


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Previously, the app monitor page hosted on our performance container was missing the http request count of 'Total Hits', e.g.:
![image](https://user-images.githubusercontent.com/18170169/71833728-7d692000-30a5-11ea-8f87-653da049cd48.png)

This populates that field correctly