### PR TITLE
fix issue that autoBuild is set incorrectly after re-enble

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -227,6 +227,16 @@ export async function createProject(req: ICreateProjectParams): Promise<ICreateP
         logger.logProjectInfo("Initial start mode for project " + projectID + " is: " + startMode, projectID, projectName);
     }
 
+    const autoBuild = req.autoBuild;
+    if (autoBuild != undefined) {
+        if (typeof autoBuild != "boolean") {
+            const msg = "ERROR: autoBuild must be with type boolean" ;
+            return {  "statusCode": 400, "error": {"msg": msg }};
+        }
+        projectInfo.autoBuildEnabled = autoBuild;
+        logger.logProjectInfo("Initial autoBuildEnabled for project " + projectID + " is: " + autoBuild, projectID, projectName);
+    }
+
         // check if application port has been provided by Portal, if not, use the default app port of the project handler
         if (settings && settings.internalPort) {
             projectInfo.appPorts.push(settings.internalPort);
@@ -1194,6 +1204,7 @@ export interface ICreateProjectParams {
     startMode?: string;
     extension?: IProjectExtension;
     language?: string;
+    autoBuild?: boolean;
 }
 
 export interface IProjectExtension {

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -243,7 +243,8 @@ module.exports = class FileWatcher {
       location: project.projectPath(false),
       applicationPort: project.applicationPort,
       settings: settingsFileContents,
-      language: project.language
+      language: project.language,
+      autoBuild: project.autoBuild
     };
 
     log.info(`Calling createProject() for project ${project.name} ${JSON.stringify(projectAction)}`);


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

This PR is for https://github.com/eclipse/codewind/issues/1857

The issue is when project is disabled, the project and it's data is considered as deleted from Turbine perspective. 
And when the project is re-enabled, portal needs to send the `autoBuild` value to Turbine on project creation. 