### PR TITLE
remove JSON parsing of payload (to match cwctl change)

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -175,9 +175,8 @@ async function uploadFile(req, res) {
       // req.body.msg is gzipped, therefore sanitization is not required and may modify a users files
       const zippedFile = buffer.Buffer.from(req.body.msg, "base64"); // eslint-disable-line microclimate-portal-eslint/sanitise-body-parameters
       const unzippedFile = await inflateAsync(zippedFile);
-      const fileToWrite = JSON.parse(unzippedFile.toString());
       const pathToWriteTo = path.join(global.codewind.CODEWIND_WORKSPACE, global.codewind.CODEWIND_TEMP_WORKSPACE, project.name, relativePathOfFile)
-      await fs.outputFile(pathToWriteTo, fileToWrite);
+      await fs.outputFile(pathToWriteTo, unzippedFile);
       if( mode !== undefined ) {
         await fs.chmod(pathToWriteTo, mode);
       }

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -244,7 +244,7 @@ async function main() {
     /* Proxy Performance container routes */
     app.use('/performance/*', pipePerfProxyReqsToPerfContainer);
 
-    app.use(bodyParser.json({limit: '1mb'}));
+    app.use(bodyParser.json({limit: '30mb'}));
     app.use(bodyParser.urlencoded({
       extended: false
     }));


### PR DESCRIPTION
CWCTL has been changed under PR eclipse/codewind-installer#332 to now convert the payload to JSON. This is the matching change.
It also ups the maximum file limit on upload to be 30mb

Signed-off-by: Toby Corbin <corbint@uk.ibm.com>