### PR TITLE
Prevent collision of ingresses

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -425,7 +425,7 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
                         const servicePort = parseInt(containerInfo.internalPort, 10);
 
                         // Expose an ingress for the project
-                        const baseURL = await kubeutil.exposeOverIngress(projectID, operation.projectInfo.isHttps, servicePort);
+                        const baseURL = await kubeutil.exposeOverIngress(projectID, projectName, operation.projectInfo.isHttps, servicePort);
 
                         // Set the appBaseURL to the ingress we exposed earlier
                         projectInfo.appBaseURL = baseURL;
@@ -1857,7 +1857,7 @@ async function getPODInfoAndSendToPortal(operation: Operation, event: string = "
     const projectInfo = operation.projectInfo;
     const projectLocation = projectInfo.location;
     const projectID = projectInfo.projectID;
-    const projectName = projectInfo.projectName;
+    const projectName = projectLocation.split("/").pop();
     const keyValuePair: UpdateProjectInfoPair = {
         key: "buildRequest",
         value: false
@@ -1916,7 +1916,7 @@ async function getPODInfoAndSendToPortal(operation: Operation, event: string = "
 
         // Expose an ingress for the project
         const servicePort = parseInt(containerInfo.internalPort, 10);
-        const baseURL = await kubeutil.exposeOverIngress(projectID, operation.projectInfo.isHttps, servicePort);
+        const baseURL = await kubeutil.exposeOverIngress(projectID, projectName, operation.projectInfo.isHttps, servicePort);
 
         // Set the appBaseURL to the ingress URL of the project
         const updatedProjectInfo: ProjectInfo = operation.projectInfo;

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -425,14 +425,14 @@ export async function exposeOverIngress(projectID: string, projectName: string, 
 
     // Calculate the ingress domain
     // Thanks to Kubernetes and Ingress, some ingress controllers impose a character limitation on the host name, so:
-    // If the ingress domain prefix is < 62 characters, trim the resultant app's ingress domain to fit within the limit
-    // If the ingress domain prefix is >= 62 characters, don't trim, as the character limit likely doesn't apply here.
+    // If the ingress domain prefix is <= 62 characters and the resultant project ingress is over 62, trim
+    // Otherwise, don't trim the ingress.
     const ingressDomain = process.env.INGRESS_PREFIX;
     const ingressDomainLength = ingressDomain.length;
 
-    let projectIngressURL: string;
-    if (ingressDomainLength < 62) {
-        // Since we include a dash, calculate the difference between 62 chars and the prefix
+    let projectIngressURL = projectName + "-" + ingressDomain;
+    if (ingressDomainLength <= 62 && projectIngressURL.length > 62) {
+        // Calculate how many characters we can keep
         const spaceRemaining = 62 - ingressDomainLength;
 
         // Generate four random alphanumeric characters and add it to the front of the project name to ensure uniqueness
@@ -440,8 +440,6 @@ export async function exposeOverIngress(projectID: string, projectName: string, 
 
         // Trim the project's ingress to fit within the limit
         projectIngressURL = projectIngress.substring(0, spaceRemaining) + "-" + ingressDomain;
-    } else {
-        projectIngressURL = projectName + "-" + ingressDomain;
     }
 
     logger.logProjectInfo("*** Ingress: " + projectIngressURL, projectID);

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -425,18 +425,18 @@ export async function exposeOverIngress(projectID: string, projectName: string, 
 
     // Calculate the ingress domain
     // Thanks to Kubernetes and Ingress, some ingress controllers impose a character limitation on the host name, so:
-    // If the ingress domain prefix is <= 62 characters and the resultant project ingress is over 62, trim
+    // If the ingress domain prefix is < 62 characters and the resultant project ingress >= 62, trim
     // Otherwise, don't trim the ingress.
     const ingressDomain = process.env.INGRESS_PREFIX;
     const ingressDomainLength = ingressDomain.length;
 
-    let projectIngressURL = projectName + "-" + ingressDomain;
-    if (ingressDomainLength <= 62 && projectIngressURL.length > 62) {
+    // Generate four random alphanumeric characters and add it to the front of the project name to ensure uniqueness
+    const projectIngress = Math.random().toString(36).substring(2, 6) + "-" + projectName;
+
+    let projectIngressURL = projectIngress + "-" + ingressDomain;
+    if (ingressDomainLength < 62 && projectIngressURL.length >= 62) {
         // Calculate how many characters we can keep
         const spaceRemaining = 62 - ingressDomainLength;
-
-        // Generate four random alphanumeric characters and add it to the front of the project name to ensure uniqueness
-        const projectIngress = Math.random().toString(36).substring(2, 6) + projectName;
 
         // Trim the project's ingress to fit within the limit
         projectIngressURL = projectIngress.substring(0, spaceRemaining) + "-" + ingressDomain;


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1522

This PR updates the ingress creation logic to prevent collisions from occurring when the ingress needs to be trimmed due to character limits:
- New ingress URL format for projects: `<4-random-alphanumeric-characters>-<projectname>-<ingressdomain>` 
- We now trim the ingress if: the ingress domain is < 62 characters **and** the resultant project ingress is over that limit
     - This is a slight change as was proposed in earlier meetings (append random characters to the end of the project name, and trim right to left). 
     - This is because we allow non-alphanumeric characters in our project names and ingress URLs **must** start with an alphanumeric character
     
Since we're using the project name in the ingress, I noticed that the `projectName` variable for generic docker projects was `undefined` and it's because `projectInfo.projectName` wasn't set. So to fix it, I used `projectLocation.split("/").pop()`, which is how we get it elsewhere in Turbine.