### PR TITLE
Remove nodesource repository.

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -24,9 +24,6 @@ RUN curl -f -o buildah.rpm $BUILDAH_RPM
 RUN curl -f -o slirp4netns.rpm $SLIRP
 RUN curl -f -o libseccomp.rpm $LIBSEC
 
-# Download and set up Node 10.x RPM
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
-
 RUN yum install -y epel-release \
     && yum -y --enablerepo=epel install zip unzip sudo ca-certificates openssl nodejs slirp4netns.rpm libseccomp.rpm buildah.rpm \
     && yum clean all \


### PR DESCRIPTION
Both `nodesource` and `AppStream` package repositories provide a `nodejs` package. Both packages install Node 10, the `nodesource` package is 20Mb (see below) and the `AppStream` package is 9Mb. Additionally the `nodesource` package has a dependency on Python 2.7 which the `AppStream` package doesn't require.

It seems that when two versions of a package are available yum chooses the most recent to install. In the interests of reproducible builds, small size and not adding external package repositories this PR removes the line that adds the `nodesource` repository to our Dockerfile. With this change we will always install from the CentOS `AppStream` repository.

Sample yum installation output:
```
================================================================================
 Package                        ArchVersion                                  Repository   Size
================================================================================
Installing:
 nodejs                         x86_642:10.18.1-1nodesource                    nodesource   20 M
```
AppStream:
```
================================================================================
 Package                        ArchVersion                                         Repository   Size
================================================================================
Installing:
 nodejs                         x86_641:10.16.3-2.module_el8.0.0+186+542b25fc         AppStream    9.0 M
```
