### PR TITLE
forward the new event to ui

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -167,6 +167,11 @@ module.exports = class FileWatcher {
           break;
         }
 
+        case "projectCapabilitiesReady" : {
+          await this.handleFWProjectEvent('projectCapabilitiesReady', fwProject);
+          break;
+        }
+
         default: {
           log.debug("Unknown event received: " + event);
           log.debug("Detailed message received from file-watcher module: " + JSON.stringify(fwProject));


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for issue https://github.com/eclipse/codewind/issues/1073

Portal needs to forward the new Turbine event to ui. 