### PR TITLE
Return an error response if project bind start or end fails

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -116,7 +116,11 @@ async function bindStart(req, res) {
     if (err.code === 'INVALID_PROJECT_NAME'){
       res.status(400).send(err.info);
     } else {
-      res.sendStatus(500);
+      let errorMessage = ""
+      if (err) {
+        errorMessage = err.info || err
+      }
+      res.status(500).send(`Project bind failed ${errorMessage}`);
     }
     log.error(err);
     return;
@@ -450,8 +454,8 @@ async function bindEnd(req, res) {
       status: 'failed',
       error: err.info || err
     }
-    res.status(500);
     user.uiSocket.emit('projectBind', data);
+    res.status(500).send(data.error);
   }
 }
 


### PR DESCRIPTION
## Problem 

If Project Bind Start or End fails portal will return an HTTP 500 response but without any meaningful data. As reported in issue : #1055 

## Solution

Continue to set the HTTP status code to 500 but in addition include an error in the body making these two functions consistent with the other project bind routes. 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>