### PR TITLE
DELETE /api/v1/imagepushregistry

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1489,6 +1489,62 @@ paths:
                     type: string
                     description: Message related to the request
                     example: Reason for failure
+    delete:
+      summary: Remove the specified Image Push Registry address
+      description: >
+        Removes the Image Push Registry namespace for the specified address
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - address
+              properties:
+                address:
+                  type: string
+      responses:
+        200:
+          description: Successfully completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: integer
+                    description: The response status code
+                    example: 200
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: integer
+                    description: The response status code
+                    example: 400
+                  msg:
+                    type: string
+                    description: Message related to the request
+                    example: Reason for failure
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  statusCode:
+                    type: integer
+                    description: The response status code
+                    example: 500
+                  msg:
+                    type: string
+                    description: Message related to the request
+                    example: Reason for failure
 
   /api/v1/extensions:
     get:

--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -295,17 +295,18 @@ export default class Filewatcher {
 
     /**
      * @function
-     * @description Write the provided workspace settings to the workspace settings file.
+     * @description Remove the image push registry from the workspace settings.
      * @param address  <Required | String>: Image Push Registry Address
      * @example await filewatcher.removeImagePushRegistry("docker.io");
      *
      * @returns Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>
      * Response codes:
-     *  @property 200: Successfully wrote the file
-     *  @property 500: Error when attempting to write the workspace settings file
+     *  @property 200: Successfully removed the image push registry
+     *  @property 400: Wrong request, no address found
+     *  @property 500: Error when attempting to remove the image push registry
      *
      */
-    removeImagePushRegistry: (address: string) => Promise<any>;
+    removeImagePushRegistry: (address: string) => Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>;
 
 
     /**

--- a/src/pfe/file-watcher/server/src/index.ts
+++ b/src/pfe/file-watcher/server/src/index.ts
@@ -293,6 +293,20 @@ export default class Filewatcher {
      */
     writeWorkspaceSettings: (address: string, namespace: string) => Promise<any>;
 
+    /**
+     * @function
+     * @description Write the provided workspace settings to the workspace settings file.
+     * @param address  <Required | String>: Image Push Registry Address
+     * @example await filewatcher.removeImagePushRegistry("docker.io");
+     *
+     * @returns Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure>
+     * Response codes:
+     *  @property 200: Successfully wrote the file
+     *  @property 500: Error when attempting to write the workspace settings file
+     *
+     */
+    removeImagePushRegistry: (address: string) => Promise<any>;
+
 
     /**
      * @function
@@ -672,6 +686,7 @@ export default class Filewatcher {
         this.setLoggingLevel = logger.setLoggingLevel;
         this.readWorkspaceSettings = workspaceSettings.readWorkspaceSettings;
         this.writeWorkspaceSettings = workspaceSettings.writeWorkspaceSettings;
+        this.removeImagePushRegistry = workspaceSettings.removeImagePushRegistry;
         this.testImagePushRegistry = workspaceSettings.testImagePushRegistry;
         this.registerListener = socket.registerListener;
         this.createProject = projectsController.createProject;

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -628,9 +628,6 @@ module.exports = class FileWatcher {
       log.error(`Error in removeImagePushRegistry`);
       throw err;
     }
-    if (retval.statusCode != 200) {
-      throw new Error(`removeImagePushRegistry ${retval.statusCode}`);
-    }
     return retval;
   }
 

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -619,6 +619,21 @@ module.exports = class FileWatcher {
     return retval;
   }
 
+  async removeImagePushRegistry(address) {
+    let retval;
+    try{
+      retval = await filewatcher.removeImagePushRegistry(address);
+      this.logFWReturnedMsg(retval);
+    } catch (err) {
+      log.error(`Error in removeImagePushRegistry`);
+      throw err;
+    }
+    if (retval.statusCode != 200) {
+      throw new Error(`removeImagePushRegistry ${retval.statusCode}`);
+    }
+    return retval;
+  }
+
 
   /**
    * Function to shutdown the user's projects

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -673,6 +673,22 @@ module.exports = class User {
   }
 
   /**
+   * Function to remove Image Push Registry
+   */
+  async removeImagePushRegistry(address) {
+    let retval;
+    try {
+      log.info(`Removing Image Push Registry from the workspace settings file.`);
+      retval = await this.fw.removeImagePushRegistry(address);
+    } catch (err) {
+      log.error(`Error in removeImagePushRegistry`);
+      throw err;
+    }
+    log.debug(`removeImagePushRegistry return value: ` + JSON.stringify(retval));
+    return retval;
+  }
+
+  /**
    * Function to get test image push registry
    */
   async testImagePushRegistry(address, namespace) {

--- a/src/pfe/portal/routes/imagePushRegistry.route.js
+++ b/src/pfe/portal/routes/imagePushRegistry.route.js
@@ -79,4 +79,26 @@ router.post('/api/v1/imagepushregistry', validateReq, async function (req, res) 
   }
 });
 
+/**
+ * API Function to delete the Image Push Registry
+ */
+router.delete('/api/v1/imagepushregistry', validateReq, async function (req, res) {
+  let retval;
+  try {
+    let user = req.cw_user;
+    log.debug(`DELETE /api/v1/imagepushregistry called`);
+    const address = req.sanitizeBody('address');
+
+    retval = await user.removeImagePushRegistry(address); 
+    res.status(retval.statusCode).send(retval);   
+  } catch (error) {
+    log.error(error);
+    const workspaceSettings = {
+      statusCode: 500,
+      msg: error.message
+    }
+    res.status(500).send(workspaceSettings);
+  }
+});
+
 module.exports = router;

--- a/src/pfe/portal/routes/imagePushRegistry.route.js
+++ b/src/pfe/portal/routes/imagePushRegistry.route.js
@@ -93,11 +93,11 @@ router.delete('/api/v1/imagepushregistry', validateReq, async function (req, res
     res.status(retval.statusCode).send(retval);   
   } catch (error) {
     log.error(error);
-    const workspaceSettings = {
+    const retval = {
       statusCode: 500,
       msg: error.message
     }
-    res.status(500).send(workspaceSettings);
+    res.status(500).send(retval);
   }
 });
 


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

Issue #1746 

This PR introduces a delete route for image push registry to clear it, when the user deletes the registry from the UI.