### PR TITLE
Do not persist detailedAppStatus, operation, logStreams

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -147,13 +147,6 @@ module.exports = class Project {
   }
 
 
-  toJSON() {
-    // Exclude properties that we don't want to write to the .info file on disk. The
-    // ... spread syntax means that cloneObj gets all the rest of the properties
-    const { logStreams, loadInProgress, loadConfig, ...cloneObj } = this;
-    return cloneObj;
-  }
-
   async checkIfMetricsAvailable() {
     let isMetricsAvailable;
     // hardcoding a return of true for appsody projects until we have a better
@@ -261,8 +254,8 @@ module.exports = class Project {
       throw new ProjectError('LOCK_FAILURE', this.name);
     }
     try {
-      // Strip out capabilitiesReady as this shouldn't persist
-      const {capabilitiesReady, detailedAppStatus,  ...updatedProject } = this
+      // Strip out properties that shouldn't persist in the .inf file
+      const {capabilitiesReady, detailedAppStatus, logStreams, loadInProgress, loadConfig, operation, ...updatedProject } = this
       await fs.writeJson(infFile, updatedProject, { spaces: '  ' });    
     } catch(err) {
       log.error(err);

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -262,7 +262,7 @@ module.exports = class Project {
     }
     try {
       // Strip out capabilitiesReady as this shouldn't persist
-      const {capabilitiesReady, ...updatedProject } = this
+      const {capabilitiesReady, detailedAppStatus,  ...updatedProject } = this
       await fs.writeJson(infFile, updatedProject, { spaces: '  ' });    
     } catch(err) {
       log.error(err);

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -86,27 +86,6 @@ describe('Project.js', () => {
             project.directory.should.not.equal(`${name}-${projectID}`);
         });
     });
-    describe('toJSON()', () => {
-        it('Checks that toJSON removes fields which shouldn\'t be written to .info file on disk', () => {
-            const obj = {
-                logStreams: 'logstream',
-                loadInProgress: true,
-                loadConfig: 'someconfig',
-            };
-            const project = createDefaultProjectAndCheckIsAnObject();
-            project.should.containSubset({ name: 'dummy' });
-            project.should.not.containSubset(obj);
-
-            project.logStreams = obj.logStreams;
-            project.loadInProgress = obj.loadInProgress;
-            project.loadConfig = obj.loadConfig;
-
-            project.should.containSubset(obj);
-
-            const json = project.toJSON();
-            json.should.not.containSubset(obj);
-        });
-    });
     describe('checkIfMetricsAvailable()', () => {
         describe('Checks if metrics are available for normal projects', () => {
             it('Generic project with no language', async() => {


### PR DESCRIPTION
We were encountering a Circular JSON reference because the project object has a logStreams property that contains a reference back to the project. This field had previously been removed from the object in the toJSON function but the introduction of removal of capabilitiesReady using the javascript spread operator meant that the new object did not have that function (spread operator does not copy class functions).  This resulted in the circular reference error. 

The solution is to consolidate the removal of properties from the project inf file into one place.  I have removed the toJSON function and put all the removal in writeInformationFile(). 

I've included the removal of operation for https://github.com/eclipse/codewind/issues/1032 and 
removal of detailedAppStatus for https://github.com/eclipse/codewind/issues/1856 alongside fixing 
https://github.com/eclipse/codewind/issues/1875
