### PR TITLE
translate NLS key before send out to listener

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -456,7 +456,7 @@ function pingInTransitApplications(): void {
     appStateMap.forEach((stateObj, projectID) => {
         const currentState = stateObj.state;
         if (currentState === AppState.starting || currentState === AppState.stopping) {
-            projectUtil.isContainerActive(projectID, (containerStatus: any) => {
+            projectUtil.isContainerActive(projectID, async (containerStatus: any) => {
                 if (containerStatus.hasOwnProperty("state")) {
                     if (containerStatus.state === ContainerStates.containerActive) {
                         // The container is running so try pinging the application
@@ -565,6 +565,7 @@ function pingInTransitApplications(): void {
                                     notify: true
                                 };
                                 appStateMap.set(projectID, new ProjectState(AppState.stopped, data.appErrorStatus, undefined, undefined, undefined, data.detailedAppStatus));
+                                data.detailedAppStatus.message =  await locale.getTranslation(data.detailedAppStatus.message);
                             } else {
                                 appStateMap.set(projectID, new ProjectState(AppState.stopped, undefined));
                             }


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is to fix issue: https://github.com/eclipse/codewind/issues/1697

The NLS key need to be translated before send out to listener. 