### PR TITLE
Fix functional test on update build queue

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -141,6 +141,8 @@ export function projectEventTest(socket: SocketIO, projData: projectsController.
                         fileContent[projectTemplate][projectLang][chosenTimestamp][`${type.toLowerCase()}-${file}`] = totalTestTime;
                         await fs.writeFileSync(dataFile, JSON.stringify(fileContent));
                     }
+
+                    await utils.setBuildStatus(projData, projectTemplate, projectLang);
                 }).timeout(timeoutConfigs.createTestTimeout);
             }
         }

--- a/src/pfe/file-watcher/server/test/scripts/exec.sh
+++ b/src/pfe/file-watcher/server/test/scripts/exec.sh
@@ -61,7 +61,7 @@ function createProject() {
 }
 
 function copyToPFE() {
-    echo -e "${BLUE}>> Copying entire projects dir to PFE for $TEST_TYPE to $2 ... ${RESET}"
+    echo -e "${BLUE}>> Copying project dir from $1 to $2 ... ${RESET}"
     if [ $TEST_TYPE == "local" ]; then
         docker cp $1 $CODEWIND_CONTAINER_ID:$2
     elif [ $TEST_TYPE == "kube" ]; then
@@ -110,11 +110,14 @@ function setup {
 
         if [ $TEST_TYPE == "local" ]; then
             PROJECT_PATH="/codewind-workspace"
+            copyToPFE "$PROJECT_DIR/." "$PROJECT_PATH"
         elif [ $TEST_TYPE == "kube" ]; then
-            PROJECT_PATH=/projects
+            PROJECT_PATH="/projects"
+            ## for kube we need to loop over the projects dir to copy because kube cp does not support bulk copy
+            for testprojectdir in $PROJECT_DIR/*; do
+                copyToPFE "$testprojectdir" "$PROJECT_PATH"
+            done
         fi
-
-        copyToPFE "$PROJECT_DIR/." "$PROJECT_PATH"
 
         if [ $TEST_TYPE == "kube" ]; then
             # Set up registry secrets (docker config) in PFE container/pod


### PR DESCRIPTION
### Description

This PR fixes the functional test on update cases with the new build queue on update scenario. It also fixes the kubectl copy on bulk copy of the project directory.

![Screen Shot 2020-01-31 at 4 40 00 PM](https://user-images.githubusercontent.com/15173354/73576752-30c8f880-4449-11ea-99c5-91f774d68d72.png)

Closes https://github.com/eclipse/codewind/issues/1972