### PR TITLE
Add generic tests on set and remove image push registry

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/lib/generic.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/lib/generic.ts
@@ -32,6 +32,14 @@ export async function testImagePushRegistry(pushRegistryAddress: string, pushReg
     return await filewatcher.testImagePushRegistry(pushRegistryAddress, pushRegistryNamespace, pullImage);
 }
 
+export async function writeWorkspaceSettings(address: string, namespace: string): Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure> {
+    return await filewatcher.writeWorkspaceSettings(address, namespace);
+}
+
+export async function removeImagePushRegistry(pushRegistryAddress: string): Promise<workspaceSettings.IWorkspaceSettingsSuccess | workspaceSettings.IWorkspaceSettingsFailure> {
+    return await filewatcher.removeImagePushRegistry(pushRegistryAddress);
+}
+
 export async function imagePushRegistryStatus(request: workspaceSettings.IImagePushRegistryStatusParams): Promise<workspaceSettings.IImagePushRegistryStatusSuccess | workspaceSettings.IImagePushRegistryStatusFailure> {
     return await filewatcher.imagePushRegistryStatus(request);
 }


### PR DESCRIPTION
### Description

Close https://github.com/eclipse/codewind/issues/1858

Add new generic test cases on set and removal of image push registries

Signed-off-by: ssh24 <sakib@ibm.com>