### PR TITLE
Add PPC people as codeowners for Dockerfiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,7 @@ src/gatekeeper/** @markcor11 @tobespc
 src/keycloak/** @markcor11 @tobespc 
 src/performance/** @markcor11 @tobespc 
 test/** @stalleyj @tobespc
+
+# Dockerfiles
+# Notify regarding Dockerfile changes for PPC
+**/Dockerfile* @vrushaliinamdar @seth-priya


### PR DESCRIPTION
### Summary
Add PPC conversion team as a Codeowner for the Dockerfiles so that they are automatically notified when a change is made to the Dockerfiles.

Signed-off-by: James Wallis <james.wallis1@ibm.com>