### PR TITLE
Update file and dir list + add tests

### DIFF
--- a/src/pfe/portal/modules/utils/ignoredPaths.js
+++ b/src/pfe/portal/modules/utils/ignoredPaths.js
@@ -1,26 +1,29 @@
-const dockerIgnoredPaths = ["/.project", "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "/load-test*",
-  "*/.dockerignore", "*/.gitignore", "*/*~", "/.settings"];
+const defaultIgnoredPaths = ["*/.idea/*", "*.iml", "/.project", "/load-test*", "*/*.swp", "*/*.swx", 
+  "*/.gitignore", "*/node_modules*", "*/4913", "*/.git/*", "*/.DS_Store", 
+  "*/.dockerignore", "*/*~", "/.settings"];
 
-const swiftIgnoredPaths = ["/.project", "/LICENSE", "/Package.resolved", "README.rtf", "/debian", "/manifest.yml", "/load-test*",
+const dockerIgnoredPaths = [...defaultIgnoredPaths];
+
+const swiftIgnoredPaths = [...defaultIgnoredPaths, "/LICENSE", "/Package.resolved", "README.rtf", "/debian", "/manifest.yml", 
   "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.bluemix", "/iterative-dev.sh", "/terraform",
   ".swift-version", "/.build-ubuntu", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json",
-  "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore",
-  "*/.gitignore", "*/*~", "/.settings"];
-
-const nodeIgnoredPaths =  ["/.project", "/run-dev", "/run-debug", "/package-lock.json*", "/nodejs_restclient.log", "/nodejs_dc.log",
-  "/manifest.yml", "/idt.js", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", "/load-test*",
-  "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore", "*/.gitignore",
+  "*/.DS_Store", "*/.dockerignore",
   "*/*~", "/.settings"];
 
-const springIgnoredPaths = ["/.project", "/target", "/Dockerfile-tools",
-  "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.m2", "/load-test*",
-  "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx",
-  "*/4913", "*/.dockerignore", "*/.gitignore", "*/*~", "/.settings", "/localm2cache.zip"];
+const nodeIgnoredPaths =  [...defaultIgnoredPaths, "/run-dev", "/run-debug", "/package-lock.json*", "/nodejs_restclient.log", "/nodejs_dc.log",
+  "/manifest.yml", "/idt.js", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", 
+  "*/.DS_Store", "*/.dockerignore",
+  "*/*~", "/.settings"];
 
-const libertyIgnoredPaths = ["/.project", "/Dockerfile-tools", "/target",
-  "/mc-target", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", "/load-test*",
-  "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore",
-  "*/.gitignore", "*/*~", "/.settings", "/localm2cache.zip", "/libertyrepocache.zip"];
+const springIgnoredPaths = [...defaultIgnoredPaths, "/target", "/Dockerfile-tools",
+  "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.m2", 
+  "*/.DS_Store",
+  "*/.dockerignore", "*/*~", "/.settings", "/localm2cache.zip"];
+
+const libertyIgnoredPaths = [...defaultIgnoredPaths, "/Dockerfile-tools", "/target",
+  "/mc-target", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", 
+  "*/.DS_Store", "*/.dockerignore",
+  "*/*~", "/.settings", "/localm2cache.zip", "/libertyrepocache.zip"];
 
 const projectTypeToIgnoredPaths = {
   'swift': swiftIgnoredPaths,

--- a/src/pfe/portal/modules/utils/ignoredPaths.js
+++ b/src/pfe/portal/modules/utils/ignoredPaths.js
@@ -6,24 +6,16 @@ const dockerIgnoredPaths = [...defaultIgnoredPaths];
 
 const swiftIgnoredPaths = [...defaultIgnoredPaths, "/LICENSE", "/Package.resolved", "README.rtf", "/debian", "/manifest.yml", 
   "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.bluemix", "/iterative-dev.sh", "/terraform",
-  ".swift-version", "/.build-ubuntu", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json",
-  "*/.DS_Store", "*/.dockerignore",
-  "*/*~", "/.settings"];
+  ".swift-version", "/.build-ubuntu", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json"];
 
 const nodeIgnoredPaths =  [...defaultIgnoredPaths, "/run-dev", "/run-debug", "/package-lock.json*", "/nodejs_restclient.log", "/nodejs_dc.log",
-  "/manifest.yml", "/idt.js", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", 
-  "*/.DS_Store", "*/.dockerignore",
-  "*/*~", "/.settings"];
+  "/manifest.yml", "/idt.js", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore"];
 
 const springIgnoredPaths = [...defaultIgnoredPaths, "/target", "/Dockerfile-tools",
-  "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.m2", 
-  "*/.DS_Store",
-  "*/.dockerignore", "*/*~", "/.settings", "/localm2cache.zip"];
+  "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.m2", "/localm2cache.zip"];
 
 const libertyIgnoredPaths = [...defaultIgnoredPaths, "/Dockerfile-tools", "/target",
-  "/mc-target", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", 
-  "*/.DS_Store", "*/.dockerignore",
-  "*/*~", "/.settings", "/localm2cache.zip", "/libertyrepocache.zip"];
+  "/mc-target", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", "/localm2cache.zip", "/libertyrepocache.zip"];
 
 const projectTypeToIgnoredPaths = {
   'swift': swiftIgnoredPaths,

--- a/test/src/unit/ignoredPaths.test.js
+++ b/test/src/unit/ignoredPaths.test.js
@@ -8,12 +8,22 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
 *******************************************************************************/
-const { projectTypeToIgnoredPaths } = require('../../../src/pfe/portal/modules/utils/ignoredPaths');
+const rewire = require('rewire');
+const ignoredPaths = rewire('../../../src/pfe/portal/modules/utils/ignoredPaths');
+const { projectTypeToIgnoredPaths } = ignoredPaths;
 
 const chai = require('chai');
 chai.should();
 
 describe('ignoredPaths.js', () => {
+    it('checks that all projectTypes return the default values', () => {
+        const defaultIgnoredPaths = ignoredPaths.__get__('defaultIgnoredPaths');
+        ['docker', 'swift', 'nodejs', 'liberty', 'spring'].forEach(type => {
+            const ignoredPaths = projectTypeToIgnoredPaths[type];
+            ignoredPaths.should.be.an('array');
+            ignoredPaths.should.include.members(defaultIgnoredPaths);
+        });
+    });
     it('returns array for docker projectType', () => {
         const ignoredPaths = projectTypeToIgnoredPaths['docker'];
         ignoredPaths.should.be.an('array');
@@ -25,7 +35,7 @@ describe('ignoredPaths.js', () => {
         ignoredPaths.should.include('.swift-version');
     });
     it('returns array for nodejs projectType', () => {
-        const ignoredPaths = projectTypeToIgnoredPaths['swift'];
+        const ignoredPaths = projectTypeToIgnoredPaths['nodejs'];
         ignoredPaths.should.be.an('array');
         ignoredPaths.should.include('*/node_modules*');
     });


### PR DESCRIPTION
Fix for: https://github.com/eclipse/codewind/issues/1996
### Summary
* Updates the ignoredPaths to have `*.iml` to ignore metadata files and to have `.idea` to ignore metadata directories.
* Makes the ignoredPaths have a default to make updating easier in the future.
    * Kept `defaultIgnoredPaths` and `dockerIgnoredPaths` separate so in the future they can be updated separate.
### Testing
* Added unit test to ensure defaults exist for every type.
* Fixed test.

Signed-off-by: James Wallis <james.wallis1@ibm.com>