### PR TITLE
Handle Health Check setting on Create

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -269,6 +269,7 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
                 settings.contextRoot = settings.contextRoot.replace(/^\/+/, "").replace(/\/+$/, "");
                 projectInfo.contextRoot = "/" + settings.contextRoot.trim();
             } else if (key == "healthCheck" && settings.healthCheck && settings.healthCheck.trim().length > 0) {
+                settings.healthCheck = settings.healthCheck.replace(/^\/+/, "").replace(/\/+$/, "");
                 projectInfo.healthCheck = "/" + settings.healthCheck.trim();
             } else if (key == "mavenProfiles") {
                 const mavenProfiles = settings.mavenProfiles;


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

For Issue #1839 

There was an issue with the `healthCheck` setting:
```
[root@b7ff9011272e /]# cat /file-watcher/fwdata/projects/default-liberty-1579813074522/default-liberty-1579813074522.json 
{"projectID":"default-liberty-1579813074522","projectType":"liberty","location":"/codewind-workspace/turbinetest-default-liberty","autoBuildEnabled":true,"startMode":"run","appPorts":["9080"],"language":"liberty","debugPort":"7777","ignoredPaths":["/.project","/Dockerfile-tools","/target","/mc-target","/cli-config.yml","/README.md","/Jenkinsfile","/.cfignore","/load-test*","*/node_modules*","*/.git/*","*/.DS_Store","*/*.swp","*/*.swx","*/4913","*/.dockerignore","*/.gitignore","*/*~","/.settings","/localm2cache.zip","/libertyrepocache.zip"],"statusPingTimeout":30,"isHttps":false,"contextRoot":"/","healthCheck":"//"}
```