### PR TITLE
handle js alongside nodejs as a language

### DIFF
--- a/src/performance/monitor/service.js
+++ b/src/performance/monitor/service.js
@@ -69,7 +69,7 @@ const scrapeProjectData = async (appOrigin, projectLanguage) => {
   if (!latestProjectData.hasOwnProperty(appOrigin)) {
     latestProjectData[appOrigin] = {};
   }
-  if (projectLanguage === 'nodejs') {
+  if (projectLanguage === 'nodejs' || 'javascript') {
     return scrapeNodejsProjectData(appOrigin);
   }
   await repeatFunc(

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -200,7 +200,7 @@ module.exports = class LoadRunner {
       this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'preparing' });
 
       // start profiling if supported by current language
-      if (this.project.language == 'nodejs') {
+      if (this.project.language == 'nodejs' || this.project.language === 'javascript') {
         this.beginNodeProfiling();
       } else if (this.project.language == 'java' && this.project.projectType == 'liberty') {
         await this.beginJavaProfiling(loadConfig.maxSeconds);

--- a/src/pfe/portal/modules/utils/metricsStatusChecker.js
+++ b/src/pfe/portal/modules/utils/metricsStatusChecker.js
@@ -22,6 +22,7 @@ const readFile = util.promisify(fs.readFile);
 const filesToCheck = {
   java : 'pom.xml',
   nodejs : 'package.json',
+  javascript : 'package.json',
   swift : 'Package.swift',
 }
 
@@ -48,7 +49,7 @@ async function doesMetricsPackageExist(pathOfFileToCheck, projectLanguage) {
   let metricsPackageExists = false; // default to appmetrics unavailable
   try {
     const fileToCheck = await readFile(pathOfFileToCheck, 'utf8');
-    if (projectLanguage === 'nodejs') {
+    if (projectLanguage === 'nodejs' || projectLanguage === 'javascript') {
       const packageJSON = JSON.parse(fileToCheck);
       // There might not be any dependencies
       if (packageJSON.dependencies) {

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -114,6 +114,19 @@ describe('Project.js', () => {
                 const areMetricsAvailable = await project.checkIfMetricsAvailable();
                 areMetricsAvailable.should.be.false;
             });
+            it('Checks metrics for Javascript', async() => {
+                const project = createProjectAndCheckIsAnObject({ name: 'dummy', language: 'javascript', locOnDisk: '/Documents/projectDir/' }, global.codewind.CODEWIND_WORKSPACE);
+                const packageJSONContents = {
+                    dependencies: {
+                        'appmetrics-dash': true,
+                    },
+                };
+                const packageJSONPath = path.join(project.projectPath(), 'package.json');
+                await fs.ensureFile(packageJSONPath);
+                await fs.writeJSON(packageJSONPath, packageJSONContents);
+                const areMetricsAvailable = await project.checkIfMetricsAvailable();
+                areMetricsAvailable.should.be.true;
+            });
             it('Checks metrics for Node.js', async() => {
                 const project = createProjectAndCheckIsAnObject({ name: 'dummy', language: 'nodejs', locOnDisk: '/Documents/projectDir/' }, global.codewind.CODEWIND_WORKSPACE);
                 const packageJSONContents = {


### PR DESCRIPTION
Resolves https://github.com/eclipse/codewind/issues/784. 

## Summary

To go alongside changes to our default [templates](https://github.com/kabanero-io/codewind-templates/pull/14) 
 and [cwctl](https://github.com/eclipse/codewind-installer/pull/333). 

Where we take into account project language, treat `javascript` the same as `nodejs`.

## Testing

Tests pass. 

Create projects from an Express Template with `language = javascript`, and from local disk with `cwctl` detecting `language = javascript`. Both show equivalent functionality to a `nodejs` project.