### PR TITLE
Allow handling of app status for server less applications

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -18,6 +18,7 @@ import * as projectExtensions from "../extensions/projectExtensions";
 import { actionMap } from "../projects/actions";
 import { ContainerStates } from "../projects/constants";
 import { ProjectInfo } from "../projects/Project";
+import * as constants from "../projects/constants";
 
 export enum STATE_TYPES {
     appState = "appState",
@@ -491,7 +492,7 @@ function pingInTransitApplications(): void {
                                             pingCount = 1;
                                         }
                                     }
-                                } else if (((oldState === AppState.stopping) || (oldState === AppState.starting)) && newMsg) {
+                                } else if ((oldState === AppState.stopping) || (projectInfo.appPorts.includes(constants.serverLessAppPort)) && newMsg) {
                                     newState = AppState.stopped;
                                     pingCountMap.delete(projectID);
                                 }

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -491,7 +491,7 @@ function pingInTransitApplications(): void {
                                             pingCount = 1;
                                         }
                                     }
-                                } else if (oldState === AppState.stopping && newMsg) {
+                                } else if (((oldState === AppState.stopping) || (oldState === AppState.starting)) && newMsg) {
                                     newState = AppState.stopped;
                                     pingCountMap.delete(projectID);
                                 }

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -492,7 +492,7 @@ function pingInTransitApplications(): void {
                                             pingCount = 1;
                                         }
                                     }
-                                } else if ((oldState === AppState.stopping) || (projectInfo.appPorts.includes(constants.serverLessAppPort)) && newMsg) {
+                                } else if ((oldState === AppState.stopping) || (projectInfo.appPorts.includes(constants.disablePingPort)) && newMsg) {
                                     newState = AppState.stopped;
                                     pingCountMap.delete(projectID);
                                 }

--- a/src/pfe/file-watcher/server/src/projects/constants.ts
+++ b/src/pfe/file-watcher/server/src/projects/constants.ts
@@ -36,3 +36,5 @@ export enum StartModes { run = "run", debug = "debug", debugNoInit = "debugNoIni
 export enum ControlCommands { stop = "stop", start = "start", restart = "restart" }
 
 export enum MavenFlags { profile = "-P ", properties = "-D " }
+
+export const serverLessAppPort = "-1";

--- a/src/pfe/file-watcher/server/src/projects/constants.ts
+++ b/src/pfe/file-watcher/server/src/projects/constants.ts
@@ -37,4 +37,4 @@ export enum ControlCommands { stop = "stop", start = "start", restart = "restart
 
 export enum MavenFlags { profile = "-P ", properties = "-D " }
 
-export const serverLessAppPort = "-1";
+export const disablePingPort = "-1";

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -18,6 +18,7 @@ import * as projectExtensions from "../extensions/projectExtensions";
 import * as projectUtil from "./projectUtil";
 import { Operation } from "./operation";
 import * as io from "../utils/socket";
+import * as constants from "./constants";
 const xss = require("xss"); // tslint:disable-line:no-require-imports
 
 export const specificationSettingMap = new Map<string, (args: any, operation: Operation) => any>();
@@ -195,7 +196,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             }
         }
 
