### PR TITLE
Delete project files from cw-temp on Project unbind

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -469,6 +469,15 @@ module.exports = class User {
       projectID: projectID,
       status: 'success'
     };
+
+    // Delete files from PFE's /codewind-workspace/cw-temp/<project> location
+    const cwTempPath = path.join(project.workspace, "cw-temp", project.directory);
+    try {
+      await cwUtils.forceRemove(cwTempPath);
+    } catch (err) {
+      log.info(`Unable to delete temp files from ${cwTempPath}`)
+    }
+
     // Stop streaming the logs files.
     project.stopStreamingAllLogs();
     // If the project is closed or validating or of unknown language

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -470,14 +470,6 @@ module.exports = class User {
       status: 'success'
     };
 
-    // Delete files from PFE's /codewind-workspace/cw-temp/<project> location
-    const cwTempPath = path.join(project.workspace, "cw-temp", project.directory);
-    try {
-      await cwUtils.forceRemove(cwTempPath);
-    } catch (err) {
-      log.info(`Unable to delete temp files from ${cwTempPath}`)
-    }
-
     // Stop streaming the logs files.
     project.stopStreamingAllLogs();
     // If the project is closed or validating or of unknown language
@@ -557,6 +549,16 @@ module.exports = class User {
     } catch (err) {
       // Log file could be missing if the project never built.
     }
+
+    // Delete temp files from PFE's /codewind-workspace/cw-temp/<project> location
+    const cwTempPath = path.join(project.workspace, "cw-temp", project.directory);
+    try {
+      await cwUtils.forceRemove(cwTempPath);
+    } catch (err) {
+      log.error(`Unable to delete temp files from ${cwTempPath}`)
+      log.error(err);
+    }
+
   }
 
 


### PR DESCRIPTION
## Problem

Error seen in logs : Error: EEXIST: file already exists thrown by mkdir /codewind-workspace/cw-temp/<project>   reported in issue #1723

## Solution 

PFE was not removing the project files from /codewind-workspace/cw-temp/<project> when unbinding. 

This PR removes the files to avoid a future collision. 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>