### PR TITLE
Fix exit code of run.sh when build script fails

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,10 +53,11 @@ else
   printf "\n\n${BLUE}BUILDING DOCKER IMAGES${RESET}\n\n";
 
   ./script/build.sh;
+  EC=$?
 
-  if [ $? -ne 0 ]; then
+  if [ $EC -ne 0 ]; then
     printf "\n${RED}FAILED TO BUILD\nExiting. $RESET";
-    exit $?
+    exit $EC
   else
     printf "\n${GREEN}ALL DOCKER IMAGES SUCCESSFULLY BUILT $RESET\n";
   fi


### PR DESCRIPTION
### Description

We were always exiting out of run.sh with exit code = 0 when build.sh fails because of the exit code of the previous command of printf `$?`.

Changed this to save the actual exit code of build.sh and then exit with that exit code if the build failed.

Signed-off-by: ssh24 <sakib@ibm.com>