### PR TITLE
Add Code Coverage for PFE into Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
 
         stage('Run Turbine unit test suite') {
             options {
-                timeout(time: 30, unit: 'MINUTES') 
+                timeout(time: 30, unit: 'MINUTES')
             }
             steps {
                 withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]) {
@@ -195,6 +195,22 @@ pipeline {
 
                             if [ $? -eq 0 ]; then
                                 echo "+++   SUCCESSFULLY BUILT $IMAGE_NAME   +++";
+
+                                echo -e "\n+++   RETAGGING $IMAGE_NAME TO HAVE TAG:':test' FOR TEST ONLY MODIFICATIONS +++\n";
+                                # Allows us to modify the Docker images for test only modifications
+                                # Such as telling PFE to run with Code Coverage generation enabled 
+                                # The original image (latest) will be the one that is pushed to Dockerhub
+
+                                if [ "$image" = "$PFE" ]; then
+                                    # Now overwrite the PFE image ':test' tag with new changes
+                                    echo -e "FROM eclipse/codewind-pfe-amd64:latest\nENV ENABLE_CODE_COVERAGE=true" >> pfe-test-dockerfile
+                                    cat pfe-test-dockerfile
+                                    docker build -t eclipse/codewind-pfe-amd64:test -f pfe-test-dockerfile .
+                                    rm pfe-test-dockerfile
+                                else
+                                    docker tag eclipse/codewind-${image}-${IMAGE_ARCH}:latest eclipse/codewind-${image}-${IMAGE_ARCH}:test
+                                fi
+
                             else
                                 echo "+++   FAILED TO BUILD $IMAGE_NAME - exiting.   +++";
                                 exit 12;
@@ -245,6 +261,9 @@ pipeline {
                         BUILT_PFE_IMAGE_ID=$(docker images --filter=reference=eclipse/codewind-pfe-amd64:latest --format "{{.ID}}")
                         echo "PFE Image: $BUILT_PFE_IMAGE_ID"
 
+                        # Set image tag to test
+                        export CWCTL_IMAGE_TAG=test
+
                         # Start Codewind
                         sh $DIR/start.sh
                         if [ $? -ne 0 ]; then
@@ -282,6 +301,33 @@ pipeline {
                 }
             }
         } 
+
+        stage('Output Code Coverage for PFE (Portal API and Unit tests, File-watcher Unit tests only)') {
+            options {
+                timeout(time: 30, unit: 'MINUTES')
+            }
+            steps {
+                withEnv(["PATH=$PATH:~/.local/bin;NOBUILD=true"]) {
+                    withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
+                        sh '''#!/usr/bin/env bash
+                            DIR=`pwd`;
+
+                            docker image inspect eclipse/codewind-pfe-amd64:test -f '{{.Config.Env}}' | grep ENABLE_CODE_COVERAGE=true
+                            if [ $? -eq 0 ]; then
+                                echo "Code coverage enabled in eclipse/codewind-pfe-amd64:test (image)"
+                            fi
+
+                            docker inspect -f '{{.Config.Env}}' codewind-pfe | grep ENABLE_CODE_COVERAGE=true
+                            if [ $? -eq 0 ]; then
+                                echo "Code coverage enabled in codewind-pfe (container)"
+                            fi
+
+                            FW_COVERAGE_ENABLED=true node $DIR/test/scripts/generate_complete_coverage.js
+                            '''
+                    }
+                }
+            }
+        }
         
         stage('Publish Docker images') {
 
@@ -408,7 +454,7 @@ pipeline {
                   printf "\n${RED}Error removing docker network $RESET\n";
               fi
 
-              # Remove the default network 
+              # Remove the default network
               printf "\nRemoving docker network\n";
               docker network rm codewind_default
               if [ $? -eq 0 ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,7 +204,6 @@ pipeline {
                                 if [ "$image" = "$PFE" ]; then
                                     # Now overwrite the PFE image ':test' tag with new changes
                                     echo -e "FROM eclipse/codewind-pfe-amd64:latest\nENV ENABLE_CODE_COVERAGE=true" >> pfe-test-dockerfile
-                                    cat pfe-test-dockerfile
                                     docker build -t eclipse/codewind-pfe-amd64:test -f pfe-test-dockerfile .
                                     rm pfe-test-dockerfile
                                 else

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -311,6 +311,13 @@ pipeline {
                     withDockerRegistry([url: 'https://index.docker.io/v1/', credentialsId: 'docker.com-bot']) {
                         sh '''#!/usr/bin/env bash
                             DIR=`pwd`;
+                            export PATH=$PATH:/home/jenkins/.jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/node_js/bin/
+
+                            # Install nvm to easily set version of node to use
+                            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+                            export NVM_DIR="$HOME/.nvm" 
+                            . $NVM_DIR/nvm.sh
+                            nvm i 10
 
                             docker image inspect eclipse/codewind-pfe-amd64:test -f '{{.Config.Env}}' | grep ENABLE_CODE_COVERAGE=true
                             if [ $? -eq 0 ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -408,7 +408,7 @@ pipeline {
                   printf "\n${RED}Error removing docker network $RESET\n";
               fi
 
-              # Remove the default network
+              # Remove the default network 
               printf "\nRemoving docker network\n";
               docker network rm codewind_default
               if [ $? -eq 0 ]; then

--- a/start.sh
+++ b/start.sh
@@ -62,13 +62,18 @@ if [ -n "$LOG_LEVEL" ]; then
   LOG_OPTION="--loglevel ${LOG_LEVEL}"
 fi
 
+if [ -n "$CWCTL_IMAGE_TAG" ]; then
+  echo "Setting image tag to ${CWCTL_IMAGE_TAG}"
+  IMAGE_TAG="--tag ${CWCTL_IMAGE_TAG}"
+fi
+
 # REMOVE PREVIOUS DOCKER PROCESSES FOR CODEWIND
 printf "\n\n${BLUE}REMOVING EXISTING CODEWIND DOCKER CONTAINERS $RESET\n";
 # Check for existing processes (stopped or running)
 $CWCTL stop-all
 
 printf "\n\n${BLUE}STARTING CODEWIND DOCKER CONTAINERS $RESET\n";
-$CWCTL $LOG_OPTION start --debug
+$CWCTL $LOG_OPTION start --debug $IMAGE_TAG
 
 if [ $? -eq 0 ]; then
   printf "\n\n${GREEN}SUCCESSFULLY STARTED CONTAINERS $RESET\n";

--- a/test/package.json
+++ b/test/package.json
@@ -4,9 +4,9 @@
   "description": "Test material for Codewind",
   "main": "index.js",
   "scripts": {
-    "test": "scripts/mocha.sh src/API src/unit",
+    "test": "ENABLE_COVERAGE=true scripts/mocha.sh src/API src/unit",
     "integrationtest": "scripts/mocha.sh src/integration",
-    "unittest": "scripts/mocha.sh src/unit",
+    "unittest": "ENABLE_COVERAGE=true scripts/mocha.sh src/unit",
     "apitest": "scripts/mocha.sh src/API",
     "eslint": "eslint src/**/*.js"
   },
@@ -45,6 +45,7 @@
     "mocha-multi-reporters": "^1.1.7",
     "mocha-sinon": "^2.1.0",
     "nyc": "^15.0.0",
+    "package.json": "^2.0.1",
     "path": "^0.12.7",
     "read-each-line-sync": "^1.0.5",
     "rewire": "^4.0.1",

--- a/test/package.json
+++ b/test/package.json
@@ -45,7 +45,6 @@
     "mocha-multi-reporters": "^1.1.7",
     "mocha-sinon": "^2.1.0",
     "nyc": "^15.0.0",
-    "package.json": "^2.0.1",
     "path": "^0.12.7",
     "read-each-line-sync": "^1.0.5",
     "rewire": "^4.0.1",

--- a/test/scripts/mocha.sh
+++ b/test/scripts/mocha.sh
@@ -17,16 +17,25 @@
 start=$(date +%F_%T)
 echo "Tests started at ${start}"
 
+NYC_CMD=''
+if [ "$ENABLE_COVERAGE" = "true" ]; then
+    echo "Running with code coverage enabled"
+    NYC_CMD=node_modules/.bin/nyc
+fi
+
 cp -r ../docs ../src/pfe/portal/docs
 if [ $? != 0 ]; then
     echo "Error copying docs directory to Portal directory (openapi.yaml)"
     exit 1;
 fi
 
-node_modules/.bin/nyc node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
+$NYC_CMD node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
 rc=$?
 end=$(date +%F_%T)
 echo "\nTests finished at ${end}"
-echo "\nView coverage report in browser at ${PWD}/coverage/index.html\n"
+
+if [ "$ENABLE_COVERAGE" = "true" ]; then
+    echo "\nView coverage report in browser at ${PWD}/coverage/index.html\n"
+fi
 
 exit $rc


### PR DESCRIPTION
Proof that the code coverage is the same as the Toby/Liam branch: https://github.com/tobespc/codewind/compare/liam...james-wallis:add-code-coverage-jenkins?expand=1

Use the test passing and failing from the #1606 branch as these will not run with the updated Jenkinsfile.

### Summary
* Added functionality to generate the code coverage for PFE unit and API tests in Jenkins, also optionally the file-watcher unit test coverage.
  * Had to enhance the `generate_complete_coverage.js` file to report the file-watcher code optionally.
  * Uses images with the tag `:test` as the PFE needs a change to run code coverage, doing it this way means that the original images `:latest` will be pushed without changes made for testing.
* Made the running of code coverage optional
  * Stops it being run when developing if wanted
  * Fixed bug in Jenkins where the `apitest` run would overwrite the previous `unittest` run. In the future this fix might need to be more complex (i.e. different `.nyc_output` directories) but for now this is fine. - We don't care about the `apitest` local `.nyc_output` as the code coverage is inside the container.

### Testing
* Ran the Jenkins test
* Ran the Portal tests locally to ensure nothing changed there and the generate coverage script too.