### PR TITLE
Add capabilitiesReady to project

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -168,7 +168,7 @@ module.exports = class FileWatcher {
         }
 
         case "projectCapabilitiesReady" : {
-          await this.handleFWProjectEvent('projectCapabilitiesReady', fwProject);
+          await this.handleCapabilitiesUpdated(fwProject);
           break;
         }
 
@@ -181,6 +181,20 @@ module.exports = class FileWatcher {
     });
   }
 
+  async handleCapabilitiesUpdated(fwProject) {
+    try {
+      const projectID = fwProject.projectID;
+      this.user.projectList.retrieveProject(projectID);
+      let projectUpdate = {
+        projectID: projectID,
+        capabilitiesReady: true
+      };
+      await this.user.projectList.updateProject(projectUpdate);
+      this.user.uiSocket.emit('projectChanged', projectUpdate);
+    } catch (err) {
+      log.error(err);
+    }
+  }
 
   async validateProject(project){
     const projectAction = {
@@ -523,6 +537,7 @@ module.exports = class FileWatcher {
         buildStatus: 'unknown',
         appStatus: 'unknown',
         state: Project.STATES.closed,
+        capabilitiesReady: false,
         detailedAppStatus: undefined
       }
       // Set the container key to '' as the container has stopped.

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -117,6 +117,7 @@ module.exports = class Project {
     if (args.hasOwnProperty('injectMetrics')) {
       this.injectMetrics = args.injectMetrics;
     }
+    this.capabilitiesReady = false;
   }
 
 
@@ -260,11 +261,9 @@ module.exports = class Project {
       throw new ProjectError('LOCK_FAILURE', this.name);
     }
     try {
-      // const currentSettings = await this.readSettingsFile();
-      // if (currentSettings.internalPort && currentSettings.internalPort != this.ports.internalPort) {
-      //   if (this.ports) this.ports.internalPort = currentSettings.internalPort;
-      // }
-      await fs.writeJson(infFile, this, { spaces: '  ' });
+      // Strip out capabilitiesReady as this shouldn't persist
+      const {capabilitiesReady, ...updatedProject } = this
+      await fs.writeJson(infFile, updatedProject, { spaces: '  ' });    
     } catch(err) {
       log.error(err);
     } finally {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

Projects will always be initialised with capabilitiesReady set to false, on creation and when loaded on startup. This field will only be set to true once the 'projectCapabilitiesReady' ready is received from Turbine. A 'projectChanged' event is then sent to the UI. The field will not be written to the project inf file.

When a project is disabled, the field will be set to false and included in the 'projectClosed' event that is sent to the UI.

Calls to GET /projects will include the new field.