### PR TITLE
Add custom timeout to Template API tests which do not currently have it

### DIFF
--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -167,6 +167,7 @@ describe('Template API tests', function() {
 
     describe('DELETE /api/v1/templates/repositories', function() {
         it('DELETE should try to remove a template repository that doesn\'t exist', async function() {
+            this.timeout(testTimeout.short);
             const res = await deleteTemplateRepo('http://something.com/index.json');            
             res.should.have.status(404);
         });
@@ -189,6 +190,7 @@ describe('Template API tests', function() {
             
         });
         it('DELETE /api/v1/templates should remove a template repository', async function() {
+            this.timeout(testTimeout.short);
             const res = await deleteTemplateRepo(repo.url);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(repo);
@@ -285,6 +287,7 @@ describe('Template API tests', function() {
         saveReposBeforeEachTestAndRestoreAfterEach();
         for (const [testName, test] of Object.entries(tests)) {
             it(`should ${testName} and return 207 and the expected operations info`, async function() {
+                this.timeout(testTimeout.short);
                 const res = await batchPatchTemplateRepos(test.input);
                 res.should.have.status(207).and.satisfyApiSpec;
                 res.body.should.deep.equal(test.output);


### PR DESCRIPTION
### Summary
* Added a larger timeout to the Template API tests in Portal as it was missing from some tests (same timeout as other template tests).
* This should reduce the flakey test failures.
Such as:
```
2 failing
09:24:02  
09:24:02    1) Template API tests
09:24:02         DELETE | GET | POST /api/v1/templates/repositories
09:24:02           DELETE /api/v1/templates should remove a template repository:
09:24:02       Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/genie.codewind/jenkins-agent/workspace/Codewind_codewind_PR-1663/test/src/API/templates/templates.test.js)
09:24:02    
09:24:02  
```

### Testing
Jenkins tests passing.

Signed-off-by: James Wallis <james.wallis1@ibm.com>