### PR TITLE
Run eslint and unit tests before Docker build in Jenkins, remove directory traversal

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     }
 
     stages {
-        stage('Run Portal eslint and Unit Test Suite') {
+        stage('Run Portal eslint and unit tests') {
             options {
                 timeout(time: 30, unit: 'MINUTES') 
             }
@@ -77,7 +77,7 @@ pipeline {
             }
         }
 
-        stage('Run Turbine Unit Test Suite') {
+        stage('Run Turbine unit test suite') {
             options {
                 timeout(time: 30, unit: 'MINUTES') 
             }
@@ -303,7 +303,6 @@ pipeline {
                     sh '''#!/usr/bin/env bash
                         echo "Publishing docker images for Eclipse Codewind ..."
                         echo "Branch name is $GIT_BRANCH"
-                        echo "change"
 
                         if [[ $GIT_BRANCH == "master" ]]; then
                             TAG="latest"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                         nvm i 10
                         
                         # Run eslint on portal code
-                        cd src/pfe/portal
+                        cd $DIR/src/pfe/portal
                         npm install
                         if [ $? -ne 0 ]; then
                             exit 1
@@ -48,7 +48,7 @@ pipeline {
                         cd $DIR
 
                         # Run eslint on portal tests
-                        cd test
+                        cd $DIR/test
                         npm install
                         if [ $? -ne 0 ]; then
                             exit 1
@@ -85,6 +85,7 @@ pipeline {
                 withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]) {
                     withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
                         sh '''#!/usr/bin/env bash
+                        DIR=`pwd`;
                         echo "Starting unit tests for Turbine..."
                         export PATH=$PATH:/home/jenkins/.jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/node_js/bin/
                         
@@ -98,7 +99,7 @@ pipeline {
                         nvm i 10
                         
                         # Run eslint on turbine code
-                        cd src/pfe/file-watcher/server
+                        cd $DIR/src/pfe/file-watcher/server
                         npm install
                         
                         if [ $? -ne 0 ]; then
@@ -243,14 +244,14 @@ pipeline {
 
                         # Create codewind-workspace if it does not exist
                         printf "\n\nCreating codewind-workspace\n"
-                        mkdir -m 777 -p codewind-workspace
+                        mkdir -m 777 -p $DIR/codewind-workspace
 
                         # Save Docker image ID of PFE to ensure we're not using the image from Dockerhub
                         BUILT_PFE_IMAGE_ID=$(docker images --filter=reference=eclipse/codewind-pfe-amd64:latest --format "{{.ID}}")
                         echo "PFE Image: $BUILT_PFE_IMAGE_ID"
 
                         # Start Codewind
-                        sh ./start.sh
+                        sh $DIR/start.sh
                         if [ $? -ne 0 ]; then
                             echo "Error starting Codewind"
                             exit 1
@@ -271,7 +272,7 @@ pipeline {
                         fi
 
                         # Run the API tests now Portal has started
-                        cd test/
+                        cd $DIR/test/
                         npm install 
                         if [ $? -ne 0 ]; then
                             exit 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,6 @@ pipeline {
                             exit 1
                         fi
 
-                        cd $DIR
-
                         # Run eslint on portal tests
                         cd $DIR/test
                         npm install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,111 @@ pipeline {
     }
 
     stages {
+        stage('Run Portal eslint and Unit Test Suite') {
+            options {
+                timeout(time: 30, unit: 'MINUTES') 
+            }
+            steps {
+                withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]) {
+                    sh '''#!/usr/bin/env bash
+                        DIR=`pwd`;
+
+                        echo "Starting unit tests for Portal..."
+                        export PATH=$PATH:/home/jenkins/.jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/node_js/bin/
+
+                        # Install nvm to easily set version of node to use
+                        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+                        export NVM_DIR="$HOME/.nvm" 
+                        . $NVM_DIR/nvm.sh
+                        nvm i 10
+                        
+                        # Run eslint on portal code
+                        cd src/pfe/portal
+                        npm install
+                        if [ $? -ne 0 ]; then
+                            exit 1
+                        fi
+
+                        npm run eslint
+                        if [ $? -ne 0 ]; then
+                            exit 1
+                        fi
+
+                        cd $DIR
+
+                        # Run eslint on portal tests
+                        cd test
+                        npm install
+                        if [ $? -ne 0 ]; then
+                            exit 1
+                        fi
+
+                        npm run eslint
+                        if [ $? -ne 0 ]; then
+                            exit 1
+                        fi
+                            
+                        # Run the unit test suite
+                        echo "Portal unit tests"
+
+                        # Copy the docs into the portal directory
+                        cp -r $DIR/docs $DIR/src/pfe/portal/
+
+                        npm run unittest
+                        if [ $? -eq 0 ]; then
+                            echo "+++   PORTAL UNIT TESTS COMPLETED SUCCESSFULLY   +++";
+                        else
+                            echo "+++   PORTAL UNIT TESTS FAILED   +++";
+                            exit 1;
+                        fi
+                        '''
+                }
+            }
+        }
+
+        stage('Run Turbine Unit Test Suite') {
+            options {
+                timeout(time: 30, unit: 'MINUTES') 
+            }
+            steps {
+                withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]) {
+                    withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
+                        sh '''#!/usr/bin/env bash
+                        echo "Starting unit tests for Turbine..."
+                        export PATH=$PATH:/home/jenkins/.jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/node_js/bin/
+                        
+                        ARCH=`uname -m`;
+                        printf "\n\n${MAGENTA}Platform: $ARCH ${RESET}\n"
+
+                        # Install nvm to easily set version of node to use
+                        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+                        export NVM_DIR="$HOME/.nvm" 
+                        . $NVM_DIR/nvm.sh
+                        nvm i 10
+                        
+                        # Run eslint on turbine code
+                        cd src/pfe/file-watcher/server
+                        npm install
+                        
+                        if [ $? -ne 0 ]; then
+                            exit 1
+                        fi
+                            
+                        # Run the unit test suite
+                        echo "Started running Turbine Unit Test Suite"
+                        npm run unit:test
+                        if [ $? -eq 0 ]; then
+                            echo "+++   TURBINE UNIT TESTS COMPLETED SUCCESSFULLY   +++";
+                        else
+                            echo "+++   TURBINE UNIT TESTS FAILED   +++";
+                            exit 1;
+                        fi
+                        '''
+                    }
+                }
+            }
+        }
+
         stage('Build Docker images') {
             steps {
                 withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
@@ -105,51 +210,8 @@ pipeline {
                 }
             }
         }
-
-        stage('Run Turbine Unit Test Suite') {
-            options {
-                timeout(time: 30, unit: 'MINUTES') 
-            }
-            steps {
-                withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]) {
-                    withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
-                        sh '''#!/usr/bin/env bash
-                        echo "Starting unit tests for Turbine..."
-                        export PATH=$PATH:/home/jenkins/.jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/node_js/bin/
-                        
-                        ARCH=`uname -m`;
-                        printf "\n\n${MAGENTA}Platform: $ARCH ${RESET}\n"
-
-                        # Install nvm to easily set version of node to use
-                        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
-                        export NVM_DIR="$HOME/.nvm" 
-                        . $NVM_DIR/nvm.sh
-                        nvm i 10
-                        
-                        # Run eslint on turbine code
-                        cd src/pfe/file-watcher/server
-                        npm install
-                        
-                        if [ $? -ne 0 ]; then
-                            exit 1
-                        fi
-                            
-                        # Run the unit test suite
-                        echo "Started running Turbine Unit Test Suite"
-                        npm run unit:test
-                        if [ $? -eq 0 ]; then
-                            echo "+++   TURBINE UNIT TESTS COMPLETED SUCCESSFULLY   +++";
-                        else
-                            echo "+++   TURBINE UNIT TESTS FAILED   +++";
-                            exit 1;
-                        fi
-                        '''
-                    }
-                }
-            }
-        }
         
-        stage('Run Codewind test suite') {  
+        stage('Start Codewind and run the API tests') {  
             options {
                 timeout(time: 2, unit: 'HOURS') 
             }   
@@ -178,34 +240,6 @@ pipeline {
                             exit 1
                         fi
                         chmod +x $HOME/dc/docker-compose
-
-                        # Run eslint on portal code
-                        cd src/pfe/portal
-                        npm install
-                        npm run eslint
-                        if [ $? -ne 0 ]; then
-                            exit 1
-                        fi
-                        cd $DIR
-
-                        # Build and eslint the portal tests
-                        cd test/
-                        npm install
-                        if [ $? -ne 0 ]; then
-                            exit 1
-                        fi
-
-                        npm run eslint
-                        if [ $? -ne 0 ]; then
-                            exit 1
-                        fi
-
-                        # Run the portal unit tests
-                        npm run unittest
-                        if [ $? -ne 0 ]; then
-                            exit 1
-                        fi
-                        cd ..
 
                         # Create codewind-workspace if it does not exist
                         printf "\n\nCreating codewind-workspace\n"
@@ -238,6 +272,11 @@ pipeline {
 
                         # Run the API tests now Portal has started
                         cd test/
+                        npm install 
+                        if [ $? -ne 0 ]; then
+                            exit 1
+                        fi
+
                         npm run apitest
                         if [ $? -ne 0 ]; then
                             exit 1
@@ -264,6 +303,7 @@ pipeline {
                     sh '''#!/usr/bin/env bash
                         echo "Publishing docker images for Eclipse Codewind ..."
                         echo "Branch name is $GIT_BRANCH"
+                        echo "change"
 
                         if [[ $GIT_BRANCH == "master" ]]; then
                             TAG="latest"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,6 +163,7 @@ pipeline {
                         export PATH=$PATH:$HOME/dc/
                         ARCH=`uname -m`;
                         printf "\n\n${MAGENTA}Platform: $ARCH ${RESET}\n"
+                        DIR=`pwd`;
 
                         # Install nvm to easily set version of node to use
                         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
@@ -185,7 +186,7 @@ pipeline {
                         if [ $? -ne 0 ]; then
                             exit 1
                         fi
-                        cd ../../..
+                        cd $DIR
 
                         # Build and eslint the portal tests
                         cd test/


### PR DESCRIPTION
Save the base directory to ensure we can return to it in the Jenkinsfile.