### PR TITLE
ExtensionList tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,6 +21,19 @@
         },
         {
             "type": "node",
+            "request": "launch",
+            "name": "Mocha Current File",
+            "program": "${workspaceFolder}/test/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--colors",
+                "--timeout",
+                "999999",
+                "${file}",
+            ],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "node",
             "request": "attach",
             "name": "Attach to Codewind",
             "address": "127.0.0.1",

--- a/src/pfe/portal/modules/Extension.js
+++ b/src/pfe/portal/modules/Extension.js
@@ -91,7 +91,8 @@ module.exports = class Extension {
         this.templates = definition.templates;
       } else {
         const providerPath = path.join(this.path, 'templatesProvider.js');
-        if (await fs.exists(providerPath))
+        const providerExists = await fs.exists(providerPath)
+        if (providerExists)
           this.templatesProvider = require(providerPath);
       }
       if (definition.hasOwnProperty('config')) {

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -90,33 +90,49 @@ module.exports = class ExtensionList {
    */
   async initialise(extensionsPath, templates) {
     try {
-      // Read the extensions directory, create and add extensions to the list
-      let entries = await fs.readdir(extensionsPath);
-      for (const entry of entries) {
-        try {
-          let fstats = await fs.lstat(path.join(extensionsPath, entry));
-          // Extensions are in sub-directories of the top-level extensions directory
-          if (fstats.isDirectory() && !entry.endsWith(suffixOld)) {
-            const extension = new Extension({path: path.join(extensionsPath, entry), name: entry});
-            await extension.initialise();
-            this.add(extension);
-            if (extension.templates) {
-              await templates.addRepository(extension.templates, extension.description);
-            } else if (extension.templatesProvider) {
-              templates.addProvider(extension.name, extension.templatesProvider);
-              delete extension.templatesProvider;
-            }
-          }
-        } catch (error) {
-          log.warn(error);
-          // ignore so that we can try to add other repos in the list
-        }
-      }
+      const extensions = await this.loadExtensionsFromDisk(extensionsPath);
+      await addExtensionsToTemplates(extensions, templates);
     } catch(err) {
       log.error('Error loading codewind extension:');
       log.error(err);
       throw new ExtensionListError('FAILED_TO_LOAD');
     }
+  }
+
+  /**
+   * Function to load an extension that exists in the extensions directory
+   * @param extensionsPath, directory path of the extensions directory
+   * @return extensions
+   */
+  async loadExtensionsFromDisk(extensionsPath) {
+    const entries = await fs.readdir(extensionsPath);
+    const returnedObjects = await Promise.all(entries.map(entry => this.loadExtensionFromDisk(extensionsPath, entry)));
+    const extensions = returnedObjects.filter(Boolean);
+    return extensions;
+  }
+
+  /**
+   * Function to load an extension that exists in the extensions directory
+   * @param extensionsPath, directory path of the extensions directory
+   * @param name, name of the extension and its directory
+   * @return Extension or null if the Extension could not be initialised
+   */
+  async loadExtensionFromDisk(extensionsPath, name) {
+    try {
+      let fstats = await fs.lstat(path.join(extensionsPath, name));
+      // Extensions are in sub-directories of the top-level extensions directory
+      if (fstats.isDirectory() && !name.endsWith(suffixOld)) {
+        const extension = new Extension({ path: path.join(extensionsPath, name), name });
+        await extension.initialise();
+        this.add(extension);
+        log.info(`Extension ${name} successfully initialised`)
+        return extension;
+      }
+    } catch (error) {
+      log.warn(error);
+      // ignore so that we can try to add other extensions
+    }
+    return null;
   }
 
   /**
@@ -210,6 +226,30 @@ module.exports = class ExtensionList {
     }
     return array;
   }
+}
+
+
+/**
+ * Function to load an extension that exists in the extensions directory
+ * @param extensions, a list of extensions
+ * @param templates, reference to the templates registry
+ * @return Promise
+ */
+function addExtensionsToTemplates(extensions, templates) {
+  return Promise.all(extensions.map(async extension => {
+    try {
+      if (extension.templates) {
+        log.trace(`Adding Extension ${extension.name}'s repository into the templates`);
+        await templates.addRepository(extension.templates, extension.description);
+      } else if (extension.templatesProvider) {
+        log.trace(`Adding Extension ${extension.name}'s provider into the templates`);
+        templates.addProvider(extension.name, extension.templatesProvider);
+        delete extension.templatesProvider;
+      }
+    } catch (error) {
+      log.warn(error);
+    }
+  }));
 }
 
 /**

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -139,7 +139,7 @@ module.exports = class ExtensionList {
    */
   remove(name) {
     if (!this._list.hasOwnProperty(name)) {
-      throw new ExtensionListError('NOT_FOUND',name);
+      throw new ExtensionListError('NOT_FOUND', name);
     } else {
       delete this._list[name];
     }

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -102,18 +102,6 @@ module.exports = class ExtensionList {
   /**
    * Function to load an extension that exists in the extensions directory
    * @param extensionsPath, directory path of the extensions directory
-   * @return extensions
-   */
-  async loadExtensionsFromDisk(extensionsPath) {
-    const entries = await fs.readdir(extensionsPath);
-    const returnedObjects = await Promise.all(entries.map(entry => this.loadExtensionFromDisk(extensionsPath, entry)));
-    const extensions = returnedObjects.filter(Boolean);
-    return extensions;
-  }
-
-  /**
-   * Function to load an extension that exists in the extensions directory
-   * @param extensionsPath, directory path of the extensions directory
    * @param name, name of the extension and its directory
    * @return Extension or null if the Extension could not be initialised
    */
@@ -133,6 +121,18 @@ module.exports = class ExtensionList {
       // ignore so that we can try to add other extensions
     }
     return null;
+  }
+
+  /**
+   * Function to load an extension that exists in the extensions directory
+   * @param extensionsPath, directory path of the extensions directory
+   * @return extensions
+   */
+  async loadExtensionsFromDisk(extensionsPath) {
+    const entries = await fs.readdir(extensionsPath);
+    const returnedObjects = await Promise.all(entries.map(entry => this.loadExtensionFromDisk(extensionsPath, entry)));
+    const extensions = returnedObjects.filter(Boolean);
+    return extensions;
   }
 
   /**

--- a/test/modules/extension.service.js
+++ b/test/modules/extension.service.js
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const fs = require('fs-extra');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const CODEWIND_YAML_FILENAME = 'codewind.yaml';
+const TEMPLATES_PROVIDER_FILENAME = 'templatesProvider.js';
+
+const CODEWIND_YAML = {
+    name: 'dummyExtension',
+    description: 'dummy extension for testing',
+};
+
+const COMPLETE_CODEWIND_YAML = {
+    ...CODEWIND_YAML,
+    version: 1,
+    projectType: 'dummyExtension',
+    commands: 'commands',
+    detection: 'package.json',
+    config: 'config',
+    templates: 'templates',
+};
+
+const createCodewindYamlFile = (directory, overwriteValues = {}) => {
+    const codewindJson = { ...CODEWIND_YAML };
+    for (const key in overwriteValues) {
+        codewindJson[key] = overwriteValues[key];
+    }
+    const codewindYamlFileContents = yaml.safeDump(codewindJson);
+    fs.ensureDirSync(directory);
+    fs.writeFileSync(path.join(directory, CODEWIND_YAML_FILENAME), codewindYamlFileContents);
+};
+
+const deleteCodewindYamlFile = (directory) => {
+    fs.removeSync(path.join(directory, CODEWIND_YAML_FILENAME));
+};
+
+const createTemplatesProviderFile = (directory) => {
+    const getRepoFunc = 'getRepositories: () => { return []; }';
+    const templates_provider_content = `module.exports = { ${getRepoFunc} };`;
+    fs.ensureDirSync(directory);
+    fs.writeFileSync(path.join(directory, TEMPLATES_PROVIDER_FILENAME), templates_provider_content);
+};
+
+const deleteTemplatesProviderFile = (directory) => {
+    fs.removeSync(path.join(directory, TEMPLATES_PROVIDER_FILENAME));
+};
+
+module.exports = {
+    CODEWIND_YAML,
+    COMPLETE_CODEWIND_YAML,
+    createCodewindYamlFile,
+    deleteCodewindYamlFile,
+    createTemplatesProviderFile,
+    deleteTemplatesProviderFile,
+};

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -98,9 +98,11 @@ const styledTemplates = {
     },
 };
 
+const templateRepositoryURL = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json';
+
 const sampleRepos = {
     codewind: {
-        url: 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json',
+        url: templateRepositoryURL,
         description: 'The default set of templates for new projects in Codewind.',
         enabled: true,
         protected: true,
@@ -226,6 +228,7 @@ function saveReposBeforeEachTestAndRestoreAfterEach() {
 module.exports = {
     defaultCodewindTemplates,
     styledTemplates,
+    templateRepositoryURL,
     sampleRepos,
     validUrlNotPointingToIndexJson,
     getTemplateRepos,

--- a/test/src/unit/modules/Extension.test.js
+++ b/test/src/unit/modules/Extension.test.js
@@ -35,7 +35,6 @@ chai.should();
 describe('Extension.js', () => {
     suppressLogOutput(Extension);
     const tempDir = `${__dirname}/extension_temp`;
-    // const codewindYamlPath = path.join(tempDir, 'codewind.yaml');
     before(() => {
         fs.ensureDirSync(tempDir);
     });

--- a/test/src/unit/modules/ExtensionList.test.js
+++ b/test/src/unit/modules/ExtensionList.test.js
@@ -47,253 +47,401 @@ describe('ExtensionList.js', () => {
         this.timeout(5000);
         execSync(`rm -rf ${EXTENSION_DIR}`);
     });
-    describe('new ExtensionList()', () => {
-        it('Initialises a new, empty ExtensionList', () => {
-            const extensionList = new ExtensionList();
-            extensionList.should.be.an('object');
-            extensionList._list.should.deep.equal({});
+    describe('Class functions', () => {
+        describe('new ExtensionList()', () => {
+            it('Initialises a new, empty ExtensionList', () => {
+                const extensionList = new ExtensionList();
+                extensionList.should.be.an('object');
+                const { _list: list } = extensionList;
+                list.should.deep.equal({});
+            });
         });
-    });
-    describe('initialise(extensionsPath, templates)', () => {
-        let templateController;
-        beforeEach(async() => {
-            fs.ensureDirSync(EXTENSION_DIR);
-            templateController = new Templates(EXTENSION_DIR);
-            await templateController.deleteRepository(templateRepositoryURL);
+        describe('initialise(extensionsPath, templates)', () => {
+            let templateController;
+            beforeEach(async() => {
+                fs.ensureDirSync(EXTENSION_DIR);
+                templateController = new Templates(EXTENSION_DIR);
+                await templateController.deleteRepository(templateRepositoryURL);
+            });
+            afterEach(() => {
+                execSync(`rm -rf ${EXTENSION_DIR}`);
+            });
+            it('Fails to load extensions from a directory that does not exist', () => {
+                const extensionList = new ExtensionList();
+                return extensionList.initialise('nonexistant_dir', templateController)
+                    .should.be.eventually.rejectedWith(`FAILED_TO_LOAD: Failed to load extensions`)
+                    .and.be.an.instanceOf(ExtensionListError)
+                    .and.have.property('code', 'FAILED_TO_LOAD');
+            });
+            it('Ignores an invalid directory without crashing', async() => {
+                fs.ensureDirSync(path.join(EXTENSION_DIR, 'notanextension'));
+                const extensionList = new ExtensionList();
+                await extensionList.initialise(EXTENSION_DIR, templateController);
+                const { _list: list } = extensionList;
+                list.should.not.have.property('notanextension');
+            });
+            it('Loads an extension', async() => {
+                createCodewindYamlFile(path.join(EXTENSION_DIR, 'extension'), { name: 'extension' });
+                const extensionList = new ExtensionList();
+                await extensionList.initialise(EXTENSION_DIR, templateController);
+                const { _list: list } = extensionList;
+                list.should.have.property('extension');
+            });
+            it('Loads an extension which contains a template repository URL', async function() {
+                this.timeout(testTimeout.short);
+                createCodewindYamlFile(path.join(EXTENSION_DIR, 'extensionWithURL'), { name: 'extensionWithURL', templates: templateRepositoryURL });
+                const extensionList = new ExtensionList();
+                await extensionList.initialise(EXTENSION_DIR, templateController);
+                const { _list: list } = extensionList;
+                list.should.have.property('extensionWithURL');
+                const { extensionWithURL } = list;
+                extensionWithURL.should.have.property('templates');
+    
+                // Ensure template repository has been added
+                await templateController.getRepository(extensionWithURL.templates).should.be.fulfilled;
+            });
+            it('Loads an extension which contains a templateProvider.js file and no template repository URL', async function() {
+                this.timeout(testTimeout.short);
+                const extensionName = 'extensionWithTemplateProvider';
+                createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName });
+                createTemplatesProviderFile(path.join(EXTENSION_DIR, extensionName));
+                const extensionList = new ExtensionList();
+    
+                await extensionList.initialise(EXTENSION_DIR, templateController);
+                const { _list: list } = extensionList;
+                list.should.have.property(extensionName);
+                const { extensionWithTemplateProvider } = list;
+                extensionWithTemplateProvider.should.not.have.property('templateProvider');
+    
+                // Ensure provider has been added
+                templateController.providers.should.have.property(extensionName);
+            });
+            it('Loads an extension which contains both a template repository URL and a templateProvider.js file (ignores the templateProvider.js file)', async function() {
+                this.timeout(testTimeout.short);
+                const extensionName = 'extensionWithBoth';
+                createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName, templates: templateRepositoryURL });
+                createTemplatesProviderFile(path.join(EXTENSION_DIR, extensionName));
+                const extensionList = new ExtensionList();
+    
+                await extensionList.initialise(EXTENSION_DIR, templateController);
+                const { _list: list } = extensionList;
+                list.should.have.property(extensionName);
+                const { extensionWithBoth } = list;
+                
+                // Ensure template repository has been added
+                await templateController.getRepository(extensionWithBoth.templates).should.be.fulfilled;
+    
+                // Ensure provider has not been added
+                templateController.providers.should.not.have.property(extensionName);
+            });
         });
-        afterEach(() => {
-            execSync(`rm -rf ${EXTENSION_DIR}`);
+        describe('loadExtensionFromDisk(extensionsPath, name)', () => {
+            const extensionName = 'extension';
+            const extensionNameOld = `${extensionName}__old`;
+            afterEach(() => {
+                execSync(`rm -rf ${EXTENSION_DIR}`);
+            });
+            it('Ignores a file within the given directory (does not Error)', async() => {
+                fs.ensureFileSync(path.join(EXTENSION_DIR, 'file.txt'));
+                const extensionList = new ExtensionList();
+                await extensionList.loadExtensionFromDisk(EXTENSION_DIR, 'file.txt');
+                const { _list: list } = extensionList;
+                list.should.deep.equal({});
+            });
+            it('Ignores directory that does not exist and returns null (does not Error)', async() => {
+                const extensionList = new ExtensionList();
+                const ext = await extensionList.loadExtensionFromDisk(EXTENSION_DIR, 'doesnotexist');
+                should.equal(ext, null);
+                const { _list: list } = extensionList;
+                list.should.deep.equal({});
+            });
+            it('Ignores directory that does not contain a codewind.yaml and returns null (does not Error)', async() => {
+                fs.ensureDirSync(path.join(EXTENSION_DIR, 'invaliddir'));
+                const extensionList = new ExtensionList();
+                const ext = await extensionList.loadExtensionFromDisk(EXTENSION_DIR, 'invaliddir');
+                should.equal(ext, null);
+                const { _list: list } = extensionList;
+                list.should.deep.equal({});
+            });
+            it('Ignores a directory with the old suffix in its name (__old) and returns null (does not Error)', async() => {
+                createCodewindYamlFile(path.join(EXTENSION_DIR, extensionNameOld), { name: extensionNameOld });
+                const extensionList = new ExtensionList();
+                const ext = await extensionList.loadExtensionFromDisk(EXTENSION_DIR, extensionNameOld);
+                should.equal(ext, null);
+                const { _list: list } = extensionList;
+                list.should.not.have.property(extensionNameOld);
+            });
+            it('Loads an extension from disk', async() => {
+                createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName });
+                const extensionList = new ExtensionList();
+                const { name } = await extensionList.loadExtensionFromDisk(EXTENSION_DIR, extensionName);
+                name.should.equal(extensionName);
+                const { _list: list } = extensionList;
+                list.should.have.property(extensionName);
+            });
+            it('Loads an extension from disk and ignores one with old suffix in its name (__old)', async() => {
+                createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName });
+                createCodewindYamlFile(path.join(EXTENSION_DIR, extensionNameOld), { name: extensionNameOld });
+                const extensionList = new ExtensionList();
+                await extensionList.loadExtensionFromDisk(EXTENSION_DIR, extensionName);
+                await extensionList.loadExtensionFromDisk(EXTENSION_DIR, extensionNameOld);
+                const { _list: list } = extensionList;
+                list.should.have.property(extensionName);
+                list.should.not.have.property(extensionNameOld);
+            });
         });
-        it('Fails to load extensions from a directory that does not exist', () => {
-            const extensionList = new ExtensionList();
-            return extensionList.initialise('nonexistant_dir', templateController)
-                .should.be.eventually.rejectedWith(`FAILED_TO_LOAD: Failed to load extensions`)
-                .and.be.an.instanceOf(ExtensionListError)
-                .and.have.property('code', 'FAILED_TO_LOAD');
+        describe('loadExtensionsFromDisk(extensionsPath)', () => {
+            const extensionNamePrefix = 'extension';
+            const numExtensionsToCreate = 5;
+            const extensionNames = [];
+            beforeEach(() => {
+                for (let i = 0; i < numExtensionsToCreate; i++) {
+                    const name = `${extensionNamePrefix}-${i}`;
+                    createCodewindYamlFile(path.join(EXTENSION_DIR, name), { name });
+                    extensionNames.push(name);
+                }
+            });
+            afterEach(() => {
+                execSync(`rm -rf ${EXTENSION_DIR}`);
+            });
+            it('Loads multiple extensions from disk', async() => { 
+                const extensionList = new ExtensionList();
+                const extensions = await extensionList.loadExtensionsFromDisk(EXTENSION_DIR);
+                extensions.length.should.equal(numExtensionsToCreate);
+                for (const extension of extensions) {
+                    const { name } = extension;
+                    extensionNames.should.include(name);
+                }
+            });
+            it('Loads multiple extensions from disk and ignores an invalid directory', async() => { 
+                fs.ensureDirSync(path.join(EXTENSION_DIR, 'invaliddir'));
+                const extensionList = new ExtensionList();
+                const extensions = await extensionList.loadExtensionsFromDisk(EXTENSION_DIR);
+                extensions.length.should.equal(numExtensionsToCreate);
+                extensions.should.not.include('invaliddir');
+            });
+            it('Correctly filters out nulls that are returned when an extension fails to load', async() => { 
+                fs.ensureDirSync(path.join(EXTENSION_DIR, 'invaliddir'));
+                const extensionList = new ExtensionList();
+                const extensions = await extensionList.loadExtensionsFromDisk(EXTENSION_DIR);
+                extensions.should.not.include(null);
+            });
         });
-        it('Ignores an invalid directory without crashing', async() => {
-            fs.ensureDirSync(path.join(EXTENSION_DIR, 'notanextension'));
-            const extensionList = new ExtensionList();
-            await extensionList.initialise(EXTENSION_DIR, templateController);
-            extensionList._list.should.not.have.property('notanextension');
+        describe('add(extension)', () => {
+            it('Adds a new Extension to the ExtensionList', () => {
+                const extension = new Extension({ name: 'dummyextension' });
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const { _list: list } = extensionList;
+                list.should.have.property(extension.name);
+            });
+            it('Fails to add an extension with the same name as an existing one', () => {
+                const extension = new Extension({ name: 'dummyextension' });
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const { _list: list } = extensionList;
+                list.should.have.property(extension.name);
+                const error = new ExtensionListError('EXISTS', extension.name);
+                (() => extensionList.add(extension)).should.throws(error.message, error.code);
+            });
         });
-        it('Loads an extension', async() => {
-            createCodewindYamlFile(path.join(EXTENSION_DIR, 'extension'), { name: 'extension' });
-            const extensionList = new ExtensionList();
-            await extensionList.initialise(EXTENSION_DIR, templateController);
-            extensionList._list.should.have.property('extension');
+        describe('remove(name)', () => {
+            it('Removes an Extension from the ExtensionList', () => {
+                const extension = new Extension({ name: 'dummyextension' });
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const { _list: list } = extensionList;
+                list.should.have.property(extension.name);
+                extensionList.remove(extension.name);
+                list.should.not.have.property(extension.name);
+            });
+            it('Fails to remove an extension that does not exist', () => {
+                const extensionList = new ExtensionList();
+                const error = new ExtensionListError('NOT_FOUND', 'nonexsistant');
+                (() => extensionList.remove('nonexsistant')).should.throws(error.message, error.code);
+            });
         });
-        it('Loads an extension which contains a template repository URL', async function() {
-            this.timeout(testTimeout.short);
-            createCodewindYamlFile(path.join(EXTENSION_DIR, 'extensionWithURL'), { name: 'extensionWithURL', templates: templateRepositoryURL });
-            const extensionList = new ExtensionList();
-            await extensionList.initialise(EXTENSION_DIR, templateController);
-            extensionList._list.should.have.property('extensionWithURL');
-            const { extensionWithURL } = extensionList._list;
-            extensionWithURL.should.have.property('templates');
-
-            // Ensure template repository has been added
-            await templateController.getRepository(extensionWithURL.templates).should.be.fulfilled;
+        describe('retrieve(name)', () => {
+            it('Retrieves an Extension from the ExtensionList', () => {
+                const extension = new Extension({ name: 'dummyextension' });
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const { _list: list } = extensionList;
+                list.should.have.property(extension.name);
+                const retrievedExtension = extensionList.retrieve(extension.name);
+                retrievedExtension.should.equal(extension);
+            });
+            it('Fails to remove an extension that does not exist', () => {
+                const extensionList = new ExtensionList();
+                const retrievedExtension = extensionList.retrieve('nonexsistant');
+                // eslint-disable-next-line no-undefined
+                should.equal(retrievedExtension, undefined);
+            });
         });
-        it('Loads an extension which contains a templateProvider.js file and no template repository URL', async function() {
-            this.timeout(testTimeout.short);
-            const extensionName = 'extensionWithTemplateProvider';
-            createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName });
-            createTemplatesProviderFile(path.join(EXTENSION_DIR, extensionName));
-            const extensionList = new ExtensionList();
-
-            await extensionList.initialise(EXTENSION_DIR, templateController);
-            extensionList._list.should.have.property(extensionName);
-            const { extensionWithTemplateProvider } = extensionList._list;
-            extensionWithTemplateProvider.should.not.have.property('templateProvider');
-
-            // Ensure provider has been added
-            templateController.providers.should.have.property(extensionName);
+        describe('getNames()', () => {
+            it('Gets all the extension names in the ExtensionList', () => {
+                const extension1 = new Extension({ name: 'dummyextension1' });
+                const extension2 = new Extension({ name: 'dummyextension2' });
+                const extensionList = new ExtensionList();
+                extensionList.add(extension1);
+                extensionList.add(extension2);
+                const names = extensionList.getNames();
+                names.length.should.equal(2);
+                names.should.include('dummyextension1', 'dummyextension2');
+            });
+            it('Gets an empty array when no Extensions exist in the ExtensionList', () => {
+                const extensionList = new ExtensionList();
+                const names = extensionList.getNames();
+                names.length.should.equal(0);
+            });
         });
-        it('Loads an extension which contains both a template repository URL and a templateProvider.js file (ignores the templateProvider.js file)', async function() {
-            this.timeout(testTimeout.short);
-            const extensionName = 'extensionWithBoth';
-            createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName, templates: templateRepositoryURL });
-            createTemplatesProviderFile(path.join(EXTENSION_DIR, extensionName));
-            const extensionList = new ExtensionList();
-
-            await extensionList.initialise(EXTENSION_DIR, templateController);
-            extensionList._list.should.have.property(extensionName);
-            const { extensionWithBoth } = extensionList._list;
-            
-            // Ensure template repository has been added
-            await templateController.getRepository(extensionWithBoth.templates).should.be.fulfilled;
-
-            // Ensure provider has not been added
-            templateController.providers.should.not.have.property(extensionName);
+        describe('getProjectTypes()', () => {
+            it('Gets all the extension names in the ExtensionList', () => {
+                const extension1 = new Extension({ name: 'dummyextension1' });
+                extension1.projectType = 'codewind';
+                const extension2 = new Extension({ name: 'dummyextension2' });
+                extension2.projectType = 'appsody';
+                const extensionList = new ExtensionList();
+                extensionList.add(extension1);
+                extensionList.add(extension2);
+                const projectTypes = extensionList.getProjectTypes();
+                projectTypes.length.should.equal(2);
+                projectTypes.should.include('codewind', 'appsody');
+            });
+            it('Gets an empty array when no Extensions exist in the ExtensionList', () => {
+                const extensionList = new ExtensionList();
+                const projectTypes = extensionList.getProjectTypes();
+                projectTypes.length.should.equal(0);
+            });
         });
-    });
-    describe('add(extension)', () => {
-        it('Adds a new Extension to the ExtensionList', () => {
-            const extension = new Extension({ name: 'dummyextension' });
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            extensionList._list.should.have.property(extension.name);
+        describe('getExtensionForProjectType(type)', () => {
+            it('Retrieves the Extension for a projectType that exists in the ExtensionList', () => {
+                const extension = new Extension({ name: 'dummyextension' });
+                extension.projectType = 'codewind';
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const retrievedExtension = extensionList.getExtensionForProjectType('codewind');
+                retrievedExtension.should.have.property('name', 'dummyextension');
+            });
+            it('Gets null when no Extension with the wanted projectType exists in the ExtensionList', () => {
+                const extension = new Extension({ name: 'dummyextension' });
+                extension.projectType = 'codewind';
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const retrievedExtension = extensionList.getExtensionForProjectType('invalidProjectType');
+                should.equal(retrievedExtension, null);
+            });
         });
-        it('Fails to add an extension with the same name as an existing one', () => {
-            const extension = new Extension({ name: 'dummyextension' });
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            extensionList._list.should.have.property(extension.name);
-            const error = new ExtensionListError('EXISTS', extension.name);
-            (() => extensionList.add(extension)).should.throws(error.message, error.code);
-        });
-    });
-    describe('remove(name)', () => {
-        it('Removes an Extension from the ExtensionList', () => {
-            const extension = new Extension({ name: 'dummyextension' });
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            extensionList._list.should.have.property(extension.name);
-            extensionList.remove(extension.name);
-            extensionList._list.should.not.have.property(extension.name);
-        });
-        it('Fails to remove an extension that does not exist', () => {
-            const extensionList = new ExtensionList();
-            const error = new ExtensionListError('NOT_FOUND', 'nonexsistant');
-            (() => extensionList.remove('nonexsistant')).should.throws(error.message, error.code);
-        });
-    });
-    describe('retrieve(name)', () => {
-        it('Retrieves an Extension from the ExtensionList', () => {
-            const extension = new Extension({ name: 'dummyextension' });
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            extensionList._list.should.have.property(extension.name);
-            const retrievedExtension = extensionList.retrieve(extension.name);
-            retrievedExtension.should.equal(extension);
-        });
-        it('Fails to remove an extension that does not exist', () => {
-            const extensionList = new ExtensionList();
-            const retrievedExtension = extensionList.retrieve('nonexsistant');
-            // eslint-disable-next-line no-undefined
-            should.equal(retrievedExtension, undefined);
-        });
-    });
-    describe('getNames()', () => {
-        it('Gets all the extension names in the ExtensionList', () => {
-            const extension1 = new Extension({ name: 'dummyextension1' });
-            const extension2 = new Extension({ name: 'dummyextension2' });
-            const extensionList = new ExtensionList();
-            extensionList.add(extension1);
-            extensionList.add(extension2);
-            const names = extensionList.getNames();
-            names.length.should.equal(2);
-            names.should.include('dummyextension1', 'dummyextension2');
-        });
-        it('Gets an empty array when no Extensions exist in the ExtensionList', () => {
-            const extensionList = new ExtensionList();
-            const names = extensionList.getNames();
-            names.length.should.equal(0);
-        });
-    });
-    describe('getProjectTypes()', () => {
-        it('Gets all the extension names in the ExtensionList', () => {
-            const extension1 = new Extension({ name: 'dummyextension1' });
-            extension1.projectType = 'codewind';
-            const extension2 = new Extension({ name: 'dummyextension2' });
-            extension2.projectType = 'appsody';
-            const extensionList = new ExtensionList();
-            extensionList.add(extension1);
-            extensionList.add(extension2);
-            const projectTypes = extensionList.getProjectTypes();
-            projectTypes.length.should.equal(2);
-            projectTypes.should.include('codewind', 'appsody');
-        });
-        it('Gets an empty array when no Extensions exist in the ExtensionList', () => {
-            const extensionList = new ExtensionList();
-            const projectTypes = extensionList.getProjectTypes();
-            projectTypes.length.should.equal(0);
-        });
-    });
-    describe('getExtensionForProjectType(type)', () => {
-        it('Retrieves the Extension for a projectType that exists in the ExtensionList', () => {
-            const extension = new Extension({ name: 'dummyextension' });
-            extension.projectType = 'codewind';
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            const retrievedExtension = extensionList.getExtensionForProjectType('codewind');
-            retrievedExtension.should.have.property('name', 'dummyextension');
-        });
-        it('Gets null when no Extension with the wanted projectType exists in the ExtensionList', () => {
-            const extension = new Extension({ name: 'dummyextension' });
-            extension.projectType = 'codewind';
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            const retrievedExtension = extensionList.getExtensionForProjectType('invalidProjectType');
-            should.equal(retrievedExtension, null);
-        });
-    });
-    describe('getDetectionList()', () => {
-        it('Returns a list of all Extensions detections lists combined', () => {
-            const extension1 = new Extension({ name: 'node-ext' });
-            extension1.projectType = 'nodejs';
-            extension1.detection = 'package.json';
-
-            const extension2 = new Extension({ name: 'appsody-ext' });
-            extension2.projectType = 'appsody';
-            extension2.detection = 'appsody-config.yaml';
-
-            const extensionList = new ExtensionList();
-            extensionList.add(extension1);
-            extensionList.add(extension2);
-
-            const detectedList = extensionList.getDetectionList();
-            const expectedList = [
-                {
+        describe('getDetectionList()', () => {
+            it('Returns a list of all Extensions detections lists combined', () => {
+                const extension1 = new Extension({ name: 'node-ext' });
+                extension1.projectType = 'nodejs';
+                extension1.detection = 'package.json';
+    
+                const extension2 = new Extension({ name: 'appsody-ext' });
+                extension2.projectType = 'appsody';
+                extension2.detection = 'appsody-config.yaml';
+    
+                const extensionList = new ExtensionList();
+                extensionList.add(extension1);
+                extensionList.add(extension2);
+    
+                const detectedList = extensionList.getDetectionList();
+                const expectedList = [
+                    {
+                        file: 'package.json',
+                        type: 'nodejs',
+                    },
+                    {
+                        file: 'appsody-config.yaml',
+                        type: 'appsody',
+                    },
+                ];
+                detectedList.should.deep.equal(expectedList);
+            });
+            it('Returns a single element as only one Extensions in the ExtensionList has detection and projectType fields', () => {
+                const extension1 = new Extension({ name: 'node-ext' });
+                extension1.projectType = 'nodejs';
+                extension1.detection = 'package.json';
+    
+                const extension2 = new Extension({ name: 'appsody-ext' });
+    
+                const extensionList = new ExtensionList();
+                extensionList.add(extension1);
+                extensionList.add(extension2);
+    
+                const detectedList = extensionList.getDetectionList();
+                detectedList.length.should.equal(1);
+                detectedList.should.deep.equal([{
                     file: 'package.json',
                     type: 'nodejs',
-                },
-                {
-                    file: 'appsody-config.yaml',
-                    type: 'appsody',
-                },
-            ];
-            detectedList.should.deep.equal(expectedList);
+                }]);
+            });
+            it('Returns an empty array as no Extensions in the ExtensionList that contain detection fields', () => {
+                const extension = new Extension({ name: 'node-ext' });
+                extension.projectType = 'nodejs';
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const detectedList = extensionList.getDetectionList();
+                detectedList.length.should.equal(0);
+            });
+            it('Returns an empty array as no Extensions in the ExtensionList that contain projectType fields', () => {
+                const extension = new Extension({ name: 'node-ext' });
+                extension.detection = 'package.json';
+                const extensionList = new ExtensionList();
+                extensionList.add(extension);
+                const detectedList = extensionList.getDetectionList();
+                detectedList.length.should.equal(0);
+            });
+            it('Returns an empty array as no Extensions exist in the ExtensionList', () => {
+                const extensionList = new ExtensionList();
+                const detectedList = extensionList.getDetectionList();
+                detectedList.length.should.equal(0);
+            });
         });
-        it('Returns a single element as only one Extensions in the ExtensionList has detection and projectType fields', () => {
-            const extension1 = new Extension({ name: 'node-ext' });
-            extension1.projectType = 'nodejs';
-            extension1.detection = 'package.json';
+    });
+    describe('Local functions', () => {
+        describe('addExtensionsToTemplates(extensions, templates)', () => {
+            const addExtensionsToTemplates = ExtensionList.__get__('addExtensionsToTemplates');
+            const extensionNamePrefix = 'extension';
+            const numExtensionsToCreate = 3;
+            const extensions = [];
+            beforeEach(() => {
+                for (let i = 0; i < numExtensionsToCreate; i++) {
+                    const name = `${extensionNamePrefix}-${i}`;
+                    const extension = new Extension({ name });
+                    extensions.push(extension);
+                }
+            });
+            it('Does not add the template repository when the templates field is invalid (Does not crash)', async() => {
+                const extension = new Extension({ name: 'extension' });
+                extension.templates = 'invalidURL';
+                const templateController = new Templates(EXTENSION_DIR);
+                await addExtensionsToTemplates([extension], templateController);
+                await templateController.getRepository(extension.templates).should.be.rejected;
+            });
+            it('Successfully adds the extension templates field as a repository when it exists', async() => {
+                const extension = new Extension({ name: 'extension' });
+                extension.templates = templateRepositoryURL;
+                const templateController = new Templates(EXTENSION_DIR);
+                await templateController.deleteRepository(templateRepositoryURL);
+                await addExtensionsToTemplates([extension], templateController);
 
-            const extension2 = new Extension({ name: 'appsody-ext' });
+                // Ensure template repository has been added
+                await templateController.getRepository(extension.templates).should.be.fulfilled;
+            });
+            it('Successfully adds the extension templateProvider as a provider', async() => {
+                const extension = new Extension({ name: 'extension' });
+                extension.templatesProvider = {
+                    getRepositories: () => [],
+                };
+                const templateController = new Templates(EXTENSION_DIR);
+                await addExtensionsToTemplates([extension], templateController);
 
-            const extensionList = new ExtensionList();
-            extensionList.add(extension1);
-            extensionList.add(extension2);
-
-            const detectedList = extensionList.getDetectionList();
-            detectedList.length.should.equal(1);
-            detectedList.should.deep.equal([{
-                file: 'package.json',
-                type: 'nodejs',
-            }]);
-        });
-        it('Returns an empty array as no Extensions in the ExtensionList that contain detection fields', () => {
-            const extension = new Extension({ name: 'node-ext' });
-            extension.projectType = 'nodejs';
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            const detectedList = extensionList.getDetectionList();
-            detectedList.length.should.equal(0);
-        });
-        it('Returns an empty array as no Extensions in the ExtensionList that contain projectType fields', () => {
-            const extension = new Extension({ name: 'node-ext' });
-            extension.detection = 'package.json';
-            const extensionList = new ExtensionList();
-            extensionList.add(extension);
-            const detectedList = extensionList.getDetectionList();
-            detectedList.length.should.equal(0);
-        });
-        it('Returns an empty array as no Extensions exist in the ExtensionList', () => {
-            const extensionList = new ExtensionList();
-            const detectedList = extensionList.getDetectionList();
-            detectedList.length.should.equal(0);
+                // Ensure provider has been added
+                templateController.providers.should.have.property('extension');
+                extension.should.not.have.property('templatesProvider');
+            });
         });
     });
 });

--- a/test/src/unit/modules/ExtensionList.test.js
+++ b/test/src/unit/modules/ExtensionList.test.js
@@ -1,0 +1,231 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+global.codewind = { RUNNING_IN_K8S: false };
+
+const fs = require('fs-extra');
+const { execSync } = require('child_process');
+const path = require('path');
+const rewire = require('rewire');
+const chai = require('chai');
+const chaiSubset = require('chai-subset');
+const chaiAsPromised = require('chai-as-promised');
+const yaml = require('js-yaml');
+
+const Extension = rewire('../../../../src/pfe/portal/modules/Extension');
+const ExtensionList = rewire('../../../../src/pfe/portal/modules/ExtensionList');
+const ExtensionListError = require('../../../../src/pfe/portal/modules/utils/errors/ExtensionListError');
+const Templates = rewire('../../../../src/pfe/portal/modules/Templates');
+const { templateRepositoryURL } = require('./../../../modules/template.service');
+const { suppressLogOutput } = require('../../../modules/log.service');
+const { testTimeout } = require('../../../config');
+
+chai.use(chaiSubset);
+chai.use(chaiAsPromised);
+chai.should();
+
+const EXTENSION_DIR =  `${__dirname}/extensionlist_temp`;
+
+describe('ExtensionList.js', () => {
+    suppressLogOutput(Extension);
+    suppressLogOutput(ExtensionList);
+    suppressLogOutput(Templates);
+    before(() => {
+        fs.ensureDirSync(EXTENSION_DIR);
+    });
+    after(function() {
+        this.timeout(5000);
+        execSync(`rm -rf ${EXTENSION_DIR}`);
+    });
+    describe('new ExtensionList()', () => {
+        it('Initialises a new, empty ExtensionList', () => {
+            const extensionList = new ExtensionList();
+            extensionList.should.be.an('object');
+            extensionList._list.should.deep.equal({});
+        });
+    });
+    describe('initialise(extensionsPath, templates)', () => {
+        let templateController;
+        beforeEach(async() => {
+            fs.ensureDirSync(EXTENSION_DIR);
+            templateController = new Templates(EXTENSION_DIR);
+            await templateController.deleteRepository(templateRepositoryURL);
+        });
+        afterEach(() => {
+            execSync(`rm -rf ${EXTENSION_DIR}`);
+        });
+        it('Fails to load extensions from a directory that does not exist', () => {
+            const extensionList = new ExtensionList();
+            return extensionList.initialise('nonexistant_dir', templateController)
+                .should.be.eventually.rejectedWith(`FAILED_TO_LOAD: Failed to load extensions`)
+                .and.be.an.instanceOf(ExtensionListError)
+                .and.have.property('code', 'FAILED_TO_LOAD');
+        });
+        it('Ignores an invalid directory without crashing', async() => {
+            fs.ensureDirSync(path.join(EXTENSION_DIR, 'notanextension'));
+            const extensionList = new ExtensionList();
+            await extensionList.initialise(EXTENSION_DIR, templateController);
+            extensionList._list.should.not.have.property('notanextension');
+        });
+        it('Loads an extension', async() => {
+            createDummyExtension('extension');
+            const extensionList = new ExtensionList();
+            await extensionList.initialise(EXTENSION_DIR, templateController);
+            extensionList._list.should.have.property('extension');
+        });
+        it('Loads an extension which contains a template repository URL', async function() {
+            this.timeout(testTimeout.short);
+            createDummyExtension('extensionWithURL', templateRepositoryURL);
+            const extensionList = new ExtensionList();
+            await extensionList.initialise(EXTENSION_DIR, templateController);
+            extensionList._list.should.have.property('extensionWithURL');
+            const { extensionWithURL } = extensionList._list;
+            extensionWithURL.should.have.property('templates');
+
+            // Ensure template repository has been added
+            await templateController.getRepository(extensionWithURL.templates).should.be.fulfilled;
+        });
+        it('Loads an extension which contains a templateProvider.js file and no template repository URL', async function() {
+            this.timeout(testTimeout.short);
+            createDummyExtensionWithTemplateProvider('extensionWithTemplateProvider');
+            const extensionList = new ExtensionList();
+            await extensionList.initialise(EXTENSION_DIR, templateController);
+            extensionList._list.should.have.property('extensionWithTemplateProvider');
+            const { extensionWithTemplateProvider } = extensionList._list;
+            extensionWithTemplateProvider.should.not.have.property('templateProvider');
+
+            // Ensure provider has been added
+            templateController.providers.should.have.property('extensionWithTemplateProvider');
+        });
+        it('Loads an extension which contains both a template repository URL and a templateProvider.js file (ignores the templateProvider.js file)', async function() {
+            this.timeout(testTimeout.short);
+            createDummyExtensionWithTemplateProvider('extensionWithBoth', templateRepositoryURL);
+            const extensionList = new ExtensionList();
+            await extensionList.initialise(EXTENSION_DIR, templateController);
+            extensionList._list.should.have.property('extensionWithBoth');
+            const { extensionWithBoth } = extensionList._list;
+            
+            // Ensure template repository has been added
+            await templateController.getRepository(extensionWithBoth.templates).should.be.fulfilled;
+
+            // Ensure provider has not been added
+            templateController.providers.should.not.have.property('extensionWithBoth');
+        });
+    });
+    describe('add(extension)', () => {
+        it('Adds a new Extension to the ExtensionList', () => {
+            const extension = new Extension({ name: 'dummyextension' });
+            const extensionList = new ExtensionList();
+            extensionList.add(extension);
+            extensionList._list.should.have.property(extension.name);
+        });
+        it('Fails to add an extension with the same name as an existing one', () => {
+            const extension = new Extension({ name: 'dummyextension' });
+            const extensionList = new ExtensionList();
+            extensionList.add(extension);
+            extensionList._list.should.have.property(extension.name);
+            const error = new ExtensionListError('EXISTS', extension.name);
+            (() => extensionList.add(extension)).should.throws(error.message, error.code);
+        });
+    });
+    describe('remove(name)', () => {
+        it('Removes an Extension from the ExtensionList', () => {
+            const extension = new Extension({ name: 'dummyextension' });
+            const extensionList = new ExtensionList();
+            extensionList.add(extension);
+            extensionList._list.should.have.property(extension.name);
+            extensionList.remove(extension.name);
+            extensionList._list.should.not.have.property(extension.name);
+        });
+        it('Fails to remove an extension that does not exist', () => {
+            const extensionList = new ExtensionList();
+            const error = new ExtensionListError('NOT_FOUND', 'nonexsistant');
+            (() => extensionList.remove('nonexsistant')).should.throws(error.message, error.code);
+        });
+    });
+    describe('retrieve(name)', () => {
+        it('Retrieves an Extension from the ExtensionList', () => {
+            const extension = new Extension({ name: 'dummyextension' });
+            const extensionList = new ExtensionList();
+            extensionList.add(extension);
+            extensionList._list.should.have.property(extension.name);
+            const retrievedExtension = extensionList.retrieve(extension.name);
+            retrievedExtension.should.equal(extension);
+        });
+        it('Fails to remove an extension that does not exist', () => {
+            const extensionList = new ExtensionList();
+            const retrievedExtension = extensionList.retrieve('nonexsistant');
+            (typeof retrievedExtension).should.equal('undefined');
+        });
+    });
+    describe('getNames()', () => {
+        it('Gets all the extension names in the ExtensionList', () => {
+            const extension1 = new Extension({ name: 'dummyextension1' });
+            const extension2 = new Extension({ name: 'dummyextension2' });
+            const extensionList = new ExtensionList();
+            extensionList.add(extension1);
+            extensionList.add(extension2);
+            const names = extensionList.getNames();
+            names.length.should.equal(2);
+            names.should.include('dummyextension1', 'dummyextension2');
+        });
+        it('Gets an empty array when no Extensions exist in the ExtensionList', () => {
+            const extensionList = new ExtensionList();
+            const names = extensionList.getNames();
+            names.length.should.equal(0);
+        });
+    });
+    describe.skip('getProjectTypes()', () => {
+        before(() => {
+
+        });
+        it('Gets all the extension names in the ExtensionList', () => {
+            const extension1 = new Extension({ name: 'dummyextension1', projectType: 'codewind' });
+            const extension2 = new Extension({ name: 'dummyextension2', projectType: 'appsody' });
+            const extensionList = new ExtensionList();
+            extensionList.add(extension1);
+            extensionList.add(extension2);
+            const projectTypes = extensionList.getProjectTypes();
+            projectTypes.length.should.equal(2);
+            projectTypes.should.include('codewind', 'appsody');
+        });
+        it('Gets an empty array when no Extensions exist in the ExtensionList', () => {
+            const extensionList = new ExtensionList();
+            const names = extensionList.getNames();
+            names.length.should.equal(0);
+        });
+    });
+});
+
+function createDummyExtension(name, repositoryURL = false) {
+    // Create extension directory
+    const dir = path.join(EXTENSION_DIR, name);
+    fs.ensureDirSync(dir);
+
+    // Create codewind.yaml file
+    const codewindFileJson = {
+        name,
+        version: 1,
+        description: 'dummy extension for testing',
+        projectType: 'dummyExtension',
+    };
+    if (repositoryURL) {
+        codewindFileJson.templates = repositoryURL;
+    }
+    const codewindFileYaml = yaml.safeDump(codewindFileJson);
+    fs.writeFileSync(path.join(dir, 'codewind.yaml'), codewindFileYaml);
+}
+
+function createDummyExtensionWithTemplateProvider(name, repositoryURL = false) {
+    createDummyExtension(name, repositoryURL);
+    const getRepoFunc = 'getRepositories: () => { return []; }';
+    const templates_provider_content = `module.exports = { ${getRepoFunc} };`;
+    fs.writeFileSync(path.join(EXTENSION_DIR, name, 'templatesProvider.js'), templates_provider_content);
+}

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -23,7 +23,7 @@ const {
     defaultCodewindTemplates,
     sampleRepos,
     validUrlNotPointingToIndexJson,
-    templateRepositoryUrl,
+    templateRepositoryURL,
 } = require('../../modules/template.service');
 const { suppressLogOutput } = require('../../modules/log.service');
 const { testTimeout } = require('../../config');
@@ -692,10 +692,10 @@ describe('Templates.js', function() {
                 describe('(<validUrlPointingToIndexJson>, <validDesc>, <validName>)', function() {
                     it('succeeds', async function() {
                         this.timeout(testTimeout.short);
-                        const func = () => templateController.addRepository(templateRepositoryUrl, 'description', 'name');
+                        const func = () => templateController.addRepository(templateRepositoryURL, 'description', 'name');
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{
-                            url: templateRepositoryUrl,
+                            url: templateRepositoryURL,
                             name: 'name',
                             description: 'description',
                             enabled: true,
@@ -711,10 +711,10 @@ describe('Templates.js', function() {
                     it('succeeds', async function() {
                         this.timeout(testTimeout.short);
                         const isRepoProtected = false;
-                        const func = () => templateController.addRepository(templateRepositoryUrl, 'description', 'name', isRepoProtected);
+                        const func = () => templateController.addRepository(templateRepositoryURL, 'description', 'name', isRepoProtected);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{
-                            url: templateRepositoryUrl,
+                            url: templateRepositoryURL,
                             name: 'name',
                             description: 'description',
                             enabled: true,
@@ -732,7 +732,7 @@ describe('Templates.js', function() {
                 describe('(<validUrl>, <ValidDesc>, <ValidName>)', function() {
                     it('succeeds, and allows the user to set the name and description', async function() {
                         this.timeout(testTimeout.short);
-                        const func = () => templateController.addRepository(templateRepositoryUrl, 'description', 'name', false);
+                        const func = () => templateController.addRepository(templateRepositoryURL, 'description', 'name', false);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{ ...sampleRepos.codewind,
                             name: 'name',
@@ -744,7 +744,7 @@ describe('Templates.js', function() {
                 describe('(repo with templates.json, <validUrl>, <NoDesc>, <NoName>)', function() {
                     it('succeeds, and gets the name and description from templates.json', async function() {
                         this.timeout(testTimeout.short);
-                        const func = () => templateController.addRepository(templateRepositoryUrl, '', '', false);
+                        const func = () => templateController.addRepository(templateRepositoryURL, '', '', false);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{ ...sampleRepos.codewind, protected: false }]);
                     });
@@ -936,7 +936,7 @@ describe('Templates.js', function() {
             });
             describe('when providers list valid repos', function() {
                 const validCodewindRepo = {
-                    url: templateRepositoryUrl,
+                    url: templateRepositoryURL,
                     description: 'The default set of templates for new projects in Codewind.',
                 };
                 before(() => {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -23,6 +23,7 @@ const {
     defaultCodewindTemplates,
     sampleRepos,
     validUrlNotPointingToIndexJson,
+    templateRepositoryUrl,
 } = require('../../modules/template.service');
 const { suppressLogOutput } = require('../../modules/log.service');
 const { testTimeout } = require('../../config');
@@ -691,11 +692,10 @@ describe('Templates.js', function() {
                 describe('(<validUrlPointingToIndexJson>, <validDesc>, <validName>)', function() {
                     it('succeeds', async function() {
                         this.timeout(testTimeout.short);
-                        const url = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/3af4928a928a5c08b07908c54799cc1675b9f965/devfiles/index.json';
-                        const func = () => templateController.addRepository(url, 'description', 'name');
+                        const func = () => templateController.addRepository(templateRepositoryUrl, 'description', 'name');
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{
-                            url,
+                            url: templateRepositoryUrl,
                             name: 'name',
                             description: 'description',
                             enabled: true,
@@ -710,12 +710,11 @@ describe('Templates.js', function() {
                 describe('(<validUrlUnprotected>, <validDesc>, <validName>)', function() {
                     it('succeeds', async function() {
                         this.timeout(testTimeout.short);
-                        const url = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/3af4928a928a5c08b07908c54799cc1675b9f965/devfiles/index.json';
                         const isRepoProtected = false;
-                        const func = () => templateController.addRepository(url, 'description', 'name', isRepoProtected);
+                        const func = () => templateController.addRepository(templateRepositoryUrl, 'description', 'name', isRepoProtected);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{
-                            url,
+                            url: templateRepositoryUrl,
                             name: 'name',
                             description: 'description',
                             enabled: true,
@@ -733,8 +732,7 @@ describe('Templates.js', function() {
                 describe('(<validUrl>, <ValidDesc>, <ValidName>)', function() {
                     it('succeeds, and allows the user to set the name and description', async function() {
                         this.timeout(testTimeout.short);
-                        const url = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json';
-                        const func = () => templateController.addRepository(url, 'description', 'name', false);
+                        const func = () => templateController.addRepository(templateRepositoryUrl, 'description', 'name', false);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{ ...sampleRepos.codewind,
                             name: 'name',
@@ -746,8 +744,7 @@ describe('Templates.js', function() {
                 describe('(repo with templates.json, <validUrl>, <NoDesc>, <NoName>)', function() {
                     it('succeeds, and gets the name and description from templates.json', async function() {
                         this.timeout(testTimeout.short);
-                        const url = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json';
-                        const func = () => templateController.addRepository(url, '', '', false);
+                        const func = () => templateController.addRepository(templateRepositoryUrl, '', '', false);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{ ...sampleRepos.codewind, protected: false }]);
                     });
@@ -939,7 +936,7 @@ describe('Templates.js', function() {
             });
             describe('when providers list valid repos', function() {
                 const validCodewindRepo = {
-                    url: 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/3af4928a928a5c08b07908c54799cc1675b9f965/devfiles/index.json',
+                    url: templateRepositoryUrl,
                     description: 'The default set of templates for new projects in Codewind.',
                 };
                 before(() => {


### PR DESCRIPTION
### Summary
* Adds tests for the `ExtensionList.js` file.
   * `installBuiltInExtensions` and non-class functions do not have tests in this PR as I'll be moving them out into a different file in another PR.
* Refactor `initialise` function to move into smaller functions and then test them separately.
* Moves common elements of `ExtensionList.test.js` and `Extension.test.js` into `extension.service.js`.
* Moves `templateRepositoryURL` into a variable so if it changes we only need to update one place for the tests to pass again.
* Adds a `Mocha Current File` script into the `launch.json` so that we can run a single Mocha file without having to drop into the terminal.

### Testing
* Travis tests passing (hopefully)
* Ran unit tests locally