### PR TITLE
add k8s check around docker command

### DIFF
--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -55,7 +55,9 @@ async function inject(req, res) {
 
     res.sendStatus(202);
 
+
     await syncProjectFilesIntoBuildContainer(project, user);
+
   } catch (err) {
     log.error(err);
     res.status(500).send(err.info || err.message);
@@ -66,11 +68,14 @@ async function syncProjectFilesIntoBuildContainer(project, user){
   const globalProjectPath = path.join(project.workspace, project.name);
   const projectRoot = cwUtils.getProjectSourceRoot(project);
   if (project.buildStatus != "inProgress") {
-    await cwUtils.copyProjectContents(
-      project,
-      globalProjectPath,
-      projectRoot
-    );
+    if (!global.codewind.RUNNING_IN_K8S && project.projectType != 'docker' &&
+      (!project.extension || !project.extension.config.needsMount)) {
+      await cwUtils.copyProjectContents(
+        project,
+        globalProjectPath,
+        projectRoot
+      );
+    }
     await user.buildProject(project, "build");
   } else {
     // if a build is in progress, wait 5 seconds and try again

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -68,8 +68,7 @@ async function syncProjectFilesIntoBuildContainer(project, user){
   const globalProjectPath = path.join(project.workspace, project.name);
   const projectRoot = cwUtils.getProjectSourceRoot(project);
   if (project.buildStatus != "inProgress") {
-    if (!global.codewind.RUNNING_IN_K8S && project.projectType != 'docker' &&
-      (!project.extension || !project.extension.config.needsMount)) {
+    if (!global.codewind.RUNNING_IN_K8S) {
       await cwUtils.copyProjectContents(
         project,
         globalProjectPath,


### PR DESCRIPTION
we should not be calling docker functions when running K8S

I've used the same logic we do when syncing to docker containers to make sure we are consistent

Signed-off-by: Toby Corbin <corbint@uk.ibm.com>