### PR TITLE
Must check for noderun exit code and update build status on nodemon restart

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -423,8 +423,8 @@ elif [ "$COMMAND" == "update" ]; then
 				echo "Build succeeded, setting build status to success"
 				$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
 			else
-				echo "Noderun failed to start, setting build status to failed"
-				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED "Noderun failed to start"
+				echo "Nodemon has failed to start, setting build status to failed"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED "buildscripts.nodemonFailedStart"
 			fi
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
 		fi
@@ -443,8 +443,8 @@ elif [ "$COMMAND" == "update" ]; then
 				echo "Build succeeded, setting build status to success"
 				$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
 			else
-				echo "Noderun failed to start, setting build status to failed"
-				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED "Noderun failed to start"
+				echo "Nodemon has failed to start, setting build status to failed"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED "buildscripts.nodemonFailedStart"
 			fi
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
 		else

--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -423,8 +423,8 @@ elif [ "$COMMAND" == "update" ]; then
 				echo "Build succeeded, setting build status to success"
 				$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
 			else
-				echo "Build failed, setting build status to failed"
-				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED " "
+				echo "Noderun failed to start, setting build status to failed"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED "Noderun failed to start"
 			fi
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
 		fi
@@ -443,8 +443,8 @@ elif [ "$COMMAND" == "update" ]; then
 				echo "Build succeeded, setting build status to success"
 				$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
 			else
-				echo "Build failed, setting build status to failed"
-				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED " "
+				echo "Noderun failed to start, setting build status to failed"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED "Noderun failed to start"
 			fi
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
 		else

--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -419,6 +419,13 @@ elif [ "$COMMAND" == "update" ]; then
 			$util updateAppState $PROJECT_ID $APP_STATE_STOPPING
 
 			$IMAGE_COMMAND exec $project /scripts/noderun.sh start $AUTO_BUILD_ENABLED $START_MODE $HOST_OS
+			if [[ $? -eq 0 ]]; then
+				echo "Build succeeded, setting build status to success"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
+			else
+				echo "Build failed, setting build status to failed"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED " "
+			fi
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
 		fi
 	else
@@ -432,6 +439,13 @@ elif [ "$COMMAND" == "update" ]; then
 			$IMAGE_COMMAND exec $project /scripts/noderun.sh stop
 			$util updateAppState $PROJECT_ID $APP_STATE_STOPPING
 			$IMAGE_COMMAND exec $project /scripts/noderun.sh start $AUTO_BUILD_ENABLED $START_MODE $HOST_OS
+			if [[ $? -eq 0 ]]; then
+				echo "Build succeeded, setting build status to success"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_SUCCESS " "
+			else
+				echo "Build failed, setting build status to failed"
+				$util updateBuildState $PROJECT_ID $BUILD_STATE_FAILED " "
+			fi
 			$util updateAppState $PROJECT_ID $APP_STATE_STARTING
 		else
 			echo "Build succeeded, setting build status to success"

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -32,7 +32,8 @@
       "odoBuildPushInProgressMsg": "Building and deploying odo component",
       "odoBuildPushFailMsg": "Failed to build or deploy odo component",
       "odoBuildUrlInProgressMsg": "Creating URL for odo component",
-      "odoBuildUrlFailMsg": "Fail to create URL for odo component"
+      "odoBuildUrlFailMsg": "Fail to create URL for odo component",
+      "nodemonFailedStart": "Nodemon has failed to start"
   },
   "buildApplicationTask": {
     "pomChangeDetected": "pom.xml change detected, running clean build",


### PR DESCRIPTION
### Description

Previously we would not check if the `noderun` start command was successful or not and the build status would be stuck at `building - build started`. This PR fixes this by checking the exit code status of the nodemon start command, and then sets the build status to success.

Fixes https://github.com/eclipse/codewind/issues/1993

Signed-off-by: ssh24 <sakib@ibm.com>