### PR TITLE
ensure ignoredPaths and refPaths always defined

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -447,7 +447,7 @@ const reconfigIgnoredFilesForDaemon = async function (ignoredPaths: string[], op
         projectID: projectID,
         status: "success",
         ignoredPaths: ignoredPaths,
-        refPaths: projectInfo.refPaths
+        refPaths: projectInfo.refPaths || []
     };
 
     logger.logProjectInfo("The ignored path list for file watching was updated successfully.", projectID);
@@ -523,7 +523,7 @@ const reconfigRefPathsForDaemon = async function (refPaths: RefPath[], operation
         operationId: operation.operationId,
         projectID: projectID,
         status: "success",
-        ignoredPaths: projectInfo.ignoredPaths,
+        ignoredPaths: projectInfo.ignoredPaths || [],
         refPaths: refPaths
     };
 


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Address a bug where if you added `refPaths` but you did not have `ignoredPaths` defined, then we miss sending out event to Filewatcherd