### PR TITLE
Initialise to empty array if null

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -205,8 +205,8 @@ async function uploadFile(req, res) {
  */
 router.post('/api/v1/projects/:id/upload/end', async (req, res) => {
   const projectID = req.sanitizeParams('id');
-  const keepFileList = req.sanitizeBody('fileList');
-  const keepDirList = req.sanitizeBody('directoryList');
+  const keepFileList = req.sanitizeBody('fileList') || [];
+  const keepDirList = req.sanitizeBody('directoryList') || [];
   const modifiedList = req.sanitizeBody('modifiedList') || [];
   const timeStamp = req.sanitizeBody('timeStamp');
   const IFileChangeEvent = [];


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

The directoryList in upload/end was being sent as null from the CLI because when we JSON marshal the request, empty arrays and set to null. This is an open issue here https://github.com/golang/go/issues/27589.

To work around this, I am initialising to an empty [].  