### PR TITLE
Cache template repositories and templates at startup.

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -108,7 +108,7 @@ module.exports = class User {
       await this.templates.initializeRepositoryList();
       log.info(`Initialising template list`);
       await this.templates.getTemplates(false);
-      log.info(`Default templates cached.`);
+      log.info(`Default templates cached`);
 
       // Connect up the UI Socket Authentication handler
       if (process.env.CODEWIND_AUTH_HOST) {

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -84,7 +84,6 @@ module.exports = class User {
       await this.initialiseExistingProjects();
 
       this.templates = new Templates(this.workspace);
-      await this.templates.initializeRepositoryList();
 
       // Create the list of codewind extensions
       this.extensionList = new ExtensionList();
@@ -101,6 +100,15 @@ module.exports = class User {
       } catch (error) {
         log.error(`Codewind extensions failed to load. Error ${util.inspect(error)}`);
       }
+
+      // Initialise the list after we have created extensions as they may
+      // add template repositories. The log messages allow us to confirm
+      // how long this takes.
+      log.info(`Initialising template repository list`);
+      await this.templates.initializeRepositoryList();
+      log.info(`Initialising template list`);
+      await this.templates.getTemplates(false);
+      log.info(`Default templates cached.`);
 
       // Connect up the UI Socket Authentication handler
       if (process.env.CODEWIND_AUTH_HOST) {

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -23,7 +23,8 @@ const log = new Logger(__filename);
  */
 router.get('/api/v1/templates', validateReq, async (req, res, _next) => {
   const { templates: templateController } = req.cw_user;
-  const { showEnabledOnly, projectStyle } = req.query;
+  const projectStyle = req.query['projectStyle'];
+  const showEnabledOnly = req.query['showEnabledOnly'] === 'true';
   try {
     const templates = (projectStyle) 
       ? await templateController.getTemplatesByStyle(projectStyle, showEnabledOnly)


### PR DESCRIPTION
This PR fixes the caching of template repositories at start up. Previously we were doing it when the user object was created but before we loaded extensions which then invalidated the cached repository.
The caching has been moved after the extensions are loaded, we also now cache the list of templates from those repositories.

This should improve performance for https://github.com/eclipse/codewind/issues/1491 as the slowness will be moved to startup. We don't add the routes to access the REST API until after the User object that populates the cache on initialisation is ready so the repositories and templates can't be queried before we have cached them. (There may still be a delay if the list of repositories is changed.)

Additionally there was a bug where the flag to getTemplates to say whether to show enabled or disabled templates was only honoured if we didn't have a cached list of templates. If a list was cached we always returned the list that was generated on the first call, even if the value of the flag was different. This PR fixes that and adds test cases to verify that the flag is honoured.
