### PR TITLE
fix: stop logging req.body as res.body

### DIFF
--- a/src/pfe/portal/modules/utils/Logger.js
+++ b/src/pfe/portal/modules/utils/Logger.js
@@ -94,13 +94,7 @@ class Logger {
   logResponse(req, res) {
     res.on('finish', () => {
       const route = `${req.method} ${req.path}`;
-      // We are removing credentials from req body because
-      // POST /api/v1/registrysecrets takes credentials in its body
-      // and we do not want to log this information to the PFE log
-      const {credentials, ...reqBodyWithoutCredentials} = res.req.body;
-      const reqBody = util.inspect(reqBodyWithoutCredentials);
-
-      this.log.trace(`responded to ${route} with status ${res.statusCode} and body ${reqBody}`);
+      this.log.trace(`responded to ${route} with status ${res.statusCode}`);
     });
   }
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

We were mistakenly logging the request body as the response body. Logging the response body is not trivial (see https://stackoverflow.com/questions/19215042/express-logging-response-body) and we already log.trace the request body on every request, so for now I am just shortening the log message on responses