-        if (isContainerRunning && !isApplicationPortExposed) {
+        if (isContainerRunning && !isApplicationPortExposed && applicationPort != constants.serverLessAppPort) {
             logger.logProjectInfo("The requested application port is not exposed: " + applicationPort, projectInfo.projectID);
             const data: ProjectSettingsEvent = {
                 operationId: operation.operationId,

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -196,7 +196,7 @@ const changeInternalPort = async function (applicationPort: string, operation: O
             }
         }
 
-        if (isContainerRunning && !isApplicationPortExposed && applicationPort != constants.serverLessAppPort) {
+        if (isContainerRunning && !isApplicationPortExposed && applicationPort != constants.disablePingPort) {
             logger.logProjectInfo("The requested application port is not exposed: " + applicationPort, projectInfo.projectID);
             const data: ProjectSettingsEvent = {
                 operationId: operation.operationId,

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -987,7 +987,7 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
         }
 
         if (projectInfo.appPorts.includes(constants.serverLessAppPort)) {
-            logger.logInfo(`Found app port set to ${constants.serverLessAppPort} for server less project ${projectInfo.projectID}`);
+            logger.logProjectInfo(`App port set to ${constants.serverLessAppPort}. This indicates ${projectID} is a server less application.`, projectID);
             handler({ error: await locale.getTranslation("projectUtil.serverLessApp") });
             return;
         }

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -986,9 +986,8 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
             return;
         }
 
-        if (projectInfo.appPorts.includes(constants.serverLessAppPort)) {
-            logger.logProjectInfo(`App port set to ${constants.serverLessAppPort}. This indicates ${projectID} is a server less application.`, projectID);
-            handler({ error: await locale.getTranslation("projectUtil.serverLessApp") });
+        if (projectInfo.appPorts.includes(constants.disablePingPort)) {
+            handler({ error: await locale.getTranslation("projectUtil.pingDisabled", { disablePingPort: constants.disablePingPort }) });
             return;
         }
 

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -40,6 +40,7 @@ import { AppLog, BuildLog, BuildRequest, ProjectInfo, UpdateProjectInfoPair } fr
 import { projectConstants, ContainerStates, StartModes, MavenFlags } from "./constants";
 import * as locale from "../utils/locale";
 import { appStateMap, DetailedAppStatus } from "../controllers/projectStatusController";
+import * as constants from "./constants";
 
 const Client = require("kubernetes-client").Client; // tslint:disable-line:no-require-imports
 const config = require("kubernetes-client").config; // tslint:disable-line:no-require-imports
@@ -982,6 +983,12 @@ export async function isApplicationUp(projectID: string, handler: any): Promise<
         const projectInfo = await getProjectInfo(projectID, ignoreLog);
         if (!projectInfo) {
             handler({ error: await locale.getTranslation("projectUtil.projectInfoError") });
+            return;
+        }
+
+        if (projectInfo.appPorts.includes(constants.serverLessAppPort)) {
+            logger.logInfo(`Found app port set to ${constants.serverLessAppPort} for server less project ${projectInfo.projectID}`);
+            handler({ error: await locale.getTranslation("projectUtil.serverLessApp") });
             return;
         }
 

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -75,6 +75,7 @@
   },
   "projectUtil": {
     "projectInfoError": "could not retrieve project info",
+    "serverLessApp": "server less application found. app status set to stopped",
     "pingMessage": "Pinging http://{{ip}}:{{port}}{{- path}}",
     "defaultPingPathMessage": "Pinging http://{{ip}}:{{port}}{{- path}} and http://{{ip}}:{{port}}/",
     "appStatusError": {

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -75,7 +75,7 @@
   },
   "projectUtil": {
     "projectInfoError": "could not retrieve project info",
-    "serverLessApp": "server less application detected. app status set to stopped",
+    "pingDisabled": "The port is set to {{disablePingPort}}, pinging is disabled and the app status is set to stopped.",
     "pingMessage": "Pinging http://{{ip}}:{{port}}{{- path}}",
     "defaultPingPathMessage": "Pinging http://{{ip}}:{{port}}{{- path}} and http://{{ip}}:{{port}}/",
     "appStatusError": {

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -75,7 +75,7 @@
   },
   "projectUtil": {
     "projectInfoError": "could not retrieve project info",
-    "serverLessApp": "server less application found. app status set to stopped",
+    "serverLessApp": "server less application detected. app status set to stopped",
     "pingMessage": "Pinging http://{{ip}}:{{port}}{{- path}}",
     "defaultPingPathMessage": "Pinging http://{{ip}}:{{port}}{{- path}} and http://{{ip}}:{{port}}/",
     "appStatusError": {


### PR DESCRIPTION
Closes https://github.com/eclipse/codewind/issues/1862

### Description
Add function to Turbine so that if the port on cw-settings is set to a special value, e.g. -1, it indicates that the app does not have a port for ping so it will not cause error on PFE on failing to ping.