### PR TITLE
Notification ID tracking support in app status events (part 1)

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -68,7 +68,6 @@ class ProjectState {
     appImageLastBuild?: string;
     buildImageLastBuild?: string;
     detailedAppStatus?: DetailedAppStatus;
-    notificationID?: string;
 
     /**
      * @constructor
@@ -80,9 +79,8 @@ class ProjectState {
      * @param appImageLastBuild <Optional | String> - The last app image info.
      * @param buildImageLastBuild <Optional | String> - The last build image info.
      * @param detailedAppStatus <Optional | DetailedAppStatus> - The detailed app status to update.
-     * @param notificationID <Optional | String> - Notification ID for IDE.
      */
-    constructor(state: any, msg: string, lastbuild?: number, appImageLastBuild?: string, buildImageLastBuild?: string, detailedAppStatus?: DetailedAppStatus, notificationID?: string) {
+    constructor(state: any, msg: string, lastbuild?: number, appImageLastBuild?: string, buildImageLastBuild?: string, detailedAppStatus?: DetailedAppStatus) {
         this.state = state;
         this.msg = msg;
         if (lastbuild)
@@ -93,8 +91,6 @@ class ProjectState {
             this.buildImageLastBuild = buildImageLastBuild;
         if (detailedAppStatus)
             this.detailedAppStatus = detailedAppStatus;
-        if (notificationID)
-            this.notificationID = notificationID;
     }
 
     /**
@@ -479,7 +475,10 @@ function pingInTransitApplications(): void {
                                     return;
                                 }
                                 const oldMsg = appStateMap.get(projectID).msg;
-                                const oldNotificationID = appStateMap.get(projectID).notificationID;
+                                let oldNotificationID = "";
+                                if ( appStateMap.get(projectID).detailedAppStatus ) {
+                                    oldNotificationID = appStateMap.get(projectID).detailedAppStatus.notificationID;
+                                }
                                 let newState = oldState;
                                 let newMsg = stateInfo.error;
 
@@ -556,7 +555,7 @@ function pingInTransitApplications(): void {
                                         data.detailedAppStatus = detailedAppStatus;
                                     }
                                     io.emitOnListener("projectStatusChanged", data);
-                                    appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, (detailedAppStatus) ? detailedAppStatus : appStateMap.get(projectID).detailedAppStatus, newNotificationID));
+                                    appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, (detailedAppStatus) ? detailedAppStatus : appStateMap.get(projectID).detailedAppStatus));
 
                                 }
                             }
@@ -567,7 +566,10 @@ function pingInTransitApplications(): void {
                         // The container is stopped so change the application state to stopped
                         if (appStateMap.get(projectID)) {
                             const oldState = appStateMap.get(projectID).state;
-                            const oldNotificationID = appStateMap.get(projectID).notificationID;
+                            let oldNotificationID = "";
+                            if ( appStateMap.get(projectID).detailedAppStatus ) {
+                                oldNotificationID = appStateMap.get(projectID).detailedAppStatus.notificationID;
+                            }
                             if (oldState !== AppState.starting && oldState !== AppState.stopping) {
                                 return;
                             }
@@ -586,7 +588,7 @@ function pingInTransitApplications(): void {
                                     notify: true,
                                     notificationID: newNotificationID
                                 };
-                                appStateMap.set(projectID, new ProjectState(AppState.stopped, data.appErrorStatus, undefined, undefined, undefined, data.detailedAppStatus, newNotificationID));
+                                appStateMap.set(projectID, new ProjectState(AppState.stopped, data.appErrorStatus, undefined, undefined, undefined, data.detailedAppStatus));
                                 data.detailedAppStatus.message =  await locale.getTranslation(data.detailedAppStatus.message);
                             } else {
                                 appStateMap.set(projectID, new ProjectState(AppState.stopped, undefined));

--- a/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectStatusController.ts
@@ -432,7 +432,6 @@ function pingApplications(): void {
 
                         // Update the state only if it has changed
                         if (newState != oldState) {
-                            const newNotificationID = "";
                             logger.logProjectInfo("pingApplications: Application state for project " + projectID + " has changed from " + oldState + " to " + newState, projectID);
                             const data: any = {
                                 projectID: projectID,
@@ -443,11 +442,11 @@ function pingApplications(): void {
                                     severity: "INFO",
                                     message: "",
                                     notify: false,
-                                    notificationID: newNotificationID
+                                    notificationID: ""
                                 };
                                 pingCountMap.delete(projectID);
                             }
-                            appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, (data.detailedAppStatus) ? data.detailedAppStatus : appStateMap.get(projectID).detailedAppStatus, newNotificationID));
+                            appStateMap.set(projectID, new ProjectState(newState, newMsg, undefined, undefined, undefined, (data.detailedAppStatus) ? data.detailedAppStatus : appStateMap.get(projectID).detailedAppStatus));
                             io.emitOnListener("projectStatusChanged", data);
                         }
                     }
@@ -545,11 +544,7 @@ function pingInTransitApplications(): void {
                                         pingCountMap.delete(projectID);
                                     } else if (newState === AppState.starting && pingCount == pingCountLimit) {
                                         const troubleShootLinkLabel = await locale.getTranslation("projectStatusController.linkLabel");
-                                        if ( !oldNotificationID ) {
-                                            newNotificationID = crypto.randomBytes(16).toString("hex");
-                                        } else {
-                                            newNotificationID = oldNotificationID;
-                                        }
+                                        newNotificationID = oldNotificationID ? oldNotificationID : crypto.randomBytes(16).toString("hex");
                                         detailedAppStatus = {
                                             severity: "WARN",
                                             message: newMsg,
@@ -584,12 +579,7 @@ function pingInTransitApplications(): void {
                             if (oldState === AppState.starting) {
                                 // If the container stopped while the application was starting up then something went wrong
                                 data.appErrorStatus = "projectStatusController.appStatusContainerStopped";
-                                let newNotificationID = "";
-                                if ( !oldNotificationID ) {
-                                    newNotificationID = crypto.randomBytes(16).toString("hex");
-                                } else {
-                                    newNotificationID = oldNotificationID;
-                                }
+                                const newNotificationID = oldNotificationID ? oldNotificationID : crypto.randomBytes(16).toString("hex");
                                 data.detailedAppStatus = {
                                     severity: "ERROR",
                                     message: data.appErrorStatus,

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -2129,7 +2129,8 @@ export async function updateDetailedAppStatus(projectID: string, ip: string, por
     pingPathEvent = {
         severity: "INFO",
         message: pingMessage,
-        notify: false
+        notify: false,
+        notificationID: ""
     };
 
     if (oldState === AppState.starting) {

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -69,7 +69,7 @@
     "appErrorWhenStopping": "An error occurred while the application was stopping. Check the application logs for details.",
     "pingTimeout": "Timeout: {{- pingMessage}}. The application is taking longer than expected to start. Please check the application logs for problems and ensure the project's 'healthCheck' setting is correct. Last error message received: {{- errMsg}}", 
     "pingTimeoutDefaultMessage": "Failed to ping application.",
-    "linkLabel": "Troubleshooting status"
+    "linkLabel": "Application status troubleshooting information"
   },
   "quickfix": {
     "generateMissingFilesName": "Generate missing files",


### PR DESCRIPTION
For https://github.com/eclipse/codewind/issues/1812

First cut of changes supporting notification IDs in status events, tracked per instance of an app/project status related problem.

Signed-off-by: Len Theivendra <theivend@ca.ibm.com>