### PR TITLE
Revert "Return error response if project unbind fails"

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -503,8 +503,6 @@ paths:
             description: if the project with id was not found
           409:
             description: if unbind was already in progress
-          500:
-            description: internal error, includes an error message string if available
 
   /api/v1/projects/{id}/compare:
     get:

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -485,7 +485,6 @@ router.post('/api/v1/projects/:id/unbind', validateReq, async function (req, res
     }
     user.uiSocket.emit('projectDeletion', data);
     log.error(`Error deleting project: ${util.inspect(data)}`);
-    res.status(500).send(data.error);
   }
 });
 


### PR DESCRIPTION
Reverts eclipse/codewind#1630 since a response may have already been dispatched. If an error occurs after the response is sent it would be too late to send back anything other than the socket message.