### PR TITLE
Remove logStreams from .inf storage

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -262,7 +262,7 @@ module.exports = class Project {
     }
     try {
       // Strip out capabilitiesReady as this shouldn't persist
-      const {capabilitiesReady, ...updatedProject } = this
+      const {capabilitiesReady, logStreams, ...updatedProject } = this
       await fs.writeJson(infFile, updatedProject, { spaces: '  ' });    
     } catch(err) {
       log.error(err);


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

This fixes https://github.com/eclipse/codewind/issues/1875 by not attempting to write `logStreams` out to the project.inf file. The throw error means it never made it there anyway, and https://github.com/eclipse/codewind/blob/master/src/pfe/portal/modules/Project.js#L153 seems to be making it clear that it wasn't supposed to by design; nevertheless I would like reviews from IDE people and also Howard who wrote the streaming section(?)