### PR TITLE
Read logging level from env var so it can be set during container start.

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -165,6 +165,7 @@ EXPOSE 9090
 
 # Moved the FORCE_COLOR env var for colored logs from root-watcher.sh to the Dockerfile
 ENV FORCE_COLOR=1
+ENV LOG_LEVEL=info
 
 # USER mcuser
 # TODO, work out how to start everything.

--- a/src/pfe/portal/modules/utils/Logger.js
+++ b/src/pfe/portal/modules/utils/Logger.js
@@ -14,7 +14,7 @@ const util = require('util');
 const LoggingError = require('./errors/LoggingError');
 
 const validLevels = ['error', 'warn', 'info', 'debug', 'trace'];
-const loggingLevel = 'info'; // Should be 'info' for production code.
+const loggingLevel = process.env.LOG_LEVEL || 'info'; // Should be 'info' for production code.
 const contextName = 'context';
 const config = {
   appenders: {


### PR DESCRIPTION
This PR lets us read the logging level from an env var.
This makes it possible to set the logging level at container start time.
e.g.
```
docker run -e LOG_LEVEL=info eclipse/codewind-pfe-amd64:latest
```
This should be enough to make it possible to set the log level in kube based deployments by editing the env vars for the deployment and causing the pod to restart but I will also add a flag to the installer so the log level can be set at start time when running in desktop mode.

This is for https://github.com/eclipse/codewind/issues/729