### PR TITLE
Set chunk total to be 1 on update project function for test call

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -30,11 +30,10 @@ export function projectEventTest(socket: SocketIO, projData: projectsController.
             socket.clearEvents();
         });
 
-        const chunk = Math.random() * 1000;
         const data: any = {
             "projectID": projData.projectID,
             "timestamp": Date.now(),
-            "chunk": chunk,
+            "chunk": 1,
             "chunk_total": 1,
             "eventArray": []
         };

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -35,7 +35,7 @@ export function projectEventTest(socket: SocketIO, projData: projectsController.
             "projectID": projData.projectID,
             "timestamp": Date.now(),
             "chunk": chunk,
-            "chunk_total": chunk + Math.random() * 100,
+            "chunk_total": 1,
             "eventArray": []
         };
 


### PR DESCRIPTION
### Description

Related to https://github.com/eclipse/codewind/issues/1222

We need to set chunk total equal to 1 for the update to not get stuck in a 20s timer. That is why we would see a 20s extra on update cases on our performance tests.

The issue is that in our product code, we expect the function to be passed with `chunk_total` value of 1. See https://github.com/eclipse/codewind/blob/b0f16f0a76be2f543d501fc718ddeaa727d75d1d/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts#L167-L169

So if chunk_total value is not passed 1, in our previous case, we just used a random number, this if statement https://github.com/eclipse/codewind/blob/b0f16f0a76be2f543d501fc718ddeaa727d75d1d/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts#L217 was never entered because the value of `newChunkRemaining` was not 0 from missing the previous if statement.

As a result, we would get stuck in this `setTimeout` function https://github.com/eclipse/codewind/blob/b0f16f0a76be2f543d501fc718ddeaa727d75d1d/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts#L262 for 20s as defined here https://github.com/eclipse/codewind/blob/b0f16f0a76be2f543d501fc718ddeaa727d75d1d/src/pfe/file-watcher/server/src/controllers/projectEventsController.ts#L42

Not sure why we have that 20s timer in the first place - looks like most of the code inside that timer is duplicated on the if statement provided above, or why the `updateProjectForNewChange` function only takes `chunk_total` value of 1 is not documented properly. But for that I have opened another issue https://github.com/eclipse/codewind/issues/1998

Signed-off-by: ssh24 <sakib@ibm.com>