### PR TITLE
test fix: don't stringify files before uploading

### DIFF
--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -99,7 +99,7 @@ async function uploadFiles(projectID, pathToDirToUpload) {
 
 async function uploadFile(projectID, pathToDirToUpload, pathFromDirToFile) {
     const filePath = path.join(pathToDirToUpload, pathFromDirToFile);
-    const fileContent = JSON.stringify(fs.readFileSync(filePath, 'utf-8'));
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
     const zippedContent = zlib.deflateSync(fileContent);
     const base64CompressedContent = zippedContent.toString('base64');
     const options = {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

The `upload` API was recently changed: https://github.com/eclipse/codewind/pull/1755 and https://github.com/eclipse/codewind-installer/pull/332) but the [re-enabled `bind` tests](https://github.com/eclipse/codewind/pull/1745) were not merged yet so were not updated. The tests still pass but the project files are incorrectly stringified when uploading.

This updates the test code to reflect the change that was merged.