### PR TITLE
fix: handle java projects as java projects not nodejs

### DIFF
--- a/src/performance/monitor/service.js
+++ b/src/performance/monitor/service.js
@@ -69,7 +69,7 @@ const scrapeProjectData = async (appOrigin, projectLanguage) => {
   if (!latestProjectData.hasOwnProperty(appOrigin)) {
     latestProjectData[appOrigin] = {};
   }
-  if (projectLanguage === 'nodejs' || 'javascript') {
+  if (['nodejs', 'javascript'].includes(projectLanguage)) {
     return scrapeNodejsProjectData(appOrigin);
   }
   await repeatFunc(


### PR DESCRIPTION
fix for https://github.com/eclipse/codewind/issues/1844

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

I believe the bug was in this block, introduced in https://github.com/eclipse/codewind/pull/1759/files#diff-7f084b029855d7ae4861028936470cb5R72. The string `'javascript'` is truthy, so `projectLanguage === 'nodejs' || 'javascript'` will always evaluate to `true`, so for all projects (including open liberty) the performance container was trying to `scrapeNodejsProjectData`. That function makes requests that succeed against node.js projects but fail on other projects, including open liberty.

Anyone could have made the little slip that introduced this bug, and to prevent future slips I recommend we schedule a little time to write a test for our metrics (app monitor and metrics injection) story.

I will follow this PR up with another that adds logging in the performance container, especially around this functionality.