### PR TITLE
Fix circular reference error in log.debug message.

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -269,9 +269,8 @@ module.exports = class Project {
       throw new ProjectError('LOCK_FAILURE', this.name);
     }
     try {
-      // Strip out properties that shouldn't persist in the .inf file
-      const {capabilitiesReady, detailedAppStatus, logStreams, loadInProgress, loadConfig, operation, ...updatedProject } = this
-      await fs.writeJson(infFile, updatedProject, { spaces: '  ' });    
+      // Fields that shouldn't be persisted are stripped out by toJSON() below.
+      await fs.writeJson(infFile, this, { spaces: '  ' });
     } catch(err) {
       log.error(err);
     } finally {
@@ -279,6 +278,13 @@ module.exports = class Project {
     }
     // May return before we've finished writing.
     return this;
+  }
+
+  toJSON() {
+    // Strip out fields we don't want to save in the .inf file or log in debug if we print the project object.
+    // (This is our guard against trying to write circular references.)
+    const { capabilitiesReady, detailedAppStatus, logStreams, loadInProgress, loadConfig, operation, ...filteredProject } = this;
+    return filteredProject;
   }
 
   /**

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -86,6 +86,27 @@ describe('Project.js', () => {
             project.directory.should.not.equal(`${name}-${projectID}`);
         });
     });
+    describe('toJSON()', () => {
+        it('Checks that toJSON removes fields which shouldn\'t be written to .info file on disk', () => {
+            const obj = {
+                logStreams: 'logstream',
+                loadInProgress: true,
+                loadConfig: 'someconfig',
+            };
+            const project = createDefaultProjectAndCheckIsAnObject();
+            project.should.containSubset({ name: 'dummy' });
+            project.should.not.containSubset(obj);
+
+            project.logStreams = obj.logStreams;
+            project.loadInProgress = obj.loadInProgress;
+            project.loadConfig = obj.loadConfig;
+
+            project.should.containSubset(obj);
+
+            const json = project.toJSON();
+            json.should.not.containSubset(obj);
+        });
+    });
     describe('checkIfMetricsAvailable()', () => {
         describe('Checks if metrics are available for normal projects', () => {
             it('Generic project with no language', async() => {


### PR DESCRIPTION
Re-implement Project.toJSON() so we can safely dump project objects in log messages.
Re-instate the test that was removed when we took out `toJSON()`.

https://github.com/eclipse/codewind/issues/1979