### PR TITLE
Pass changedFilesMap as an arg to triggerBuild function

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -30,7 +30,7 @@ import * as statusController from "./projectStatusController";
 import * as projectExtensions from "../extensions/projectExtensions";
 import * as processManager from "../utils/processManager";
 import { Validator } from "../projects/Validator";
-import { changedFilesMap } from "../utils/fileChanges";
+import { changedFilesMap, IFileChangeEvent } from "../utils/fileChanges";
 
 
 interface ProjectInfoCache {
@@ -482,8 +482,8 @@ async function checkBuildQueue(): Promise<void> {
 
                 logger.logDebug("Metadata for next build: " + JSON.stringify(buildToBeTriggered));
 
-                triggerBuild(buildToBeTriggered);
                 runningBuilds.push(buildToBeTriggered);
+                triggerBuild(buildToBeTriggered, changedFilesMap.get(buildToBeTriggered.operation.projectInfo.projectID));
             }
         }
         done();
@@ -508,7 +508,7 @@ async function checkBuildQueue(): Promise<void> {
  *
  * @returns Promise<void>
  */
-async function triggerBuild(project: BuildQueueType): Promise<void> {
+async function triggerBuild(project: BuildQueueType, changedFiles?: IFileChangeEvent[]): Promise<void> {
     const projectInfo = project.operation.projectInfo;
 
     const projectID = projectInfo.projectID;
@@ -553,7 +553,7 @@ async function triggerBuild(project: BuildQueueType): Promise<void> {
 
         // Hand off operation to appropriate handler for execution
         logger.logProjectInfo(`Handing ${operationType} operation to the selected project handler`, projectID);
-        selectedProjectHandler.update(operation, changedFilesMap.get(projectID));
+        selectedProjectHandler.update(operation, changedFiles);
     } else {
         return;
     }


### PR DESCRIPTION
### Description

Related to https://github.com/eclipse/codewind/issues/2015

We need to pass changed files map as an argument to trigger build function because the function does not await. We intentionally don't do an await on `triggerBuild` because we want the process of putting projects into the list sync and non-blocking. As a result, since there is no await, the changedFilesMap delete is called before it even goes to the update call where it is used.

This PR fixes this by passing the changedFilesMap into the triggerBuild function and then using that copy of it in the update call.

Verified this works on the appsody stack with instructions from @makandre.

Signed-off-by: ssh24 <sakib@ibm.com>