### PR TITLE
Install cwctl version based on passed argument instead of always master

### DIFF
--- a/src/pfe/file-watcher/server/test/scripts/exec.sh
+++ b/src/pfe/file-watcher/server/test/scripts/exec.sh
@@ -45,7 +45,12 @@ function downloadCwctl() {
         extension="linux"
     fi
     echo "Extension is $extension"
-    curl -X GET http://download.eclipse.org/codewind/codewind-installer/master/latest/cwctl-$extension --output $EXECUTABLE_NAME
+    if [ ! -z $TURBINE_PERFORMANCE_TEST ]; then
+        CWCTL_INSTALL_TARGET="$TURBINE_PERFORMANCE_TEST"
+    else
+        CWCTL_INSTALL_TARGET="master"
+    fi
+    curl -X GET http://download.eclipse.org/codewind/codewind-installer/$CWCTL_INSTALL_TARGET/latest/cwctl-$extension --output $EXECUTABLE_NAME
     checkExitCode $? "Failed to download latest installer."
 
     echo -e "${BLUE}>> Giving executable permission to installer ... ${RESET}"


### PR DESCRIPTION
### Description

We should install cwctl for our tests based on the passed argument instead of always master. This was seen when doing performance test on 0.8.0 and the cwctl project create command had a different syntax to compared to what master has and the performance test broke.

Signed-off-by: ssh24 <sakib@ibm.com>