### PR TITLE
fix: dont send headers twice in projects/:id/upload/end

### DIFF
--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -216,7 +216,7 @@ async function uploadEnd(req, res) {
   let filesToDelete;
   
   try {
-    const project = user.projectList.retrieveProject(projectID);
+    project = user.projectList.retrieveProject(projectID);
     if (!project) {
       res.sendStatus(404);
       return;

--- a/test/src/API/projects/uploadEnd.test.js
+++ b/test/src/API/projects/uploadEnd.test.js
@@ -37,6 +37,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
         'chart/node/templates/service.yaml',
         'chart/node/values.yaml',
         'cli-config.yml',
+        'images/header-logo.svg',
         'nodemon.json',
         'package.json',
         'public/404.html',
@@ -60,6 +61,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
         'server/config',
         'server/routers',
         'test',
+        'images',
     ];
 
     describe('Sync modified file (these `it` blocks depend on each other passing)', function() {


### PR DESCRIPTION
Previously when we caught errors after `res.send(200)` we would respond again with 500, causing an error. 

I've split the previous try-catch block into 2 try-catch blocks, so that in the 2nd one we don't send another response.

Also fixed a test that was incorrectly triggering this block, because in that test I'd forgotten to include the `images` dir while uploading, so it thought the test was trying to delete that dir, when really the test was not trying to change any files at all