### PR TITLE
Revert to yq 2.4.1

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -51,8 +51,8 @@ RUN curl -f -o buildah.rpm $BUILDAH_RPM \
     && cp -r /tmp/$OPENJ9_JRE /opt/java/jre \
     && rm -rf /tmp/$OPENJ9_JRE /tmp/OpenJDK8U-jre_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz \
 # Install the latest version of yq
-    && VERSION=2.4.1 \
-    && curl -sL -O https://github.com/mikefarah/yq/releases/download/$VERSION/yq_linux_amd64 \
+    && YQ_VERSION=2.4.1 \
+    && curl -sL -O https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_linux_amd64 \
     && echo '754c6e6a7ef92b00ef73b8b0bb1d76d651e04d26aa6c6625e272201afa889f8b  yq_linux_amd64' | sha256sum -c - \
     && mv ./yq_linux_amd64 /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq \

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -51,9 +51,9 @@ RUN curl -f -o buildah.rpm $BUILDAH_RPM \
     && cp -r /tmp/$OPENJ9_JRE /opt/java/jre \
     && rm -rf /tmp/$OPENJ9_JRE /tmp/OpenJDK8U-jre_x64_linux_openj9_8u222b10_openj9-0.15.1.tar.gz \
 # Install the latest version of yq
-    && LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/mikefarah/yq/releases/latest) \
-    && LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/') \
-    && curl -sL -O https://github.com/mikefarah/yq/releases/download/$LATEST_VERSION/yq_linux_amd64 \
+    && VERSION=2.4.1 \
+    && curl -sL -O https://github.com/mikefarah/yq/releases/download/$VERSION/yq_linux_amd64 \
+    && echo '754c6e6a7ef92b00ef73b8b0bb1d76d651e04d26aa6c6625e272201afa889f8b  yq_linux_amd64' | sha256sum -c - \
     && mv ./yq_linux_amd64 /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq \
 # Install kubectl


### PR DESCRIPTION
Fixes https://github.com/eclipse/codewind/issues/1973

`yq` 3.0 was recently released and it changed the syntax of a number of commands, causing the commands in https://github.com/eclipse/codewind/blob/master/src/pfe/file-watcher/scripts/kubeScripts/modify-helm-chart.sh to fail. This was causing the Helm chart to fail to deploy with the following error:
```
 Error: unable to build kubernetes objects from release manifest: error validating "": error validating
data: [ValidationError(Service.metadata.ownerReferences[0]): missing required field "kind" in
io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference,
ValidationError(Service.metadata.ownerReferences[0]): missing required field "name" in
io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference,
ValidationError(Service.metadata.ownerReferences[0]): missing required field "uid" in
io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference,
ValidationError(Service.metadata.ownerReferences[1]): missing required field "apiVersion" in
io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference]
```

Since our yq scripts are heavily dependent on the yq 2.0 syntax, this PR is reverting the yq we're using back to 2.4.1, so that the error doesn't occur.