### PR TITLE
test, docs: validate 4xx responses against docs

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -217,7 +217,7 @@ paths:
         400:
           description: Invalid request
         404:
-          description: Project with given projectID not found
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Internal error
 
@@ -295,7 +295,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Project'
         404:
-          description: Project with given projectiD was not found.
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Any other error
 
@@ -325,7 +325,7 @@ paths:
                 type: string
                 example: OK
         404:
-          description: Project with given projectID not found
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Any other error
 
@@ -357,7 +357,7 @@ paths:
                 type: string
                 example: OK
         404:
-          description: Project with given projectiD was not found.
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Any other error
 
@@ -381,11 +381,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Project'
         404:
-          description: The project was not found
-          content:
-            text/html:
-              schema:
-                type: string
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Any other error
 
@@ -418,7 +414,7 @@ paths:
               schema:
                 type: string
         404:
-          description: Project not found
+          $ref: '#/components/responses/ProjectNotFound'
         409:
           description: Load test already in progress
           content:
@@ -447,7 +443,7 @@ paths:
               schema:
                 type: string
         404:
-          description: Project with given projectID not found
+          $ref: '#/components/responses/ProjectNotFound'
         409:
           description: No run in progress for this project
           content:
@@ -517,7 +513,7 @@ paths:
         400:
           description: Incorrect parameters given
         404:
-          description: Project with given projectID not found
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Internal error
 
@@ -541,7 +537,7 @@ paths:
         400:
           description: Incorrect parameters given
         404:
-          description: Project not found
+          $ref: '#/components/responses/ProjectNotFound'
         500:
           description: Internal error
 
@@ -566,7 +562,7 @@ paths:
                 schema:
                   type: string
           404:
-            description: if the project with id was not found
+            $ref: '#/components/responses/ProjectNotFound'
           409:
             description: if unbind was already in progress
 

--- a/test/src/API/projects/bind.test.js
+++ b/test/src/API/projects/bind.test.js
@@ -160,6 +160,7 @@ describe('Bind projects tests', () => {
                     'package.json',
                 );
                 res.should.have.status(404);
+                res.should.satisfyApiSpec;
             });
         });
     });
@@ -170,6 +171,7 @@ describe('Bind projects tests', () => {
                 const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
                 const res = await projectService.bindEnd(idMatchingNoProjects);
                 res.should.have.status(404);
+                res.should.satisfyApiSpec;
                 res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
             });
         });
@@ -181,6 +183,7 @@ describe('Bind projects tests', () => {
                 const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
                 const res = await projectService.unbind(idMatchingNoProjects, 404);
                 res.should.have.status(404);
+                res.should.satisfyApiSpec;
                 res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
             });
         });

--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -131,6 +131,7 @@ describe('Load Runner Tests', function() {
                     this.timeout(testTimeout.short);
                     const res = await writeToLoadTestConfig('falseID', configOptions);
                     res.should.have.status(404);
+                    res.should.satisfyApiSpec;
                 });
             });
         });
@@ -146,6 +147,7 @@ describe('Load Runner Tests', function() {
                 this.timeout(testTimeout.short);
                 const res = await readLoadTestConfig('falseID');
                 res.should.have.status(404);
+                res.should.satisfyApiSpec;
             });
         });
     });
@@ -155,12 +157,14 @@ describe('Load Runner Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.runLoad('invalidID');
             res.should.have.status(404);
+            res.should.satisfyApiSpec;
         });
 
         it('fails with 404 to cancel load on a project with an invalid id', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.cancelLoad('invalidID');
             res.should.have.status(404);
+            res.should.satisfyApiSpec;
         });
 
         it('returns 202 and starts running load against a project', async function() {
@@ -184,7 +188,7 @@ describe('Load Runner Tests', function() {
             res.should.satisfyApiSpec;
         });
 
-        it("fails with 404 to cancel load that isn't being run", async function() {
+        it("fails with 409 to cancel load that isn't being run", async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.cancelLoad(projectID);
             res.should.have.status(409);

--- a/test/src/API/projects/uploadEnd.test.js
+++ b/test/src/API/projects/uploadEnd.test.js
@@ -383,6 +383,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(idMatchingNoProjects, options);
             res.should.have.status(404);
+            res.should.satisfyApiSpec;
         });
     });
 });


### PR DESCRIPTION
Ensures more of our 4xx responses behave as documented in our OpenAPI spec

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>