### PR TITLE
re-enable PFE container code coverage

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -106,7 +106,7 @@ FROM codewind-pfe-base
 COPY --from=codewind-pfe-portal /portal /portal
 WORKDIR /portal
 
-ARG NODE_ENV
+ARG NODE_ENV=production
 
 RUN NODE_ENV=${NODE_ENV} npm ci \
     && npm cache clean -f
@@ -126,8 +126,10 @@ RUN mv /portal/LICENSE /portal/NOTICE.md / \
 EXPOSE 9090
 
 ARG IMAGE_BUILD_TIME
+ARG ENABLE_CODE_COVERAGE=false
 ENV NODE_ENV=${NODE_ENV} \
     IMAGE_BUILD_TIME=${IMAGE_BUILD_TIME} \
+    ENABLE_CODE_COVERAGE=${ENABLE_CODE_COVERAGE} \
     FORCE_COLOR=1 \
     LOG_LEVEL=info
 


### PR DESCRIPTION
### Summary
Code coverage was disabled yesterday by myself accidentally when refactoring the Dockerfile.
Also re-added the `production` default to the `NODE_ENV`.
PR that added: https://github.com/eclipse/codewind/pull/1816/
PR that disabled: https://github.com/eclipse/codewind/pull/1916

### Testing
Enabled the `ENABLE_CODE_COVERAGE` variable and tested that the code coverage was indeed activated in PFE.

Signed-off-by: James Wallis <james.wallis1@ibm.com>