### PR TITLE
Use global workspace flag

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -565,7 +565,7 @@ module.exports = class User {
     }
 
     // Delete temp files from PFE's /codewind-workspace/cw-temp/<project> location
-    const cwTempPath = path.join(project.workspace, "cw-temp", project.directory);
+    const cwTempPath = path.join(global.codewind.CODEWIND_WORKSPACE, "cw-temp", project.directory);
     try {
       await cwUtils.forceRemove(cwTempPath);
     } catch (err) {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

In the process of deleting a project, we delete the temporary project directory inside the docker volume. We need to use the global.codewind.CODEWIND_WORKSPACE location to make the full path rather than the project.workspace.