### PR TITLE
Add debug logging to startup

### DIFF
--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -11,24 +11,28 @@
 'use strict';
 
 const Logger = require('./modules/utils/Logger');
-const { pipePerfProxyReqsToPerfContainer } = require('./controllers/performance.controller');
-
 const log = new Logger('server.js');
+const sanitizer = require('sanitizer');
+const URL = require('url-parse');
+
+log.info(`Starting Codewind PFE container`);
 
 // Because main is async it can swallow exceptions (like syntax errors in
 // required files unless we handle them.
-main().catch(err => console.dir(err));
+let ready = false;
+main().catch(err => log.error(err)).finally(() => log.info(`Codewind PFE container startup ${ready?'complete':'failed'}`));
 
 // Wrap everything in an async function so we can use
 // await to serialize initialisation.
 async function main() {
-  let ready = false;
 
   // Set the umask for file creation.
   process.umask(0o002);
 
   // dotenv reads .env and adds it to the process.env object
   require('dotenv').config()
+
+  log.info(`Codewind PFE image version '${process.env.CODEWIND_VERSION}' image build time '${process.env.IMAGE_BUILD_TIME}'`);
 
   if (process.env.APPMETRICS) { // dev mode
     require('appmetrics-dash').monitor({ title: "Application Metrics Dashboard - Monitoring codewind Portal" });
@@ -40,102 +44,29 @@ async function main() {
   const WebSocket = require('./modules/WebSocket');
   const app = express();
 
+  log.debug(`Created express instance.`);
+
   const serverPort = (process.env.PORTAL_HTTPS == 'true') ? 9191 : 9090;
   let server;
   if (process.env.PORTAL_HTTPS == 'true') {
+    log.debug(`HTTPS enabled will listen on port ${serverPort}`);
+    log.debug(`Using HTTPS, creating self-signed certificate.`);
     const pem = require('pem');
     const createCertificateAsync = promisify(pem.createCertificate);
     let keys = await createCertificateAsync({ selfSigned: true });
     const https = require('https');
     server = https.createServer({ key: keys.serviceKey, cert: keys.certificate }, app).listen(serverPort);
   } else {
+    log.debug(`HTTP enabled will listen on port ${serverPort}`);
     const http = require('http');
     server = http.createServer(app).listen(serverPort);
   }
+  // Log port information at debug as the container may expose the server on
+  // a different port number.
+  log.debug(`Server created, listening on ${serverPort}`);
+
   WebSocket.createWebsocketServer(server);
-  // Add basic protection against XSS and CSRF.
-  // This is not foolproof just a sanity check.
-  // https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
-  // This needs to happen before we add authentication or any
-  // other routes.
-  function isRequestAllowed(req) {
-    // The target origin is the host in the header, but if proxied we should
-    // prefer the x-forwarded-host header field.
-    let targetOrigin = req.headers['x-forwarded-host'] || req.headers['host'];
-    // The origin may be in the header field but if that is missing use the
-    // referer field.
-    let origin = req.headers['origin'] || req.headers['referer'];
-
-    if (targetOrigin) {
-      targetOrigin = targetOrigin.toLowerCase()
-    }
-    if (origin) {
-      origin = origin.toLowerCase()
-    }
-
-    let originURL = new URL(origin);
-
-    log.trace(`Checking origin host ${originURL.host} matches expected host ${targetOrigin}`);
-
-    if (origin && targetOrigin) {
-      if (originURL.host === targetOrigin) {
-        // Origin and target match so this request is Ok.
-        return true;
-      }
-      log.error(`portal/server.js: Origin host ${originURL.host} does not match expected host ${targetOrigin}`);
-      return false;
-    }
-    // No origin or targetOrigin, can't check.
-    return true;
-  }
-
-  function addSanitize(req) {
-    // Only sanitize strings, bodyParser will have parsed JSON
-    // and created numbers and booleans which should be safe.
-    function santizeStrings(arg) {
-      if (typeof arg === 'string') {
-        return sanitizer.sanitize(arg);
-      }
-      return arg;
-    }
-
-    // Add sanitising getter for body params here.
-    req.sanitizeBody = (name) => santizeStrings(req.body[name]); // eslint-disable-line microclimate-portal-eslint/sanitise-body-parameters
-    req.sanitizeParams = (name) => santizeStrings(req.params[name]); // eslint-disable-line microclimate-portal-eslint/sanitise-body-parameters
-
-    return req;
-  }
-
-  function securityMiddleware(req, res, next) {
-    req = addSanitize(req); // eslint-disable-line no-param-reassign
-
-    // disable iframe usage from other origins
-    res.set('X-Frame-Options', 'SAMEORIGIN');
-    res.set('Content-Security-Policy', "frame-ancestors 'self';");
-
-    // Only block requests that change state like PUT, POST, DELETE
-    if (req.method == "GET") {
-      return next();
-    }
-
-    if (!isRequestAllowed(req)) {
-      res.status(403).end();
-    }
-
-    return next();
-  }
-
-  const bodyParser = require('body-parser');
-  const sanitizer = require('sanitizer');
-  const URL = require('url-parse');
-
-  // Kubernetes-client v5
-  const K8Client = require('kubernetes-client').Client
-  const k8config = require('kubernetes-client').config;
-  let k8Client = null
-
-  // Make the JSON output from REST APIs human readable.
-  app.set('json spaces', 2);
+  log.debug(`Websocket bound to server.`);
 
   // Setup global variables
   global.codewind = {
@@ -150,20 +81,24 @@ async function main() {
     MOUNTED_WORKSPACE: '/mounted-workspace'
   };
 
-  // find if running in kubernetes and build up a whitelist of allowed origins
+  // Kubernetes-client v5
+  const K8Client = require('kubernetes-client').Client
+  const k8config = require('kubernetes-client').config;
+  let k8Client = null
 
+  // find if running in kubernetes and build up a whitelist of allowed origins
   try {
     k8Client = new K8Client({ config: k8config.getInCluster(), version: '1.9' });
   }
   catch (err) {
-    log.info('Codewind does not appear to be running in k8s')
+    log.info('Codewind does not appear to be running in Kubernetes')
     global.codewind.RUNNING_IN_K8S = false;
   }
 
   const originsWhitelist = []
   try {
     if (k8Client) {
-      log.info('Codewind is running in k8s');
+      log.info('Codewind is running in Kubernetes');
       global.codewind.RUNNING_IN_K8S = true;
       global.codewind.k8Client = k8Client;
 
@@ -201,18 +136,11 @@ async function main() {
     }
   });
 
-  const routes = require('./routes');
-  const { handleErrors } = require('./middleware/errorHandler');
   // Classes
+  log.debug(`Creating default user.`);
   const UserList = require('./modules/UserList.js');
   const User = require('./modules/User.js');
-
   let userList = new UserList();
-
-  app.get('/', (req, res) => { res.sendStatus(200); });
-  app.get('/health', (req, res) => { res.sendStatus(200); });
-  app.get('/ready', (req, res) => { res.status(200).send(ready); });
-  app.use(securityMiddleware);
 
   // Default, single user implementation
   let user = await User.createUser(
@@ -222,44 +150,129 @@ async function main() {
     io
   );
   userList.add(user);
-  setRoutes();
+  log.debug(`Default user created.`);
+
+  log.debug(`Configuring routes.`);
+  setRoutes(app, userList);
   // We have finished initialising the user, any projects and routes so we are ready now
   ready = true;
+}
 
-  /**
-   * Function to set up express routes for codewind portal. All external APIs
-   * should be defined inside this function, so that any authentication routes can
-   * be set up first, before this function is run.
-   */
-  function setRoutes() {
-    log.info('Setting up codewind Express routes');
+// Add basic protection against XSS and CSRF.
+// This is not foolproof just a sanity check.
+// https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md
+// This needs to happen before we add authentication or any
+// other routes.
+function isRequestAllowed(req) {
+  // The target origin is the host in the header, but if proxied we should
+  // prefer the x-forwarded-host header field.
+  let targetOrigin = req.headers['x-forwarded-host'] || req.headers['host'];
+  // The origin may be in the header field but if that is missing use the
+  // referer field.
+  let origin = req.headers['origin'] || req.headers['referer'];
 
-    // Add the user object into the request
-    app.all('*', function (req, res, next) {
-      if (req.user == undefined) req.user = "default"
-      req.cw_user = userList.retrieve(req.user);
-      next();
-    });
-
-    /* Proxy Performance container routes */
-    app.use('/performance/*', pipePerfProxyReqsToPerfContainer);
-
-    app.use(bodyParser.json({limit: '30mb'}));
-    app.use(bodyParser.urlencoded({
-      extended: false
-    }));
-
-    log.logAllApiCalls(app); // must be called after 'app.use(bodyParser)', and before 'app.use(router)'
-
-    app.use(routes);
-
-    // Default route to send a 404 response, rather than the express default which
-    // sends back the user input, and was seen as a content spoofing vulnerability
-    app.use(function (req, res) {
-      res.sendStatus(404);
-    });
-
-    app.use(handleErrors);
+  if (targetOrigin) {
+    targetOrigin = targetOrigin.toLowerCase()
+  }
+  if (origin) {
+    origin = origin.toLowerCase()
   }
 
+  let originURL = new URL(origin);
+
+  log.trace(`Checking origin host ${originURL.host} matches expected host ${targetOrigin}`);
+
+  if (origin && targetOrigin) {
+    if (originURL.host === targetOrigin) {
+      // Origin and target match so this request is Ok.
+      return true;
+    }
+    log.error(`portal/server.js: Origin host ${originURL.host} does not match expected host ${targetOrigin}`);
+    return false;
+  }
+  // No origin or targetOrigin, can't check.
+  return true;
+}
+
+// Only sanitize strings, bodyParser will have parsed JSON
+// and created numbers and booleans which should be safe.
+function santizeStrings(arg) {
+  if (typeof arg === 'string') {
+    return sanitizer.sanitize(arg);
+  }
+  return arg;
+}
+
+function addSanitize(req) {
+  // Add sanitising getter for body params here.
+  req.sanitizeBody = (name) => santizeStrings(req.body[name]); // eslint-disable-line microclimate-portal-eslint/sanitise-body-parameters
+  req.sanitizeParams = (name) => santizeStrings(req.params[name]); // eslint-disable-line microclimate-portal-eslint/sanitise-body-parameters
+}
+
+function securityMiddleware(req, res, next) {
+  addSanitize(req); // eslint-disable-line no-param-reassign
+
+  // disable iframe usage from other origins
+  res.set('X-Frame-Options', 'SAMEORIGIN');
+  res.set('Content-Security-Policy', "frame-ancestors 'self';");
+
+  // Only block requests that change state like PUT, POST, DELETE
+  if (req.method == "GET") {
+    return next();
+  }
+
+  if (!isRequestAllowed(req)) {
+    res.status(403).end();
+  }
+
+  return next();
+}
+
+/**
+ * Function to set up express routes for codewind portal. All external APIs
+ * should be defined inside this function, so that any authentication routes can
+ * be set up first, before this function is run.
+ */
+function setRoutes(app, userList) {
+  log.info('Setting up codewind Express routes');
+
+  // Make the JSON output from REST APIs human readable.
+  app.set('json spaces', 2);
+  app.get('/', (req, res) => { res.sendStatus(200); });
+  app.get('/health', (req, res) => { res.sendStatus(200); });
+  app.get('/ready', (req, res) => { res.status(200).send(ready); });
+  app.use(securityMiddleware);
+
+  const bodyParser = require('body-parser');
+  const routes = require('./routes');
+  const { pipePerfProxyReqsToPerfContainer } = require('./controllers/performance.controller');
+  const { handleErrors } = require('./middleware/errorHandler');
+
+  // Add the user object into the request
+  app.all('*', function (req, res, next) {
+    if (req.user == undefined) req.user = "default"
+    req.cw_user = userList.retrieve(req.user);
+    next();
+  });
+
+  /* Proxy Performance container routes */
+  app.use('/performance/*', pipePerfProxyReqsToPerfContainer);
+
+  app.use(bodyParser.json({ limit: '30mb' }));
+  app.use(bodyParser.urlencoded({
+    extended: false
+  }));
+
+  log.logAllApiCalls(app); // must be called after 'app.use(bodyParser)', and before 'app.use(router)'
+
+  app.use(routes);
+
+  // Default route to send a 404 response, rather than the express default which
+  // sends back the user input, and was seen as a content spoofing vulnerability
+  app.use(function (req, res) {
+    res.sendStatus(404);
+  });
+
+  app.use(handleErrors);
+  log.info('Express routes configured');
 }

--- a/start.sh
+++ b/start.sh
@@ -57,13 +57,18 @@ else
 fi
 cd - 
 
+if [ -n "$LOG_LEVEL" ]; then
+  echo "Setting PFE logging to ${LOG_LEVEL}"
+  LOG_OPTION="--loglevel ${LOG_LEVEL}"
+fi
+
 # REMOVE PREVIOUS DOCKER PROCESSES FOR CODEWIND
 printf "\n\n${BLUE}REMOVING EXISTING CODEWIND DOCKER CONTAINERS $RESET\n";
 # Check for existing processes (stopped or running)
 $CWCTL stop-all
 
 printf "\n\n${BLUE}STARTING CODEWIND DOCKER CONTAINERS $RESET\n";
-$CWCTL start --debug
+$CWCTL $LOG_OPTION start --debug
 
 if [ $? -eq 0 ]; then
   printf "\n\n${GREEN}SUCCESSFULLY STARTED CONTAINERS $RESET\n";


### PR DESCRIPTION
This PR improves startup debug in server.js and User.js so we log more initialisation progress at debug in both. It also re-organises `server.js` so that we don't declare functions in the middle of main() and moves code doing same task (initialising the User, adding the routes to express) together so the code is organised more logically.

This is worth doing now as we now have the ability to start Codewind with more logging enabled in the PFE container by setting the initial log level:
`./cwctl --loglevel debug start -t latest`
(This sets `LOG_LEVEL=debug` in the environment variables in the docker compose file we use to start the codewind-pfe container.)

Post startup the log level can be changed by doing:
`./cwctl-darwin log info`
(This calls `api/v1/logging` on the PFE container to change the log level.)