### PR TITLE
Fix else case on build action for Node.js project

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -433,6 +433,9 @@ elif [ "$COMMAND" == "update" ]; then
 			$util updateAppState $PROJECT_ID $APP_STATE_STOPPING
 			$IMAGE_COMMAND exec $project /scripts/noderun.sh start $AUTO_BUILD_ENABLED $START_MODE $HOST_OS
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
+		else
+			echo "Build succeeded, setting build status to success"
+			$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
 		fi
 	fi
 


### PR DESCRIPTION
### Description

Closes https://github.com/eclipse/codewind/issues/1956

The `if` case was missing on the node.js container script. This is basically the step when auto build is enabled and ACTION=NONE, node.js relies on nodemon to pick up the changes quick, so from turbine end, we should emit the build success status.

Now on update scenarios, we push them into build queue and change status to in progress. All other projects work because on their container script there is the case to to set build status back to success for example in spring https://github.com/eclipse/codewind/blob/a34de49c7c54fc29c2feac614e6f4a7b56a2470b/src/pfe/file-watcher/scripts/spring-container.sh#L375, but for node.js there was no case to handle it when auto build is enabled. This PR helps solve this.

Signed-off-by: ssh24 <sakib@ibm.com>