### PR TITLE
Cleanup docker-build agent workspace after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -432,6 +432,8 @@ pipeline {
               echo "Removing docker-compose"
               rm -rf $HOME/dc
             '''
+            echo 'Clean up workspace'
+            deleteDir() /* clean up our workspace */
         }
         failure {
           sh '''#!/usr/bin/env bash


### PR DESCRIPTION
In order to prevent 'no space' issue on the docker-build agent, clean up the workspace after a build. 