### PR TITLE
Fix K8 condition on workspace test after hook

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/generic/tests/workspace.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/generic/tests/workspace.ts
@@ -61,11 +61,13 @@ export default class WorkspaceTest {
                     expect(info.statusCode).to.equal(200);
                 }
             });
-            after("set and test image push registry for project tests", async function(): Promise<void> {
-                this.timeout(timeoutConfigs.testImagePushRegistryTimeout);
-                await self.setImagePushRegistry();
-                await self.testImagePushRegistry();
-            });
+            if (process.env.IN_K8) {
+                after("set and test image push registry for project tests", async function(): Promise<void> {
+                    this.timeout(timeoutConfigs.testImagePushRegistryTimeout);
+                    await self.setImagePushRegistry();
+                    await self.testImagePushRegistry();
+                });
+            }
 
             this.runReadWorkspaceSettings(socket, settingsPath, settingsContent, backupSettingsPath);
             this.runImagePushRegistryStatus(socket);


### PR DESCRIPTION
### Description

The after hook on workspace test needs to be encapsulated on K8 condition because setting and testing image push registry only works in Kube.

Signed-off-by: ssh24 <sakib@ibm.com>