### PR TITLE
0.8.0: remove uuid format for template repo id

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1634,7 +1634,6 @@ components:
       properties:
         id:
           type: string
-          format: uuid
         url:
           type: string
         name:


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Fixes https://github.com/eclipse/codewind/issues/1678