### PR TITLE
add new event to indicate the project data is ready

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -354,6 +354,10 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
     try {
         // Save project metadata
         await saveProjectInfo(projectID, projectInfo);
+        const data = {
+            projectID: projectID
+        };
+        io.emitOnListener("projectCapabilitiesReady", data);
     } catch (err) {
         logger.logProjectError(JSON.stringify(err), projectID);
     }

--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -218,6 +218,13 @@ export default class Filewatcher {
      * }
      * ```
      *
+     * @example projectCapabilitiesReady
+     * ```json
+     * {
+     *     "projectID": "271c8f40-7721-11e9-81ae-6f8cd0194e7c"
+     * }
+     * ```
+     *
      */
     registerListener: (listener: socket.FWEventHandler) => void ;
 


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for issue: https://github.com/eclipse/codewind/issues/1073

Introduced a new event `projectCapabilitiesReady`, indicate the projectInfo is ready to read/write 
sent out through listener after the projectInfo has been saved into file. 

```
 message: projectCapabilitiesReady
 data: {
  "projectID": "98f58470-20e8-11ea-8829-0bf2e574be7f"
}
```