### PR TITLE
Add PFE project sync tests (POST upload/end API)

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -327,6 +327,11 @@ paths:
         200:
           description: >
             The project uploads completed successfully and it will now be built.
+          content:
+            text/html:
+              schema:
+                type: string
+                example: OK
         404:
           description: Project with given projectiD was not found.
         500:
@@ -1725,12 +1730,12 @@ components:
     UploadEnd:
       type: object
       required:
-        - timestamp
+        - timeStamp
         - fileList
         - directoryList
         - modifiedList
       properties:
-        timestamp:
+        timeStamp:
           description: time since epoch of last upload
           type: number
           example: 157139320301
@@ -1745,6 +1750,7 @@ components:
         modifiedList:
           description: an array of files that have been modified since the last project upload
           type: array
+          nullable: true
           example: ["/project/modifiedfile1"]
 
     Upload:

--- a/test/modules/container.service/index.js
+++ b/test/modules/container.service/index.js
@@ -82,7 +82,7 @@ async function readFile(filePath) {
 };
 
 async function readJson(filePath) {
-    const fileData = await readFile(filePath, 'utf8');
+    const fileData = await readFile(filePath);
     return JSON.parse(fileData);
 };
 

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -99,7 +99,7 @@ async function uploadFiles(projectID, pathToDirToUpload) {
 
 async function uploadFile(projectID, pathToDirToUpload, pathFromDirToFile) {
     const filePath = path.join(pathToDirToUpload, pathFromDirToFile);
-    const fileContent = JSON.stringify(fs.readFileSync(filePath, 'utf-8'));
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
     const zippedContent = zlib.deflateSync(fileContent);
     const base64CompressedContent = zippedContent.toString('base64');
     const options = {

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -153,6 +153,15 @@ async function unbindProject(projectID, expectedResStatus = 202) {
     return res;
 }
 
+/**
+ * For cleaning up PFE
+ */
+async function unbindAllProjects() {
+    const projectIds = await getProjectIDs();
+    const promises = projectIds.map(id => unbindProject(id));
+    await Promise.all(promises);
+}
+
 async function buildProject(projectID) {
     const res = await reqService.chai.post(`/api/v1/projects/${projectID}/build`)
         .set('Cookie', ADMIN_COOKIE)
@@ -401,6 +410,7 @@ module.exports = {
     uploadFiles,
     uploadFile,
     unbindProject,
+    unbindAllProjects,
     removeProject,
     buildProject,
     cloneProject,

--- a/test/package.json
+++ b/test/package.json
@@ -34,6 +34,7 @@
     "dockerode": "^2.5.2",
     "find-in-files": "^0.5.0",
     "fs-extra": "^5.0.0",
+    "glob-to-regexp": "^0.4.1",
     "klaw-sync": "^6.0.0",
     "kubernetes-client": "^6.10.0",
     "license-checker": "^25.0.1",

--- a/test/src/API/projects/bind.test.js
+++ b/test/src/API/projects/bind.test.js
@@ -23,20 +23,20 @@ chai.should();
 
 describe('Bind projects tests', () => {
     const projectName = `test-projects-bind-${Date.now()}`;
-    const pathToLocalRepo = path.join(TEMP_TEST_DIR, projectName);
+    const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
     let projectID;
 
     before('use the git API to clone a project to disk, ready for upload to codewind', async function() {
         this.timeout(testTimeout.med);
         await projectService.cloneProject(
-            'https://github.com/microclimate-dev2ops/microclimateNodeTemplate.git',
-            pathToLocalRepo,
+            'https://github.com/codewind-resources/nodeExpressTemplate.git',
+            pathToLocalProject,
         );
     });
 
     after(async function() {
         this.timeout(testTimeout.med);
-        await projectService.removeProject(pathToLocalRepo, projectID);
+        await projectService.removeProject(pathToLocalProject, projectID);
     });
 
     describe('Complete bind (these `it` blocks depend on each other passing)', () => {
@@ -47,7 +47,7 @@ describe('Bind projects tests', () => {
                 name: projectName,
                 language: 'nodejs',
                 projectType: 'nodejs',
-                path: pathToLocalRepo,
+                path: pathToLocalProject,
                 creationTime: Date.now(),
             });
 
@@ -59,7 +59,7 @@ describe('Bind projects tests', () => {
         it('returns 200 for each file successfully uploaded to PFE', async function() {
             this.timeout(testTimeout.med);
 
-            const responses = await projectService.uploadFiles(projectID, pathToLocalRepo);
+            const responses = await projectService.uploadFiles(projectID, pathToLocalProject, 'nodejs');
 
             responses.forEach(res => {
                 res.should.have.status(200);
@@ -80,7 +80,7 @@ describe('Bind projects tests', () => {
                 name: projectName,
                 language: 'nodejs',
                 projectType: 'nodejs',
-                path: pathToLocalRepo,
+                path: pathToLocalProject,
                 creationTime: Date.now(),
             });
 
@@ -120,7 +120,7 @@ describe('Bind projects tests', () => {
                 const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
                 const res = await projectService.uploadFile(
                     idMatchingNoProjects,
-                    pathToLocalRepo,
+                    pathToLocalProject,
                     'package.json',
                 );
                 res.should.have.status(404);

--- a/test/src/API/projects/projectlist.test.js
+++ b/test/src/API/projects/projectlist.test.js
@@ -22,7 +22,7 @@ describe('Project-list tests', function() {
         let originalProjectIDs;
         let projectID;
         const projectName = `projectlist${Date.now()}`;
-        const pathToLocalRepo = path.join(TEMP_TEST_DIR, projectName);
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
 
         it('should return a list of projectIDs', async function() {
             originalProjectIDs = await projectService.getProjectIDs();
@@ -31,7 +31,7 @@ describe('Project-list tests', function() {
 
         it('should create a project', async function() {
             this.timeout(testTimeout.med);
-            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs');
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject);
         });
 
         it('should return the same list but now including the extra projectID', async function() {
@@ -41,7 +41,7 @@ describe('Project-list tests', function() {
 
         it('should delete the extra project', async function() {
             this.timeout(testTimeout.med);
-            await projectService.removeProject(pathToLocalRepo, projectID);
+            await projectService.removeProject(pathToLocalProject, projectID);
         });
 
         it('should return the original list of projectIDs', async function() {

--- a/test/src/API/projects/uploadEnd.test.js
+++ b/test/src/API/projects/uploadEnd.test.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -292,7 +292,6 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             this.timeout(testTimeout.short);
             const projectID = '00000000-0000-0000-0000-000000000000';
             const options = {
-                // fileList: validFileList,
                 directoryList: validDirList,
                 modifiedList: null,
                 timeStamp: Date.now(),
@@ -306,7 +305,6 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             const projectID = '00000000-0000-0000-0000-000000000000';
             const options = {
                 fileList: validFileList,
-                // directoryList: validDirList,
                 modifiedList: null,
                 timeStamp: Date.now(),
             };
@@ -320,7 +318,6 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             const options = {
                 fileList: validFileList,
                 directoryList: validDirList,
-                // modifiedList: null,
                 timeStamp: Date.now(),
             };
             const res = await projectService.uploadEnd(projectID, options);
@@ -334,7 +331,6 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 fileList: validFileList,
                 directoryList: validDirList,
                 modifiedList: null,
-                // timeStamp: Date.now(),
             };
             const res = await projectService.uploadEnd(projectID, options);
             res.should.have.status(400);

--- a/test/src/API/projects/uploadEnd.test.js
+++ b/test/src/API/projects/uploadEnd.test.js
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+const chai = require('chai');
+const path = require('path');
+const fs = require('fs-extra');
+const chaiResValidator = require('chai-openapi-response-validator');
+
+const projectService = require('../../../modules/project.service');
+const containerService = require('../../../modules/container.service');
+const { testTimeout, TEMP_TEST_DIR, pathToApiSpec } = require('../../../config');
+
+chai.use(chaiResValidator(pathToApiSpec));
+chai.should();
+
+describe('Sync tests (POST projects/{id}/upload/end)', () => {
+    // These are for the nodejs template at https://github.com/codewind-resources/nodeExpressTemplate
+    const validFileList = [
+        '.cw-settings',
+        '.dockerignore',
+        '.gitignore',
+        'Dockerfile',
+        'Dockerfile-tools',
+        'chart/node/Chart.yaml',
+        'chart/node/templates/basedeployment.yaml',
+        'chart/node/templates/deployment.yaml',
+        'chart/node/templates/hpa.yaml',
+        'chart/node/templates/istio.yaml',
+        'chart/node/templates/service.yaml',
+        'chart/node/values.yaml',
+        'cli-config.yml',
+        'nodemon.json',
+        'package.json',
+        'public/404.html',
+        'public/500.html',
+        'public/index.html',
+        'server/config/local.json',
+        'server/routers/codewind.js',
+        'server/routers/health.js',
+        'server/routers/index.js',
+        'server/routers/public.js',
+        'server/server.js',
+        'test/test-demo.js',
+        'test/test-server.js',
+    ];
+    const validDirList = [
+        'chart',
+        'chart/node',
+        'chart/node/templates',
+        'public',
+        'server',
+        'server/config',
+        'server/routers',
+        'test',
+    ];
+
+    describe('Sync modified file (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-sync-modified-file-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        const pathFromDirToModifiedFile = 'server/routers/health.js';
+        let newFileContents;
+        let projectID;
+
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject);
+        });
+
+        before('modify a local file', function() {
+            this.timeout(testTimeout.med);
+            const filepath = path.join(pathToLocalProject, pathFromDirToModifiedFile);
+            const originalFileContents = fs.readFileSync(filepath);
+            newFileContents = `${originalFileContents}\nconsole.log('foo');\n`;
+            fs.writeFileSync(filepath, newFileContents);
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+
+        it('returns 200 when uploading the modified file', async function() {
+            this.timeout(testTimeout.med);
+            const res = await projectService.uploadFile(
+                projectID,
+                pathToLocalProject,
+                pathFromDirToModifiedFile,
+            );
+
+            res.should.have.status(200);
+            res.should.satisfyApiSpec;
+
+            const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToModifiedFile);
+            const fileExistsInPfeTempDir = await containerService.fileExists(pathToFileInPfeTempDir);
+            fileExistsInPfeTempDir.should.be.true;
+        });
+
+        it('returns 200 and correctly syncs the project when POST upload/end is called', async function() {
+            this.timeout(testTimeout.med);
+            const options = {
+                fileList: validFileList,
+                directoryList: validDirList,
+                modifiedList: [
+                    pathFromDirToModifiedFile,
+                ],
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+
+            res.should.have.status(200);
+            res.should.satisfyApiSpec;
+
+            const pathToFileInPfeProjectDir = path.join('codewind-workspace', projectName, pathFromDirToModifiedFile);
+            const contentsOfFileInPfeProjectDir = await containerService.readFile(pathToFileInPfeProjectDir);
+            contentsOfFileInPfeProjectDir.should.deep.equal(newFileContents);
+        });
+    });
+
+    describe('Sync new file (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-sync-new-file-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        const pathFromDirToNewFile = 'newFile.js';
+        const contentsOfNewFile = 'console.log(\'foo\');\n';
+        let projectID;
+
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject);
+        });
+
+        before('create a local file', function() {
+            this.timeout(testTimeout.med);
+            const filepath = path.join(pathToLocalProject, pathFromDirToNewFile);
+            fs.writeFileSync(filepath, contentsOfNewFile);
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+
+        it('returns 200 when uploading the new file', async function() {
+            this.timeout(testTimeout.med);
+            const res = await projectService.uploadFile(
+                projectID,
+                pathToLocalProject,
+                pathFromDirToNewFile,
+            );
+
+            res.should.have.status(200);
+            res.should.satisfyApiSpec;
+
+            const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToNewFile);
+            const fileExistsInPfeTempDir = await containerService.fileExists(pathToFileInPfeTempDir);
+            fileExistsInPfeTempDir.should.be.true;
+        });
+
+        it('returns 200 and correctly syncs the project when POST upload/end is called', async function() {
+            this.timeout(testTimeout.med);
+            const options = {
+                fileList: [
+                    ...validFileList,
+                    pathFromDirToNewFile,
+                ],
+                directoryList: validDirList,
+                modifiedList: [
+                    pathFromDirToNewFile,
+                ],
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+
+            res.should.have.status(200);
+            res.should.satisfyApiSpec;
+
+            const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToNewFile);
+            const fileExistsInPfeTempDir = await containerService.fileExists(pathToFileInPfeTempDir);
+            fileExistsInPfeTempDir.should.be.true;
+
+            const pathToFileInPfeProjectDir = path.join('codewind-workspace', projectName, pathFromDirToNewFile);
+            const contentsOfFileInPfeProjectDir = await containerService.readFile(pathToFileInPfeProjectDir);
+            contentsOfFileInPfeProjectDir.should.deep.equal(contentsOfNewFile);
+        });
+    });
+
+    describe('Sync deleted file (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-sync-deleted-file-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        const pathFromDirToDeletedFile = 'test/test-server.js'; // path must exist and not be ignored in /src/pfe/portal/modules/utils/ignoredPaths.js
+        let projectID;
+
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject);
+        });
+
+        before('delete a local file', function() {
+            this.timeout(testTimeout.med);
+            const filepath = path.join(pathToLocalProject, pathFromDirToDeletedFile);
+            fs.removeSync(filepath);
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+
+        it('returns 200 and correctly syncs the project when POST upload/end is called', async function() {
+            this.timeout(testTimeout.med);
+            const options = {
+                fileList: validFileList.filter(
+                    filepath => filepath !== pathFromDirToDeletedFile
+                ),
+                directoryList: validDirList,
+                modifiedList: null,
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+
+            res.should.have.status(200);
+            res.should.satisfyApiSpec;
+
+            const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToDeletedFile);
+            const fileExistsInPfeTempDir = await containerService.fileExists(pathToFileInPfeTempDir);
+            fileExistsInPfeTempDir.should.be.false;
+
+            const pathToFileInPfeProjectDir = path.join('codewind-workspace', projectName, pathFromDirToDeletedFile);
+            const fileExistsInPfeProjectDir = await containerService.fileExists(pathToFileInPfeProjectDir);
+            fileExistsInPfeProjectDir.should.be.false;
+        });
+    });
+
+    describe('Sync deleted dir (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-sync-deleted-dir-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        const pathFromDirToDeletedDir = 'test'; // path must exist and not be ignored in /src/pfe/portal/modules/utils/ignoredPaths.js
+        let projectID;
+
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject);
+        });
+
+        before('delete a local dir', function() {
+            this.timeout(testTimeout.med);
+            const dirpath = path.join(pathToLocalProject, pathFromDirToDeletedDir);
+            fs.removeSync(dirpath);
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+
+        it('returns 200 and correctly syncs the project when POST upload/end is called', async function() {
+            this.timeout(testTimeout.med);
+            const options = {
+                fileList: validFileList.filter(
+                    filepath => !filepath.startsWith('test/')
+                ),
+                directoryList: validDirList.filter(
+                    dirpath => dirpath !== pathFromDirToDeletedDir
+                ),
+                modifiedList: null,
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+
+            res.should.have.status(200);
+            res.should.satisfyApiSpec;
+
+            const pathToDirInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToDeletedDir);
+            const dirExistsInPfeTempDir = await containerService.dirExists(pathToDirInPfeTempDir);
+            dirExistsInPfeTempDir.should.be.false;
+
+            const pathToDirInPfeProjectDir = path.join('codewind-workspace', projectName, pathFromDirToDeletedDir);
+            const dirExistsInPfeProjectDir = await containerService.dirExists(pathToDirInPfeProjectDir);
+            dirExistsInPfeProjectDir.should.be.false;
+        });
+    });
+
+    describe('Fail cases for POST /upload/end', () => {
+        it('returns 400 when req.body has no `fileList`', async function() {
+            this.timeout(testTimeout.short);
+            const projectID = '00000000-0000-0000-0000-000000000000';
+            const options = {
+                // fileList: validFileList,
+                directoryList: validDirList,
+                modifiedList: null,
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+            res.should.have.status(400);
+        });
+
+        it('returns 400 when req.body has no `directoryList`', async function() {
+            this.timeout(testTimeout.short);
+            const projectID = '00000000-0000-0000-0000-000000000000';
+            const options = {
+                fileList: validFileList,
+                // directoryList: validDirList,
+                modifiedList: null,
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+            res.should.have.status(400);
+        });
+
+        it('returns 400 when req.body has no `modifiedList`', async function() {
+            this.timeout(testTimeout.short);
+            const projectID = '00000000-0000-0000-0000-000000000000';
+            const options = {
+                fileList: validFileList,
+                directoryList: validDirList,
+                // modifiedList: null,
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+            res.should.have.status(400);
+        });
+
+        it('returns 400 when req.body has no `timeStamp`', async function() {
+            this.timeout(testTimeout.short);
+            const projectID = '00000000-0000-0000-0000-000000000000';
+            const options = {
+                fileList: validFileList,
+                directoryList: validDirList,
+                modifiedList: null,
+                // timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(projectID, options);
+            res.should.have.status(400);
+        });
+
+        it('returns 404 when the project does not exist', async function() {
+            this.timeout(testTimeout.short);
+            const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
+            const options = {
+                fileList: validFileList,
+                directoryList: validDirList,
+                modifiedList: null,
+                timeStamp: Date.now(),
+            };
+            const res = await projectService.uploadEnd(idMatchingNoProjects, options);
+            res.should.have.status(404);
+        });
+    });
+});


### PR DESCRIPTION
Part of https://github.com/eclipse/codewind/issues/1716

Hopefully the commit messages split this PR into manageable chunks.

https://github.com/eclipse/codewind/commit/5e92a56ab0899a1b64dcb063e67239cfb3674d7a tests syncing a project when we modify a file, add a new one, delete one, and delete a directory. It also tests some basic 4XX fail cases. It corrects our openapi.yml.

Test output:
<img width="742" alt="image" src="https://user-images.githubusercontent.com/18170169/72623778-a0b18c00-393d-11ea-9054-64adb5fb04c2.png">


Signed-off-by: Richard Waller <Richard.Waller@ibm.com>