### PR TITLE
Use an object for ports rather than an empty string

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1539,8 +1539,17 @@ components:
           type: integer
           example: localhost
         ports:
-          type: integer
-          example: 31234
+          type: object
+          properties:
+            exposedPort:
+              type: string
+              example: "32801"
+            internalPort:
+              type: string
+              example: "3000"
+            internalDebugPort:
+              type: string
+              example: "9229"
     ProjectID:
       type: string
       format: uuid

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -80,7 +80,7 @@ module.exports = class Project {
     
     // Project status information
     this.host = args.host || '';
-    this.ports = args.port || '';
+    this.ports = args.ports || {};
 
     // workspace is the parent directory of the project
     // NOT the global.codewind.CODEWIND_WORKSPACE we store


### PR DESCRIPTION
Fixes a bug where the CLI won't be able to read the ports field in a Project without some Golang trickery as we don't give the ports field a specific type.
Makes it easier to keep the Ports object inline with the API docs by using a single type.

### Summary
* Use an empty object for the ports field in Project.js rather than an empty String.
* Initialise `this.ports` from `args.ports` rather than `args.port` which I don't think will ever exist.
* Update API spec (openapi.yaml) to reflect that the ports field will be an object (not an integer or string).

### Testing
* Ran tests + ran Codewind.

Signed-off-by: James Wallis <james.wallis1@ibm.com>