### PR TITLE
Copy docs directory before each test 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,9 +60,6 @@ pipeline {
                         # Run the unit test suite
                         echo "Portal unit tests"
 
-                        # Copy the docs into the portal directory
-                        cp -r $DIR/docs $DIR/src/pfe/portal/
-
                         npm run unittest
                         if [ $? -eq 0 ]; then
                             echo "+++   PORTAL UNIT TESTS COMPLETED SUCCESSFULLY   +++";

--- a/test/scripts/mocha.sh
+++ b/test/scripts/mocha.sh
@@ -16,6 +16,13 @@
 
 start=$(date +%F_%T)
 echo "Tests started at ${start}"
+
+cp -r ../docs ../src/pfe/portal/docs
+if [ $? != 0 ]; then
+    echo "Error copying docs directory to Portal directory (openapi.yaml)"
+    exit 1;
+fi
+
 node_modules/.bin/nyc node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
 rc=$?
 end=$(date +%F_%T)


### PR DESCRIPTION
Fix for https://github.com/eclipse/codewind/issues/1673
### Summary 
* Copy the `docs` directory into the `src/pfe/portal` directory before each test run.
  * Fixes it not existing when the repository is cloned.
  * Ensures the most up to date one is used in every test run.
* Remove line in Jenkinsfile which copys the directory - redundant with this change.
  * I can't test this but I cannot see why it would fail if this change works.

### Testing
* Deleted `docs` directory from `pfe/portal` directory and successfully ran the unit tests.