### PR TITLE
Move DockerJava=OpenLiberty into utility function

### DIFF
--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -37,15 +37,10 @@ async function inject(req, res) {
     }
 
     const projectDir = path.join(project.workspace, project.directory);
-    let projType = project.projectType;
-    if (project.projectType === 'docker' && project.language === 'java') {
-      projType = 'openLiberty'
-      // this is the best we can do at the moment
-    }
     if (injectMetrics) {
-      await metricsService.injectMetricsCollectorIntoProject(projType, projectDir);
+      await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, projectDir);
     } else {
-      await metricsService.removeMetricsCollectorFromProject(projType, projectDir);
+      await metricsService.removeMetricsCollectorFromProject(project.projectType, project.language, projectDir);
     }
 
     await user.projectList.updateProject({

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -36,20 +36,30 @@ const metricsCollectorRemovalFunctions = {
   spring: removeMetricsCollectorFromSpringProject,
 }
 
-async function injectMetricsCollectorIntoProject(projectType, projectDir) {
-  if (!metricsCollectorInjectionFunctions.hasOwnProperty(projectType)) {
-    throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
+async function identifyProject(projectType, projectLanguage) {
+  if (projectType === 'docker' && projectLanguage === 'java') {
+    return 'openLiberty';
+    // this is the best we can do at the moment
   }
-  await metricsCollectorInjectionFunctions[projectType](projectDir);
-  log.debug(`Successfully injected metrics collector into ${projectType} project`);
+  return projectType
 }
 
-async function removeMetricsCollectorFromProject(projectType, projectDir) {
-  if (!metricsCollectorRemovalFunctions.hasOwnProperty(projectType)) {
-    throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
+async function injectMetricsCollectorIntoProject(projectType, projectLanguage, projectDir) {
+  let projType = await identifyProject(projectType, projectLanguage);
+  if (!metricsCollectorInjectionFunctions.hasOwnProperty(projType)) {
+    throw new Error(`Injection of metrics collector is not supported for projects of type '${projType}'`);
   }
-  await metricsCollectorRemovalFunctions[projectType](projectDir);
-  log.debug(`Successfully removed metrics collector from ${projectType} project`);
+  await metricsCollectorInjectionFunctions[projType](projectDir);
+  log.debug(`Successfully injected metrics collector into ${projType} project`);
+}
+
+async function removeMetricsCollectorFromProject(projectType, projectLanguage, projectDir) {
+  let projType = await identifyProject(projectType, projectLanguage);
+  if (!metricsCollectorRemovalFunctions.hasOwnProperty(projType)) {
+    throw new Error(`Injection of metrics collector is not supported for projects of type '${projType}'`);
+  }
+  await metricsCollectorRemovalFunctions[projType](projectDir);
+  log.debug(`Successfully removed metrics collector from ${projType} project`);
 }
 
 const getPathToPomXml = (projectDir) => path.join(projectDir, 'pom.xml');

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -97,6 +97,13 @@ async function removeMetricsCollectorFromJvmOptions(projectDir) {
   }
 }
 
+async function deleteBackupPomXml(projectDir) {
+  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
+  if (await fs.exists(pathToBackupPomXml)) {
+    await fs.remove(pathToBackupPomXml);
+  }
+}
+
 async function removeMetricsCollectorFromSpringProject(projectDir) {
   await removeMetricsCollectorFromPomXml(projectDir);
   await removeMetricsCollectorFromMainAppClassFile(projectDir);
@@ -122,7 +129,7 @@ async function injectMetricsCollectorIntoLibertyProject(projectDir) {
   let jvmOptionsPresent = false;
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
   const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
-  if ((await fs.exists(pathToBackupPomXml)) || (await fs.exists(pathToBackupJvmOptions))) {
+  if (await fs.exists(pathToBackupPomXml)) {
     throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
   }
 
@@ -141,7 +148,7 @@ async function injectMetricsCollectorIntoLibertyProject(projectDir) {
 async function injectMetricsCollectorIntoSpringProject(projectDir) {
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
   const pathToBackupMainAppClassFile = getPathToBackupMainAppClassFile(projectDir);
-  if ((await fs.exists(pathToBackupPomXml)) || (await fs.exists(pathToBackupMainAppClassFile))) {
+  if (await fs.exists(pathToBackupPomXml)) {
     throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
   }
 
@@ -554,4 +561,5 @@ function getNewPomXmlBuildPlugins(originalBuildPlugins) {
 module.exports = {
   injectMetricsCollectorIntoProject,
   removeMetricsCollectorFromProject,
+  deleteBackupPomXml,
 }

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -271,7 +271,7 @@ async function uploadEnd(req, res) {
 
       if (project.injectMetrics) {
         try {
-          await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
+          await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, path.join(project.workspace, project.directory));
         } catch (error) {
           log.warn(error);
         }
@@ -429,7 +429,7 @@ async function bindEnd(req, res) {
 
     if (project.injectMetrics) {
       try {
-        await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
+        await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, path.join(project.workspace, project.directory));
       } catch (error) {
         log.warn(error);
       }

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -270,8 +270,13 @@ async function uploadEnd(req, res) {
       await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
 
       if (project.injectMetrics) {
+        const projectDir = path.join(project.workspace, project.directory);
+        if (modifiedList.includes("pom.xml")) {
+          // we'll need to inject this new pom.xml; to do this, remove the backup pom.
+          await metricsService.deleteBackupPomXml(projectDir);
+        }
         try {
-          await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, path.join(project.workspace, project.directory));
+          await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, projectDir);
         } catch (error) {
           log.warn(error);
         }

--- a/test/src/unit/controllers/metrics.controller.test.js
+++ b/test/src/unit/controllers/metrics.controller.test.js
@@ -17,7 +17,7 @@ const { suppressLogOutput } = require('../../../modules/log.service');
 
 chai.should();
 
-describe('metrics.controller.js', () => {
+describe.only('metrics.controller.js', () => {
     suppressLogOutput(metricsController);
     describe('inject(req, res)', () => {
         it('returns 404 if the specified project does not exist', async() => {

--- a/test/src/unit/modules/metricsService.test.js
+++ b/test/src/unit/modules/metricsService.test.js
@@ -104,7 +104,7 @@ describe('metricsService/index.js', () => {
         // console.log(util.inspect(expectedPomXmlForLiberty, { showHidden: false, depth: null }));
     });
 
-    describe('injectMetricsCollectorIntoProject(projectType, projectDir)', () => {
+    describe('injectMetricsCollectorIntoProject(projectType, project.language, projectDir)', () => {
         afterEach(() => {
             fs.removeSync(projectDir);
         });
@@ -114,7 +114,7 @@ describe('metricsService/index.js', () => {
                     fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
                 });
                 it(`injects metrics collector into the project's package.json, and saves a back up`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('nodejs', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('nodejs', 'nodejs', projectDir);
 
                     fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithCollector);
                     fs.readJSONSync(pathToBackupPackageJson).should.deep.equal(packageJsonWithoutCollector);
@@ -126,7 +126,7 @@ describe('metricsService/index.js', () => {
                     fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('nodejs', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('nodejs', 'nodejs', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithoutCollector);
@@ -141,7 +141,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToJvmOptions, originalJvmOptions);
                 });
                 it(`injects metrics collector into the project's jvm.options and pom.xml, and saves backups`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('liberty', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('liberty', 'java', projectDir);
 
                     const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                     outputJvmOptions.should.equal(expectedJvmOptions);
@@ -163,7 +163,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToBackupJvmOptions, originalJvmOptions);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('liberty', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('liberty', 'java', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readFileSync(pathToJvmOptions, 'utf8')
@@ -185,7 +185,7 @@ describe('metricsService/index.js', () => {
                     fs.removeSync(pathToJvmOptions);
                 });
                 it(`injects metrics collector into the project's jvm.options and pom.xml, and saves backups`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('openLiberty', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('openLiberty', 'java', projectDir);
 
                     const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                     outputJvmOptions.should.equal(expectedNewJvmOptions);
@@ -207,7 +207,7 @@ describe('metricsService/index.js', () => {
                     fs.removeSync(pathToBackupJvmOptions);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('openLiberty', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('docker', 'java', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readFileSync(pathToJvmOptions, 'utf8')
@@ -228,7 +228,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToMainAppClassFile, originalMainAppClassFile);
                 });
                 it(`injects metrics collector into the project's main app class file and pom.xml`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('spring', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('spring', 'java', projectDir);
 
                     const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
                     outputClassFile.should.equal(expectedMainAppClassFile);
@@ -250,7 +250,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToBackupMainAppClassFile, originalMainAppClassFile);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('spring', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('spring', 'java', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readFileSync(pathToMainAppClassFile, 'utf8')
@@ -270,13 +270,13 @@ describe('metricsService/index.js', () => {
                 fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
             });
             it(`throws a useful error`, () => {
-                const funcToTest = () => metricsService.injectMetricsCollectorIntoProject('unsupportedProjectType', projectDir);
+                const funcToTest = () => metricsService.injectMetricsCollectorIntoProject('unsupportedProjectType', 'unknown', projectDir);
                 return funcToTest().should.be.rejectedWith(`Injection of metrics collector is not supported for projects of type 'unsupportedProjectType'`);
             });
         });
     });
 
-    describe('removeMetricsCollectorFromProject(projectType, projectDir)', () => {
+    describe('removeMetricsCollectorFromProject(projectType, projectLanguage, projectDir)', () => {
         afterEach(() => {
             fs.removeSync(projectDir);
         });
@@ -286,7 +286,7 @@ describe('metricsService/index.js', () => {
                 fs.outputJSONSync(pathToBackupPackageJson, packageJsonWithoutCollector);
             });
             it(`removes metrics collector from the project's package.json`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('nodejs', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('nodejs', 'nodejs', projectDir);
 
                 fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithoutCollector);
                 fs.existsSync(pathToBackupPackageJson).should.be.false;
@@ -301,7 +301,7 @@ describe('metricsService/index.js', () => {
                 fs.outputFileSync(pathToBackupJvmOptions, originalJvmOptions);
             });
             it(`removes metrics collector from the project's jvm.options and pom.xml`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('liberty', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('liberty', 'java', projectDir);
 
                 const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                 outputJvmOptions.should.equal(originalJvmOptions);
@@ -321,7 +321,7 @@ describe('metricsService/index.js', () => {
                 fs.removeSync(pathToBackupJvmOptions);
             });
             it(`removes metrics collector from the project's jvm.options and pom.xml`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('openLiberty', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('docker', 'java', projectDir);
 
                 fs.pathExistsSync(pathToJvmOptions).should.be.false;
                 fs.pathExistsSync(pathToBackupJvmOptions).should.be.false;
@@ -340,7 +340,7 @@ describe('metricsService/index.js', () => {
                 fs.outputFileSync(pathToBackupMainAppClassFile, originalMainAppClassFile);
             });
             it(`removes metrics collector from the project's main app class file and pom.xml`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('spring', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('spring', 'java', projectDir);
 
                 const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
                 outputClassFile.should.equal(originalMainAppClassFile);
@@ -357,7 +357,7 @@ describe('metricsService/index.js', () => {
                 fs.outputJSONSync(pathToBackupPackageJson, packageJsonWithoutCollector);
             });
             it(`throws a useful error`, () => {
-                const funcToTest = () => metricsService.removeMetricsCollectorFromProject('unsupportedProjectType', projectDir);
+                const funcToTest = () => metricsService.removeMetricsCollectorFromProject('unsupportedProjectType', 'unknown', projectDir);
                 return funcToTest().should.be.rejectedWith(`Injection of metrics collector is not supported for projects of type 'unsupportedProjectType'`);
             });
         });


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

Fixes #2002 by moving the identification of Docker-Java projects as OpenLiberty projects into MetricsService, so that it can be called from both metrics.controller and remote.bind.