### PR TITLE
Initialise to an empty array

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1737,10 +1737,12 @@ components:
         fileList:
           description: an array of all files the project contains
           type: array
+          nullable: true
           example: ["/project/file1", "/project/file2", "project/modifiedfile1"]
         directoryList:
           description: an array of all directories the project contains
           type: array
+          nullable: true
           example: ["/project"]
         modifiedList:
           description: an array of files that have been modified since the last project upload

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -205,8 +205,8 @@ async function uploadFile(req, res) {
  */
 router.post('/api/v1/projects/:id/upload/end', validateReq, async (req, res) => {
   const projectID = req.sanitizeParams('id');
-  const keepFileList = req.sanitizeBody('fileList');
-  const keepDirList = req.sanitizeBody('directoryList');
+  const keepFileList = req.sanitizeBody('fileList') || [];
+  const keepDirList = req.sanitizeBody('directoryList') || [];
   const modifiedList = req.sanitizeBody('modifiedList') || [];
   const timeStamp = req.sanitizeBody('timeStamp');
   const IFileChangeEvent = [];


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

The directoryList in upload/end was being sent as null from the CLI because when we JSON marshal the request, empty arrays and set to null. This is an open issue here golang/go#27589.

To work around this, I am initialising to an empty [].

Also needed to update the api definition to allow fileList and directoryList to be nullable.