### PR TITLE
Fix path for creating a new file in lagom project test

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/configs/app.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/app.config.ts
@@ -34,7 +34,7 @@ export enum codewindTemplates {
     odo = "odo"
 }
 
-export enum projecLanguges {
+export enum projectLanguges {
     go = "go",
     lagom = "lagom",
     liberty = "liberty",
@@ -51,34 +51,34 @@ export const extensionPaths: any = {
 
 export const projectTypes: any = {
     [codewindTemplates.default]: [
-        projecLanguges.liberty,
-        projecLanguges.nodejs,
-        projecLanguges.spring,
-        projecLanguges.swift
+        projectLanguges.liberty,
+        projectLanguges.nodejs,
+        projectLanguges.spring,
+        projectLanguges.swift
     ],
     [codewindTemplates.docker]: [
-        projecLanguges.go,
-        projecLanguges.lagom,
-        projecLanguges.python
+        projectLanguges.go,
+        projectLanguges.lagom,
+        projectLanguges.python
     ],
     [codewindTemplates.odo]: process.env.IN_K8 ? [
-        projecLanguges.nodejs,
-        projecLanguges.perl,
-        projecLanguges.python
+        projectLanguges.nodejs,
+        projectLanguges.perl,
+        projectLanguges.python
     ] : []
 };
 
 export const templateNames: any = {
     [codewindTemplates.default] : {
-        [projecLanguges.liberty]: "javamicroprofiletemplate",
-        [projecLanguges.nodejs]: "node",
-        [projecLanguges.spring]: "springjavatemplate",
-        [projecLanguges.swift]: "swifttemplate",
+        [projectLanguges.liberty]: "javamicroprofiletemplate",
+        [projectLanguges.nodejs]: "node",
+        [projectLanguges.spring]: "springjavatemplate",
+        [projectLanguges.swift]: "swifttemplate",
     },
     [codewindTemplates.docker]: {
-        [projecLanguges.go]: "gotemplate",
-        [projecLanguges.lagom]: "lagomjavatemplate",
-        [projecLanguges.python]: "pythontemplate",
+        [projectLanguges.go]: "gotemplate",
+        [projectLanguges.lagom]: "lagomjavatemplate",
+        [projectLanguges.python]: "pythontemplate",
     }
 };
 

--- a/src/pfe/file-watcher/server/test/functional-test/configs/log.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/log.config.ts
@@ -14,7 +14,7 @@
  * maven.build -> maven build log file
  * app.compile -> app compilation log file
  */
-import { codewindTemplates, projecLanguges } from "./app.config";
+import { codewindTemplates, projectLanguges } from "./app.config";
 
 export enum log_names {
     dockerBuild = "docker.build.log",
@@ -62,7 +62,7 @@ const defaultODOLogs = {
 
 export const logFileMappings: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: {
+        [projectLanguges.liberty]: {
             [logTypes.build]: [{
                 "origin": logOrigins.container,
                 "files": [log_names.mavenBuild]
@@ -78,7 +78,7 @@ export const logFileMappings: any = {
                 "files": [log_names.libertyConsole, log_names.libertyMessages]
             }]
         },
-        [projecLanguges.nodejs]: {
+        [projectLanguges.nodejs]: {
             [logTypes.build]: [{
                 "origin": logOrigins.workspace,
                 "files": [log_names.dockerBuild]
@@ -88,7 +88,7 @@ export const logFileMappings: any = {
                 "files": [log_names.application]
             }]
         },
-        [projecLanguges.spring]: {
+        [projectLanguges.spring]: {
             [logTypes.build]: [{
                 "origin": logOrigins.container,
                 "files": [log_names.mavenBuild]
@@ -101,7 +101,7 @@ export const logFileMappings: any = {
                 "files": [log_names.application]
             }]
         },
-        [projecLanguges.swift]: {
+        [projectLanguges.swift]: {
             [logTypes.build]: [{
                 "origin": logOrigins.workspace,
                 "files": process.env.IN_K8 ? [log_names.appCompile, log_names.dockerApp] : [log_names.dockerApp, log_names.appCompile, log_names.dockerBuild]
@@ -113,13 +113,13 @@ export const logFileMappings: any = {
         }
     },
     [codewindTemplates.docker]: {
-        [projecLanguges.go]:  defaultDockerLogs,
-        [projecLanguges.lagom]: defaultDockerLogs,
-        [projecLanguges.python]: defaultDockerLogs
+        [projectLanguges.go]:  defaultDockerLogs,
+        [projectLanguges.lagom]: defaultDockerLogs,
+        [projectLanguges.python]: defaultDockerLogs
     },
     [codewindTemplates.odo]: {
-        [projecLanguges.nodejs]: defaultODOLogs,
-        [projecLanguges.perl]: defaultODOLogs,
-        [projecLanguges.python]: defaultODOLogs
+        [projectLanguges.nodejs]: defaultODOLogs,
+        [projectLanguges.perl]: defaultODOLogs,
+        [projectLanguges.python]: defaultODOLogs
     },
 };

--- a/src/pfe/file-watcher/server/test/functional-test/configs/project.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/project.config.ts
@@ -17,7 +17,7 @@ import * as nodeProject from "../../../src/projects/nodejsProject";
 import * as springProject from "../../../src/projects/springProject";
 import * as swiftProject from "../../../src/projects/swiftProject";
 
-import { codewindTemplates, projecLanguges } from "./app.config";
+import { codewindTemplates, projectLanguges } from "./app.config";
 
 /**
  * Please note: This is the project config file. The configs are set in the order of template -> projectLang in an object. If a key is missing by default it means that specific functionality for that key is not supported.
@@ -27,33 +27,33 @@ import { codewindTemplates, projecLanguges } from "./app.config";
 // We currently need to do that because project that relies on script and IDC code does not follow the typescript code and need to be manually reset.
 export const needManualReset: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: {
+        [projectLanguges.liberty]: {
             "appStatus": true,
             "buildStatus": true
         },
-        [projecLanguges.nodejs]: {
+        [projectLanguges.nodejs]: {
             "appStatus": true,
             "buildStatus": true
         },
-        [projecLanguges.spring]: {
+        [projectLanguges.spring]: {
             "appStatus": true,
             "buildStatus": true,
         },
-        [projecLanguges.swift]: {
+        [projectLanguges.swift]: {
             "appStatus": false,
             "buildStatus": true
         }
     },
     [codewindTemplates.odo]: {
-        [projecLanguges.nodejs]: {
+        [projectLanguges.nodejs]: {
             "appStatus": false,
             "buildStatus": true
         },
-        [projecLanguges.perl]: {
+        [projectLanguges.perl]: {
             "appStatus": false,
             "buildStatus": true
         },
-        [projecLanguges.python]: {
+        [projectLanguges.python]: {
             "appStatus": false,
             "buildStatus": true
         }
@@ -63,54 +63,54 @@ export const needManualReset: any = {
 // project specific capability settings: start modes and control commands
 export const projectCapabilities: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: {
+        [projectLanguges.liberty]: {
             "local": {
                 "startModes": ["run", "debug"],
                 "controlCommands": ["restart"]
             },
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.nodejs]: {
+        [projectLanguges.nodejs]: {
             "local": {
                 "startModes": ["run", "debugNoInit"],
                 "controlCommands": ["restart"]
             },
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.spring]: {
+        [projectLanguges.spring]: {
             "local": {
                 "startModes": ["run", "debug", "debugNoInit"],
                 "controlCommands": ["restart"]
             },
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.swift]: {
+        [projectLanguges.swift]: {
             "local": project.defaultProjectCapabilities,
             "kube": project.defaultProjectCapabilities
         }
     },
     [codewindTemplates.docker]: {
-        [projecLanguges.go]: {
+        [projectLanguges.go]: {
             "local": project.defaultProjectCapabilities,
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.lagom]: {
+        [projectLanguges.lagom]: {
             "local": project.defaultProjectCapabilities,
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.python]: {
+        [projectLanguges.python]: {
             "local": project.defaultProjectCapabilities,
             "kube": project.defaultProjectCapabilities
         }
     },
     [codewindTemplates.odo]: {
-        [projecLanguges.nodejs]: {
+        [projectLanguges.nodejs]: {
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.perl]: {
+        [projectLanguges.perl]: {
             "kube": project.defaultProjectCapabilities
         },
-        [projecLanguges.python]: {
+        [projectLanguges.python]: {
             "kube": project.defaultProjectCapabilities
         }
     }
@@ -119,7 +119,7 @@ export const projectCapabilities: any = {
 // auto build enable/disable event capabilities: some projects emit the project changed event and some don't do anything
 export const autoBuildEventCapabailities: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.nodejs]: true,
+        [projectLanguges.nodejs]: true,
     }
 };
 
@@ -129,26 +129,26 @@ export const startModes: Array<string> = ["run", "debug", "debugNoInit"];
 // project specific restart capabilities depending on the above start modes
 export const restartCapabilities: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: [startModes[0], startModes[1]],
-        [projecLanguges.nodejs]: [startModes[0], startModes[2]],
-        [projecLanguges.spring]: startModes,
+        [projectLanguges.liberty]: [startModes[0], startModes[1]],
+        [projectLanguges.nodejs]: [startModes[0], startModes[2]],
+        [projectLanguges.spring]: startModes,
     }
 };
 
 // project specific debug capabilities
 export const debugCapabilities: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: true,
-        [projecLanguges.nodejs]: true,
-        [projecLanguges.spring]: true,
+        [projectLanguges.liberty]: true,
+        [projectLanguges.nodejs]: true,
+        [projectLanguges.spring]: true,
     }
 };
 
 // project specific maven profile capabilities
 export const mavenProfileCapabilities: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: true,
-        [projecLanguges.spring]: true,
+        [projectLanguges.liberty]: true,
+        [projectLanguges.spring]: true,
     }
 };
 
@@ -158,7 +158,7 @@ export const randomDebugPort = "1000";
 // default context roots for projects
 export const defaultContextRoot: any = {
     [codewindTemplates.docker]: {
-        [projecLanguges.lagom]: "/api/hello/you"
+        [projectLanguges.lagom]: "/api/hello/you"
     }
 };
 
@@ -168,33 +168,33 @@ export const defaultHealthCheckEndPoint = "/";
 // project specific setting for projects that only expose one app port
 export const oneExposedPortOnly: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: {
+        [projectLanguges.liberty]: {
             "local": false,
             "kube": false
         },
-        [projecLanguges.nodejs]: {
+        [projectLanguges.nodejs]: {
             "local": false,
             "kube": true
         },
-        [projecLanguges.spring]: {
+        [projectLanguges.spring]: {
             "local": false,
             "kube": true
         },
-        [projecLanguges.swift]: {
+        [projectLanguges.swift]: {
             "local": true,
             "kube": true
         }
     },
     [codewindTemplates.docker]: {
-        [projecLanguges.go]: {
+        [projectLanguges.go]: {
             "local": true,
             "kube": true
         },
-        [projecLanguges.lagom]: {
+        [projectLanguges.lagom]: {
             "local": false,
             "kube": true
         },
-        [projecLanguges.python]: {
+        [projectLanguges.python]: {
             "local": true,
             "kube": true
         }
@@ -204,46 +204,46 @@ export const oneExposedPortOnly: any = {
 // project specific setting for default app ports
 export const defaultInternalPorts: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: libertyProject.getDefaultAppPort(),
-        [projecLanguges.nodejs]: nodeProject.getDefaultAppPort(),
-        [projecLanguges.spring]: springProject.getDefaultAppPort(),
-        [projecLanguges.swift]: swiftProject.getDefaultAppPort()
+        [projectLanguges.liberty]: libertyProject.getDefaultAppPort(),
+        [projectLanguges.nodejs]: nodeProject.getDefaultAppPort(),
+        [projectLanguges.spring]: springProject.getDefaultAppPort(),
+        [projectLanguges.swift]: swiftProject.getDefaultAppPort()
     },
     [codewindTemplates.docker]: {
-        [projecLanguges.go]: "8000",
-        [projecLanguges.lagom]: "9000",
-        [projecLanguges.python]: "5000",
+        [projectLanguges.go]: "8000",
+        [projectLanguges.lagom]: "9000",
+        [projectLanguges.python]: "5000",
     }
 };
 
 // project specific setting for default app debug ports
 export const defaultInternalDebugPorts: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: libertyProject.getDefaultDebugPort(),
-        [projecLanguges.nodejs]: nodeProject.getDefaultDebugPort(),
-        [projecLanguges.spring]: springProject.getDefaultDebugPort(),
+        [projectLanguges.liberty]: libertyProject.getDefaultDebugPort(),
+        [projectLanguges.nodejs]: nodeProject.getDefaultDebugPort(),
+        [projectLanguges.spring]: springProject.getDefaultDebugPort(),
     }
 };
 
 // project specific settings to mark the main files
 export const filesToUpdate: any = {
     [codewindTemplates.default]: {
-        [projecLanguges.liberty]: ["Dockerfile", "src/main/java/application/rest/v1/Example.java"],
-        [projecLanguges.nodejs]: ["Dockerfile", "server/server.js"],
-        [projecLanguges.spring]: ["Dockerfile", "src/main/java/application/rest/v1/Example.java"],
-        [projecLanguges.swift]: ["Dockerfile", "Sources/Application/Routes/HealthRoutes.swift"],
+        [projectLanguges.liberty]: ["Dockerfile", "src/main/java/application/rest/v1/Example.java"],
+        [projectLanguges.nodejs]: ["Dockerfile", "server/server.js"],
+        [projectLanguges.spring]: ["Dockerfile", "src/main/java/application/rest/v1/Example.java"],
+        [projectLanguges.swift]: ["Dockerfile", "Sources/Application/Routes/HealthRoutes.swift"],
     },
     [codewindTemplates.docker]: {
-        [projecLanguges.go]: ["Dockerfile", "main.go"],
-        [projecLanguges.lagom]: ["Dockerfile",
+        [projectLanguges.go]: ["Dockerfile", "main.go"],
+        [projectLanguges.lagom]: ["Dockerfile",
             "hello-api/src/main/java/com/example/rp/test/lagomendpoints/api/HelloService.java",
             "hello-impl/src/main/java/com/example/rp/test/lagomendpoints/impl/HelloModule.java",
             "hello-impl/src/main/java/com/example/rp/test/lagomendpoints/impl/HelloServiceImpl.java"],
-        [projecLanguges.python]: ["Dockerfile", "app.py"],
+        [projectLanguges.python]: ["Dockerfile", "app.py"],
     },
     [codewindTemplates.odo]: {
-        [projecLanguges.nodejs]: ["server.js"],
-        [projecLanguges.perl]: ["index.pl"],
-        [projecLanguges.python]: ["wsgi.py"]
+        [projectLanguges.nodejs]: ["server.js"],
+        [projectLanguges.perl]: ["index.pl"],
+        [projectLanguges.python]: ["wsgi.py"]
     }
 };

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -22,7 +22,7 @@ import * as utils from "../../../lib/utils";
 import * as eventConfigs from "../../../configs/event.config";
 import * as project_configs from "../../../configs/project.config";
 import * as timeoutConfigs from "../../../configs/timeout.config";
-import { projecLanguges } from "../../../configs/app.config";
+import { projectLanguges } from "../../../configs/app.config";
 import { fail } from "assert";
 
 export function projectEventTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
@@ -78,7 +78,7 @@ export function projectEventTest(socket: SocketIO, projData: projectsController.
                     }
 
                     const fileToChange = file;
-                    const pathFileToChange = projectLang.toLowerCase() === projecLanguges.lagom ? path.join(projData.location, "hello-impl", fileToChange) : path.join(projData.location, fileToChange);
+                    const pathFileToChange = projectLang.toLowerCase() === projectLanguges.lagom ? path.join(projData.location, "hello-impl", fileToChange) : path.join(projData.location, fileToChange);
 
                     if (file.toLowerCase() === "dockerfile") {
                         const dockerFileContents = await fs.readFileSync(pathFileToChange).toString();

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -22,6 +22,7 @@ import * as utils from "../../../lib/utils";
 import * as eventConfigs from "../../../configs/event.config";
 import * as project_configs from "../../../configs/project.config";
 import * as timeoutConfigs from "../../../configs/timeout.config";
+import { projecLanguges } from "../../../configs/app.config";
 import { fail } from "assert";
 
 export function projectEventTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
@@ -77,7 +78,7 @@ export function projectEventTest(socket: SocketIO, projData: projectsController.
                     }
 
                     const fileToChange = file;
-                    const pathFileToChange = path.join(projData.location, fileToChange);
+                    const pathFileToChange = projectLang.toLowerCase() === projecLanguges.lagom ? path.join(projData.location, "hello-impl", fileToChange) : path.join(projData.location, fileToChange);
 
                     if (file.toLowerCase() === "dockerfile") {
                         const dockerFileContents = await fs.readFileSync(pathFileToChange).toString();


### PR DESCRIPTION
### Description

The performance time for creating a new file for lagom in our test is significantly low. This is because the file is created in a folder that is not taken into account for docker builds. We need to have the file under `hello-impl` for it to be taken into consideration.

Reran the test after this change and saw the full dockerbuild take place which takes ~3.5mins

Signed-off-by: ssh24 <sakib@ibm.com>