### PR TITLE
fix: update injected nodejs metrics package

### DIFF
--- a/src/pfe/portal/modules/metricsService/node.js
+++ b/src/pfe/portal/modules/metricsService/node.js
@@ -55,7 +55,7 @@ function getNewContentsOfPackageJson(originalContentsOfPackageJson) {
   newContentsOfPackageJson.scripts.start = getNewStartScript(originalContentsOfPackageJson.scripts.start);
   newContentsOfPackageJson.dependencies = {
     ...newContentsOfPackageJson.dependencies,
-    'appmetrics-codewind': '^0.1.0',
+    'appmetrics-codewind': '^0.2.0',
   }
   return newContentsOfPackageJson;
 }

--- a/test/resources/metricsService/node/package.json/validForInjection/withDependencies/withCollector.json
+++ b/test/resources/metricsService/node/package.json/validForInjection/withDependencies/withCollector.json
@@ -9,6 +9,6 @@
     "dependencies": {
         "body-parser": "^1.18.3",
         "express": "^4.16.4",
-        "appmetrics-codewind": "^0.1.0"
+        "appmetrics-codewind": "^0.2.0"
     }
 }

--- a/test/resources/metricsService/node/package.json/validForInjection/withoutDependencies/withCollector.json
+++ b/test/resources/metricsService/node/package.json/validForInjection/withoutDependencies/withCollector.json
@@ -7,6 +7,6 @@
         "debug": "node --inspect=0.0.0.0:9229 $npm_package_config_entrypoint"
     },
     "dependencies": {
-        "appmetrics-codewind": "^0.1.0"
+        "appmetrics-codewind": "^0.2.0"
     }
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

Update metrics injection code to use the new `appmetrics-codewind` 0.2.0 we've [released](https://github.com/RuntimeTools/appmetrics-codewind/pull/5), which fixes https://github.com/eclipse/codewind/issues/1602