### PR TITLE
feat, test, refactor: clarify project metrics info

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -522,9 +522,11 @@ module.exports = class FileWatcher {
       if(error) {
         results.error = error;
       }
-      let updatedProject = await this.user.projectList.updateProject(projectUpdate);
+      const { projectList } = this.user;
+      const updatedProject = await projectList.updateProject(projectUpdate);
+      const projectWithMetricsInfo = await projectList.retrieveProjectWithMetricsInfo(updatedProject.projectID);
       // remove fields which are not required by the UI
-      const { logStreams, ...projectInfoForUI } = updatedProject
+      const { logStreams, ...projectInfoForUI } = projectWithMetricsInfo;
       this.user.uiSocket.emit(event, { ...results, ...projectInfoForUI })
       if (fwProject.buildStatus === 'inProgress') {
         // Reset build logs.

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -522,11 +522,9 @@ module.exports = class FileWatcher {
       if(error) {
         results.error = error;
       }
-      const { projectList } = this.user;
-      const updatedProject = await projectList.updateProject(projectUpdate);
-      const projectWithMetricsInfo = await projectList.retrieveProjectWithMetricsInfo(updatedProject.projectID);
+      let updatedProject = await this.user.projectList.updateProject(projectUpdate);
       // remove fields which are not required by the UI
-      const { logStreams, ...projectInfoForUI } = projectWithMetricsInfo;
+      const { logStreams, ...projectInfoForUI } = updatedProject
       this.user.uiSocket.emit(event, { ...results, ...projectInfoForUI })
       if (fwProject.buildStatus === 'inProgress') {
         // Reset build logs.

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -166,33 +166,33 @@ module.exports = class Project {
     return {}
   }
 
-  async getPerfDashPath() {
-    const isPerfDashAvailable = this.injectMetrics || this.isOpenLiberty || (await this.checkIfMetricsAvailable());
+  getPerfDashPath() {
+    const isPerfDashAvailable = this.injectMetrics || this.isOpenLiberty || this.metricsAvailable;
     return isPerfDashAvailable
       ? `/performance/charts?project=${this.projectID}`
       : null;
   }
   
-  async getMetricsDashHost() {
-    const isMetricsDashAvailable = this.injectMetrics || this.isOpenLiberty || (await this.checkIfMetricsAvailable());
+  getMetricsDashHost() {
+    const isMetricsDashAvailable = this.injectMetrics || this.isOpenLiberty || this.metricsAvailable;
     if (!isMetricsDashAvailable) {
       return null;
     }
     
-    const shouldShowMetricsDashHostedOnProject = !this.injectMetrics && (await this.checkIfMetricsAvailable());
+    const shouldShowMetricsDashHostedOnProject = !this.injectMetrics && this.metricsAvailable;
     return shouldShowMetricsDashHostedOnProject
       ? METRICS_DASH_HOST.project
       : METRICS_DASH_HOST.performanceContainer;
   }
   
-  async getMetricsDashPath() {
-    const metricsDashHost = await this.getMetricsDashHost();
+  getMetricsDashPath() {
+    const metricsDashHost = this.getMetricsDashHost();
     if (!metricsDashHost) {
       return null;
     }
     
     if (metricsDashHost === METRICS_DASH_HOST.project) {
-      return `${pathsToUserHostedMetricsDashboards[this.language]}?theme=dark`;
+      return `/${pathsToUserHostedMetricsDashboards[this.language]}?theme=dark`;
     }
 
     if (metricsDashHost === METRICS_DASH_HOST.performanceContainer) {

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -192,7 +192,7 @@ module.exports = class Project {
     }
     
     if (metricsDashHost === METRICS_DASH_HOST.project) {
-      return `/${pathsToUserHostedMetricsDashboards[this.language]}?theme=dark`;
+      return `/${pathsToUserHostedMetricsDashboards[this.language]}/?theme=dark`;
     }
 
     if (metricsDashHost === METRICS_DASH_HOST.performanceContainer) {

--- a/src/pfe/portal/modules/ProjectList.js
+++ b/src/pfe/portal/modules/ProjectList.js
@@ -81,28 +81,28 @@ module.exports = class ProjectList {
    * @return the requested project
    */
   retrieveProject(id) {
-    return (this._list.hasOwnProperty(id) ? this._list[id] : undefined);
-  }
-
-  async retrieveProjectWithMetricsInfo(projectID) {
-    const project = this.retrieveProject(projectID);
+    const project = (this._list.hasOwnProperty(id) ? this._list[id] : undefined);
     if (!project) {
       return;
     }
-    const projectWithMetricsInfo = { 
-      ...project,
-      injection: {
-        injectable: project.canMetricsBeInjected,
-        injected: project.injectMetrics,
-      },
-      appMonitor: {
-        hosting: await project.getMetricsDashHost(),
-        path: await project.getMetricsDashPath(),
-      },
-      perfDashboardPath: await project.getPerfDashPath(),
+    project.injection = {
+      injectable: project.canMetricsBeInjected,
+      injected: project.injectMetrics,
     };
-    
-    return projectWithMetricsInfo;  
+    project.metricsDashboard = {
+      hosting: project.getMetricsDashHost(),
+      path: project.getMetricsDashPath(),
+    };
+    project.perfDashboardPath = project.getPerfDashPath();
+
+    return project;  
+  }
+
+  retrieveProjects() {
+    const projects = Object.values(this._list).map(
+      project => this.retrieveProject(project.projectID)
+    );
+    return projects;
   }
 
   /**
@@ -133,7 +133,7 @@ module.exports = class ProjectList {
     }
     this._list[updatedProject.projectID] = currentProject;
     await this._list[updatedProject.projectID].writeInformationFile();
-    return this._list[updatedProject.projectID];
+    return this.retrieveProject(updatedProject.projectID);
   }
 
   /**

--- a/src/pfe/portal/modules/ProjectList.js
+++ b/src/pfe/portal/modules/ProjectList.js
@@ -10,7 +10,6 @@
  *******************************************************************************/
 
 const ProjectListError = require('./utils/errors/ProjectListError');
-const metricsService = require('./metricsService');
 
 const Logger = require('./utils/Logger');
 
@@ -90,23 +89,17 @@ module.exports = class ProjectList {
     if (!project) {
       return;
     }
-    const canMetricsBeInjected = metricsService.canMetricsBeInjected(project);
-    const haveMetricsBeenInjected = project.injectMetrics;
-    const locationOfAppMonitorDashboard = await project.getLocationOfAppMonitorDashboard();
-    const pathToAppMonitorDashboard = await project.getPathToAppMonitorDashboard();
-    const pathToPerfDashboard = await project.getPathToPerfDashboard();
-  
     const projectWithMetricsInfo = { 
       ...project,
       injection: {
-        injectable: canMetricsBeInjected,
-        injected: haveMetricsBeenInjected,
+        injectable: project.canMetricsBeInjected,
+        injected: project.injectMetrics,
       },
       appMonitor: {
-        dashboardLocation: locationOfAppMonitorDashboard,
-        pathToDashboard: pathToAppMonitorDashboard,
+        hosting: await project.getMetricsDashHost(),
+        path: await project.getMetricsDashPath(),
       },
-      perfDashboard: pathToPerfDashboard,
+      perfDashboardPath: await project.getPerfDashPath(),
     };
     
     return projectWithMetricsInfo;  

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -36,6 +36,13 @@ const metricsCollectorRemovalFunctions = {
   spring: removeMetricsCollectorFromSpringProject,
 }
 
+const pathsToUserHostedMonitorDashboards = {
+  nodejs: 'appmetrics-dash',
+  javascript: 'appmetrics-dash',
+  java: 'javametrics-dash',
+  swift: 'swiftmetrics-dash',
+};
+
 async function injectMetricsCollectorIntoProject(projectType, projectDir) {
   if (!metricsCollectorInjectionFunctions.hasOwnProperty(projectType)) {
     throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -36,13 +36,6 @@ const metricsCollectorRemovalFunctions = {
   spring: removeMetricsCollectorFromSpringProject,
 }
 
-const pathsToUserHostedMonitorDashboards = {
-  nodejs: 'appmetrics-dash',
-  javascript: 'appmetrics-dash',
-  java: 'javametrics-dash',
-  swift: 'swiftmetrics-dash',
-};
-
 async function injectMetricsCollectorIntoProject(projectType, projectDir) {
   if (!metricsCollectorInjectionFunctions.hasOwnProperty(projectType)) {
     throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
@@ -551,4 +544,5 @@ function getNewPomXmlBuildPlugins(originalBuildPlugins) {
 module.exports = {
   injectMetricsCollectorIntoProject,
   removeMetricsCollectorFromProject,
+  metricsCollectorInjectionFunctions,
 }

--- a/src/pfe/portal/routes/projects/projects.route.js
+++ b/src/pfe/portal/routes/projects/projects.route.js
@@ -18,11 +18,11 @@ const log = new Logger(__filename);
  * API Function to get the a single project and return it as a json object
  * @return the project object
  */
-router.get('/api/v1/projects/:id', (req, res) => {
+router.get('/api/v1/projects/:id', async(req, res) => {
   try {
     let projectID = req.sanitizeParams('id');
     let user = req.cw_user;
-    let project = user.projectList.retrieveProject(projectID);
+    const project = await user.projectList.retrieveProjectWithMetricsInfo(projectID);
     if (project) {
       res.status(200).send(project);
     } else {
@@ -38,11 +38,16 @@ router.get('/api/v1/projects/:id', (req, res) => {
  * API Function to get the projectList and return it as an array
  * @return the projectList
  */
-router.get('/api/v1/projects', (req, res) => {
+router.get('/api/v1/projects', async(req, res) => {
   try {
     const user = req.cw_user;
-    const list = user.projectList.getAsArray();
-    res.status(200).send(list);
+    const { projectList } = user;
+    const projects = projectList.getAsArray();
+    const promises = projects.map(
+      project => projectList.retrieveProjectWithMetricsInfo(project.projectID)
+    );
+    const projectsWithMetricsInfo = await Promise.all(promises);
+    res.status(200).send(projectsWithMetricsInfo);
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/src/pfe/portal/routes/projects/projects.route.js
+++ b/src/pfe/portal/routes/projects/projects.route.js
@@ -18,11 +18,11 @@ const log = new Logger(__filename);
  * API Function to get the a single project and return it as a json object
  * @return the project object
  */
-router.get('/api/v1/projects/:id', async(req, res) => {
+router.get('/api/v1/projects/:id', (req, res) => {
   try {
     let projectID = req.sanitizeParams('id');
     let user = req.cw_user;
-    const project = await user.projectList.retrieveProjectWithMetricsInfo(projectID);
+    let project = user.projectList.retrieveProject(projectID);
     if (project) {
       res.status(200).send(project);
     } else {
@@ -38,16 +38,11 @@ router.get('/api/v1/projects/:id', async(req, res) => {
  * API Function to get the projectList and return it as an array
  * @return the projectList
  */
-router.get('/api/v1/projects', async(req, res) => {
+router.get('/api/v1/projects', (req, res) => {
   try {
     const user = req.cw_user;
-    const { projectList } = user;
-    const projects = projectList.getAsArray();
-    const promises = projects.map(
-      project => projectList.retrieveProjectWithMetricsInfo(project.projectID)
-    );
-    const projectsWithMetricsInfo = await Promise.all(promises);
-    res.status(200).send(projectsWithMetricsInfo);
+    const projects = user.projectList.retrieveProjects();
+    res.status(200).send(projects);
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -267,6 +267,8 @@ async function uploadEnd(req, res) {
       || filesToDelete.length > 0
       || modifiedList.length > 0;
     if (wasProjectChanged) {
+      await project.checkIfMetricsAvailable();
+
       await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
 
       if (project.injectMetrics) {

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -254,6 +254,8 @@ async function uploadEnd(req, res) {
       await deletePathsInArray(pathToProj, filesToDelete);
     }
 
+    await project.checkIfMetricsAvailable();
+
     res.sendStatus(200);
     
   } catch (err) {
@@ -267,8 +269,6 @@ async function uploadEnd(req, res) {
       || filesToDelete.length > 0
       || modifiedList.length > 0;
     if (wasProjectChanged) {
-      await project.checkIfMetricsAvailable();
-
       await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
 
       if (project.injectMetrics) {

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -442,6 +442,8 @@ async function bindEnd(req, res) {
     log.info(`Total time to bind project ${project.name} is ${totalbindtime} seconds`);
     timersyncstart = 0;
 
+    await project.checkIfMetricsAvailable();
+
     let updatedProject = {
       projectID,
       state: Project.STATES.open,

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -33,13 +33,17 @@ const sleep = promisify(setTimeout);
 async function createProjectFromTemplate(name, projectType, path, autoBuild = false) {
     const { url, language } = templateOptions[projectType];
 
+    const pfeProjectType = (projectType === 'openliberty')
+        ? 'docker'
+        : projectType;
+
     await cloneProject(url, path);
 
     const res = await bindProject({
         name,
         path,
         language,
-        projectType,
+        projectType: pfeProjectType,
         autoBuild,
         creationTime: Date.now(),
     });

--- a/test/src/API/projects/metricsInject.test.js
+++ b/test/src/API/projects/metricsInject.test.js
@@ -94,7 +94,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
                 isOpenLiberty: false,
                 metricsDashboard: {
                     hosting: 'project',
-                    path: `/appmetrics-dash?theme=dark`,
+                    path: `/appmetrics-dash/?theme=dark`,
                 },
                 perfDashboardPath: `/performance/charts?project=${projectID}`,
             });
@@ -154,7 +154,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
                 isOpenLiberty: false,
                 metricsDashboard: {
                     hosting: 'project',
-                    path: `/javametrics-dash?theme=dark`,
+                    path: `/javametrics-dash/?theme=dark`,
                 },
                 perfDashboardPath: `/performance/charts?project=${projectID}`,
             });

--- a/test/src/API/projects/metricsInject.test.js
+++ b/test/src/API/projects/metricsInject.test.js
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const chai = require('chai');
+const path = require('path');
+const chaiSubset = require('chai-subset');
+const chaiResValidator = require('chai-openapi-response-validator');
+
+const projectService = require('../../../modules/project.service');
+const reqService = require('../../../modules/request.service');
+const { 
+    ADMIN_COOKIE,
+    TEMP_TEST_DIR,
+    testTimeout,
+    pathToApiSpec,
+} = require('../../../config');
+
+chai.use(chaiSubset);
+chai.use(chaiResValidator(pathToApiSpec));
+chai.should();
+
+const postMetricsInject = (projectID, options) => reqService.chai
+    .post(`/api/v1/projects/${projectID}/metrics/inject`)
+    .set('Cookie', ADMIN_COOKIE)
+    .send(options);
+
+describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function() {
+    it('returns 404 to /metrics/inject when project does not exist', async function() {
+        const projectID = '00000000-0000-0000-0000-000000000000';
+        this.timeout(testTimeout.short);
+        const res = await postMetricsInject(projectID, { enable: true });
+        
+        res.should.have.status(404);
+        res.text.should.equal(`Unable to find project ${projectID}`);
+    });
+    
+    describe('Node.js success case (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-node-metrics-inject-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+    
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+    
+        it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: true });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: true,
+                injection: {
+                    injectable: true,
+                    injected: true,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/nodejs?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    
+        it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: false });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: false,
+                injection: {
+                    injectable: true,
+                    injected: false,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'project',
+                    path: `/appmetrics-dash?theme=dark`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    });
+    
+    describe('Java Liberty success case (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-liberty-metrics-inject-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+    
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'liberty', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+    
+        it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: true });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: true,
+                injection: {
+                    injectable: true,
+                    injected: true,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/java?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    
+        it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: false });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: false,
+                injection: {
+                    injectable: true,
+                    injected: false,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'project',
+                    path: `/javametrics-dash?theme=dark`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    });
+    
+    describe('Java Open Liberty success case (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-open-liberty-metrics-inject-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+    
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'openliberty', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+    
+        it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: true });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: false,
+                injectMetrics: true,
+                injection: {
+                    injectable: true,
+                    injected: true,
+                },
+                isOpenLiberty: true,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/java?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    
+        it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: false });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: false,
+                injectMetrics: false,
+                injection: {
+                    injectable: true,
+                    injected: false,
+                },
+                isOpenLiberty: true,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/java?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    });
+});


### PR DESCRIPTION
for https://github.com/eclipse/codewind/issues/1815, specifically this design https://github.com/eclipse/codewind/issues/1815#issuecomment-583354048

**Changes**
https://github.com/eclipse/codewind/pull/2043/commits/dd4bb4c220ff7da624a90ef3871649ba3374c625 and https://github.com/eclipse/codewind/pull/2043/commits/397f614265ca5ef27ee598d43856311d1a826ba1 adds the information to the `/projects` and `/project/:id` APIs, as well as the `projectChanged` event payload. https://github.com/eclipse/codewind/pull/2043/commits/971bfb69ede91d6739f7dd648839d2776615ea66 integrates this into our core `projectList.retrieveProject()` function.

**Testing**
I manually tested this across node.js, liberty, open liberty (with and without metrics packages already in the project) on local and remote. I also added automatic tests for our default node.js, liberty, open liberty projects on local.

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>
