### PR TITLE
test: test project unbind; extend bind tests

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -517,6 +517,10 @@ paths:
         responses:
           202:
             description: if project deletion was accepted
+            content:
+              text/html:
+                schema:
+                  type: string
           404:
             description: if the project with id was not found
           409:

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -116,11 +116,7 @@ async function bindStart(req, res) {
     if (err.code === 'INVALID_PROJECT_NAME'){
       res.status(400).send(err.info);
     } else {
-      let errorMessage = ""
-      if (err) {
-        errorMessage = err.info || err
-      }
-      res.status(500).send(`Project bind failed ${errorMessage}`);
+      res.status(500).send(`Project bind failed ${err.info || err}`);
     }
     log.error(err);
     return;
@@ -456,7 +452,9 @@ async function bindEnd(req, res) {
  * @return 404 if the project with id was not found
  * @return 409 if unbind was already in progress
  */
-router.post('/api/v1/projects/:id/unbind', validateReq, async function (req, res) {
+router.post('/api/v1/projects/:id/unbind', validateReq, unbind);
+
+async function unbind(req, res) {
   const user = req.cw_user;
   // Null checks on projectID done by validateReq.
   const projectID = req.sanitizeParams('id');
@@ -485,6 +483,6 @@ router.post('/api/v1/projects/:id/unbind', validateReq, async function (req, res
     user.uiSocket.emit('projectDeletion', data);
     log.error(`Error deleting project: ${util.inspect(data)}`);
   }
-});
+}
 
 module.exports = router;

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -145,7 +145,7 @@ function zipFileToBase64(filepath) {
  * @param {JSON} [options] e.g. { name: 'example' }
  * @param {number} [expectedResStatus] default 202
  */
-async function unbindProject(projectID, expectedResStatus = 202) {
+async function unbind(projectID, expectedResStatus = 202) {
     const req = () => reqService.chai
         .post(`/api/v1/projects/${projectID}/unbind`)
         .set('Cookie', ADMIN_COOKIE);
@@ -158,7 +158,7 @@ async function unbindProject(projectID, expectedResStatus = 202) {
  */
 async function unbindAllProjects() {
     const projectIds = await getProjectIDs();
-    const promises = projectIds.map(id => unbindProject(id));
+    const promises = projectIds.map(id => unbind(id));
     await Promise.all(promises);
 }
 
@@ -213,7 +213,7 @@ function closeProject(
 
 async function removeProject(pathToProjectDir, projectID){
     fs.removeSync(pathToProjectDir);
-    await unbindProject(projectID);
+    await unbind(projectID);
 }
 
 /**
@@ -409,7 +409,7 @@ module.exports = {
     uploadEnd,
     uploadFiles,
     uploadFile,
-    unbindProject,
+    unbind,
     unbindAllProjects,
     removeProject,
     buildProject,

--- a/test/src/API/projects/bind.test.js
+++ b/test/src/API/projects/bind.test.js
@@ -12,6 +12,7 @@
 
 const chai = require('chai');
 const path = require('path');
+const fs = require('fs-extra');
 const chaiResValidator = require('chai-openapi-response-validator');
 
 const projectService = require('../../../modules/project.service');
@@ -34,12 +35,12 @@ describe('Bind projects tests', () => {
         );
     });
 
-    after(async function() {
+    after(function() {
         this.timeout(testTimeout.med);
-        await projectService.removeProject(pathToLocalProject, projectID);
+        fs.removeSync(pathToLocalProject);
     });
 
-    describe('Complete bind (these `it` blocks depend on each other passing)', () => {
+    describe('Complete bind and unbind (these `it` blocks depend on each other passing)', () => {
         it('returns 202 when starting the bind process', async function() {
             this.timeout(testTimeout.med);
 
@@ -53,6 +54,10 @@ describe('Bind projects tests', () => {
 
             res.should.have.status(202);
             res.should.satisfyApiSpec;
+            
+            const pathToPfeTempProjectDir = path.join('codewind-workspace', 'cw-temp', projectName);
+            const pfeTempProjectDirExists = await containerService.dirExists(pathToPfeTempProjectDir);
+            pfeTempProjectDirExists.should.be.true;
 
             projectID = res.body.projectID;
         });
@@ -70,11 +75,21 @@ describe('Bind projects tests', () => {
             uploadedFileExists.should.be.true;
         });
         it('returns 200 when ending the bind process', async function() {
+            this.timeout(testTimeout.short);
+            
             const res = await projectService.bindEnd(projectID);
             res.should.have.status(200);
             res.should.satisfyApiSpec;
+            
+            const pathToPfeTempProjectDir = path.join('codewind-workspace', 'cw-temp', projectName);
+            const pfeTempProjectDirExists = await containerService.dirExists(pathToPfeTempProjectDir);
+            pfeTempProjectDirExists.should.be.true;
+            
+            const pathToPfeProjectDir = path.join('codewind-workspace', projectName);
+            const pfeProjectDirExists = await containerService.dirExists(pathToPfeProjectDir);
+            pfeProjectDirExists.should.be.true;
         });
-        it('returns 409 when trying to bind a project that is already bound', async function() {
+        it('returns 409 when trying to bind a project with the same name', async function() {
             const originalNumProjects = await projectService.countProjects();
             const res = await projectService.bindStart({
                 name: projectName,
@@ -90,17 +105,35 @@ describe('Bind projects tests', () => {
             const finalNumProjects = await projectService.countProjects();
             finalNumProjects.should.equal(originalNumProjects);
         });
+        it('returns 202 when unbinding the project', async function() {
+            this.timeout(testTimeout.short);
+            
+            const res = await projectService.unbind(projectID);
+            res.should.have.status(202);
+            res.should.satisfyApiSpec;
+            
+            const pathToPfeTempProjectDir = path.join('codewind-workspace', 'cw-temp', projectName);
+            const pfeTempProjectDirExists = await containerService.dirExists(pathToPfeTempProjectDir);
+            pfeTempProjectDirExists.should.be.false;
+            
+            const pathToPfeProjectDir = path.join('codewind-workspace', projectName);
+            const pfeProjectDirExists = await containerService.dirExists(pathToPfeProjectDir);
+            pfeProjectDirExists.should.be.false;
+        });
     });
     describe('POST /bind/start', () => {
         describe('Failure Cases', () => {
             it('returns 400 if projectName is invalid', async function() {
                 this.timeout(testTimeout.short);
                 const res = await projectService.bindStart({
-                    name: '<',
+                    name: '&',
                     language: 'nodejs',
                     projectType: 'nodejs',
+                    path: 'valid/path',
+                    creationTime: Date.now(),
                 });
                 res.should.have.status(400);
+                res.body.message.should.equal('Project name is invalid: invalid characters : ["&"]');
             });
             it('returns 400 if projectType is invalid', async function() {
                 this.timeout(testTimeout.short);
@@ -108,8 +141,11 @@ describe('Bind projects tests', () => {
                     name: projectName,
                     language: 'nodejs',
                     projectType: 'invalid',
+                    path: 'valid/path',
+                    creationTime: Date.now(),
                 });
                 res.should.have.status(400);
+                res.text.should.equal('projects must specify a valid project type');
             });
         });
     });
@@ -134,6 +170,18 @@ describe('Bind projects tests', () => {
                 const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
                 const res = await projectService.bindEnd(idMatchingNoProjects);
                 res.should.have.status(404);
+                res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
+            });
+        });
+    });
+    describe('POST /unbind', () => {
+        describe('Failure Cases', () => {
+            it('returns 404 for a project that does not exist', async function() {
+                this.timeout(testTimeout.short);
+                const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
+                const res = await projectService.unbind(idMatchingNoProjects, 404);
+                res.should.have.status(404);
+                res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
             });
         });
     });

--- a/test/src/API/projects/uploadEnd.test.js
+++ b/test/src/API/projects/uploadEnd.test.js
@@ -298,6 +298,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
             res.should.have.status(400);
+            res.text.should.equal('Error while validating request: request.body should have required property \'fileList\'');
         });
 
         it('returns 400 when req.body has no `directoryList`', async function() {
@@ -310,6 +311,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
             res.should.have.status(400);
+            res.text.should.equal('Error while validating request: request.body should have required property \'directoryList\'');
         });
 
         it('returns 400 when req.body has no `modifiedList`', async function() {
@@ -322,6 +324,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
             res.should.have.status(400);
+            res.text.should.equal('Error while validating request: request.body should have required property \'modifiedList\'');
         });
 
         it('returns 400 when req.body has no `timeStamp`', async function() {
@@ -334,6 +337,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
             res.should.have.status(400);
+            res.text.should.equal('Error while validating request: request.body should have required property \'timeStamp\'');
         });
 
         it('returns 404 when the project does not exist', async function() {


### PR DESCRIPTION
for https://github.com/eclipse/codewind/issues/1716

Added tests for /projects/{id}/unbind, fixed our OpenAPI doc accordingly

Our new code coverage tools showed that the existing bind tests were not strict enough, so I have made them stricter

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>