### PR TITLE
Bump eslint from 3.9.1 to 6.8.0 in /src/pfe/portal/eslint-rules

### DIFF
--- a/src/pfe/portal/eslint-rules/package.json
+++ b/src/pfe/portal/eslint-rules/package.json
@@ -16,7 +16,7 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
-    "eslint": "~3.9.1",
+    "eslint": "~6.8.0",
     "mocha": "^3.1.2"
   },
   "engines": {


### PR DESCRIPTION
This is a copy of https://github.com/eclipse/codewind/pull/1650 - we can't commit that directly as dependabot hasn't signed the ECA.