### PR TITLE
Profiling API uses ReadStream

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -544,14 +544,21 @@ paths:
   /api/v1/projects/{id}/profiling/{testRunTime}:
     get:
       summary: Reads the load run data for the given timestamp
-      description: Reads and returns profiling.json for Node projects. Copies over health center data to pfe from Java projects and returns the file path.
+      description: Reads profiling data from pfe and returns a stream of the file. For java projects, this first copies profiling data
+        from the project pod to PFE.
       parameters:
-        - name: id
-          in: path
+        - in: path
+          name: id
           schema:
             type: string
           required: true
           description: id of project
+        - in: path
+          schema:
+            type: string
+          name: testRunTime
+          required: true
+          description: Time of loadtest run
       responses:
         200:
           description: Successful read of load run data

--- a/src/pfe/portal/modules/utils/errors/ProjectMetricsError.js
+++ b/src/pfe/portal/modules/utils/errors/ProjectMetricsError.js
@@ -39,6 +39,9 @@ function constructMessage(code, identifier, message) {
   case 'HCD_NOT_FOUND':
     output = `Unable to find .hcd saved in project ${identifier}`
     break;
+  case 'PROFILING_NOT_FOUND':
+    output = `Unable to find profiling.json saved in project ${identifier}`;
+    break;
   default:
     output = `Unknown project metrics error`;
   }

--- a/src/pfe/portal/routes/projects/loadtest.route.js
+++ b/src/pfe/portal/routes/projects/loadtest.route.js
@@ -190,8 +190,10 @@ router.get('/api/v1/projects/:id/profiling/:testRunTime', validateReq, async fun
       return;
     }
     const testRunTime = req.sanitizeParams('testRunTime');
-    const newProfiling = await project.getProfilingByTime(testRunTime);
-    res.status(200).send(newProfiling);
+    const profilingStream = await project.getProfilingByTime(testRunTime);
+    res.status(200)
+    profilingStream.on('end', () => res.end());
+    profilingStream.pipe(res);
   } catch (err) {
     log.error(err.info || err);
     res.status(500).send(err.info || err);

--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -194,26 +194,6 @@ describe('Load Runner Tests', function() {
             res.should.have.status(409);
         });
     });
-
-    describe('retrieve profiling data (GET/profiling/:testRunTime', function() {
-        it('returns fails with 404 to GET/profiling/:testRunTime when project does not exist', async function() {
-            this.timeout(testTimeout.short);
-            const res = await getProfilingData('falseID', 0);
-            res.should.have.status(404);
-        });
-
-        it('returns fails with 500 to GET/profiling/:testRunTime when timestamp is invalid', async function() {
-            this.timeout(testTimeout.short);
-            const res = await getProfilingData(projectID, 'invalid');
-            res.should.have.status(500);
-        });
-
-        it('returns fails with 500 to GET/profiling/:testRunTime when load run at timestamp does not exist', async function() {
-            this.timeout(testTimeout.short);
-            const res = await getProfilingData(projectID, 0);
-            res.should.have.status(500);
-        });
-    });
 });
 
 async function writeToLoadTestConfig(projectID, configOptions) {
@@ -238,10 +218,3 @@ function modifyOptions(options, newOptions) {
     });
     return modifiedOptions;
 };
-
-async function getProfilingData(projectID, timestamp) {
-    const res = await reqService.chai
-        .get(`/api/v1/projects/${projectID}/profiling/${timestamp}`)
-        .set('cookie', ADMIN_COOKIE);
-    return res;
-}

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -538,18 +538,36 @@ describe('Project.js', () => {
             project.language = 'nodejs';
             project.loadTestPath = loadTestResources;
             const profilingFile = '20190326154749';
-            const profilingTypes = await project.getProfilingByTime(profilingFile);
-            const actualProfilingFromFile = await fs.readJSON(path.join(loadTestResources, profilingFile, 'profiling.json'));
-            profilingTypes.should.deep.equal(actualProfilingFromFile);
+            const profilingStream = await project.getProfilingByTime(profilingFile);
+            const actualProfilingFromFile = await fs.readJSON(path.join(loadTestResources, String(profilingFile), 'profiling.json'));
+            const bufferS = [];
+            let buffer = null;
+            profilingStream.on('data', function(data) {
+                bufferS.push(data);
+            });
+            profilingStream.on('end', function() {
+                buffer = Buffer.concat(bufferS);
+                const profilingOutput = JSON.parse(buffer);
+                profilingOutput.should.deep.equal(actualProfilingFromFile);
+            });
         });
         it('Gets a profiling file using a valid time stamp (Int)', async() => {
             const project = createDefaultProjectAndCheckIsAnObject();
             project.language = 'nodejs';
             project.loadTestPath = loadTestResources;
             const profilingFile = 20190326154749;
-            const profilingTypes = await project.getProfilingByTime(profilingFile);
+            const profilingStream = await project.getProfilingByTime(profilingFile);
             const actualProfilingFromFile = await fs.readJSON(path.join(loadTestResources, String(profilingFile), 'profiling.json'));
-            profilingTypes.should.deep.equal(actualProfilingFromFile);
+            const bufferS = [];
+            let buffer = null;
+            profilingStream.on('data', function(data) {
+                bufferS.push(data);
+            });
+            profilingStream.on('end', function() {
+                buffer = Buffer.concat(bufferS);
+                const profilingOutput = JSON.parse(buffer);
+                profilingOutput.should.deep.equal(actualProfilingFromFile);
+            });
         });
     });
     describe('getPathToProfilingFile(timeOfTestRun)', () => {


### PR DESCRIPTION
- Update the profiling API to return a readStream for both Node and Java, simplifying the API to have a consistent return
- Enables the return of profiling to work on both local and remote as files can be retrieved from PFE without the need for docker commands
- Updated tests to reflect the new output
- Inclusion of a counter in the retry loop to check for .hcd file saving to prevent spinning infinitely
- Consistency of emitted socket messages from LoadRunner

Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>