### PR TITLE
Fix vscode test debugger config for running PFE tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,8 @@
                 "--recursive",
                 "--exit",
             ],
-            "internalConsoleOptions": "openOnSessionStart"
+            "internalConsoleOptions": "openOnSessionStart",
+            "cwd": "${workspaceFolder}/test"
         },
         {
             "type": "node",


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

This was previously erroring due to the debugger and `fs` running from different current working directories