### PR TITLE
Add a delay on setting build status so that the running build queue can be cleared

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -55,7 +55,7 @@ const MAX_BUILDS = parseInt(process.env.MC_MAX_BUILDS) || 3;
 const BUILD_KEY = "projectStatusController.buildRank";
 
 // timeout to ping build projects
-setInterval(checkBuildQueue, 5000);
+setInterval(checkBuildQueue, constants.buildQueueInterval);
 
 /**
  * @see [[Filewatcher.getProjectTypes]]

--- a/src/pfe/file-watcher/server/src/projects/constants.ts
+++ b/src/pfe/file-watcher/server/src/projects/constants.ts
@@ -38,3 +38,5 @@ export enum ControlCommands { stop = "stop", start = "start", restart = "restart
 export enum MavenFlags { profile = "-P ", properties = "-D " }
 
 export const disablePingPort = "-1";
+
+export const buildQueueInterval = 5000;

--- a/src/pfe/file-watcher/server/test/functional-test/configs/timeout.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/timeout.config.ts
@@ -10,9 +10,11 @@
  *******************************************************************************/
 
 import ms from "ms";
+import * as constants from "../../../src/projects/constants";
 
 export const defaultTimeout = ms("5m");
-export const defaultInterval = ms("5s");
+export const defaultInterval = ms("10s");
+export const buildQueueInterval = constants.buildQueueInterval + 2000; // 2 additional seconds on top of the regular build queue interval to wait for the build queue to be cleared
 
 export const createTestTimeout = ms("20m");
 export const deleteTestTimeout = ms("1m");

--- a/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
@@ -212,6 +212,7 @@ export async function setBuildStatus(projData: projectsController.ICreateProject
         });
         expect(info);
         expect(info.statusCode).to.equal(200);
+        await delay(timeoutConfigs.buildQueueInterval);
     }
 }
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/create.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/create.ts
@@ -48,7 +48,8 @@ export default class CreateTest {
             socket.clearEvents();
         });
 
-        after("remove build from running queue", async () => {
+        after("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
     }

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-action.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-action.ts
@@ -157,7 +157,8 @@ export function projectActionTest(socket: SocketIO, projData: projectsController
             await utils.callProjectAction(action, mode, socket, projData, targetEvents, targetEventDatas);
         });
 
-        after("remove build from running queue", async () => {
+        after("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
@@ -235,7 +235,8 @@ export function projectSpecificationTest(socket: SocketIO, projData: projectsCon
             socket.clearEvents();
         });
 
-        afterEach("remove build from running queue", async () => {
+        afterEach("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
@@ -31,7 +31,8 @@ export function updateStatusTest(socket: SocketIO, projData: projectsController.
             "projectID": projectID,
         };
 
-        afterEach("remove build from running queue", async () => {
+        afterEach("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
 
@@ -118,7 +119,8 @@ export function updateStatusTest(socket: SocketIO, projData: projectsController.
                     await utils.callProjectAction(action, mode, socket, projData, targetEvents, targetEventDatas);
                 });
 
-                after("remove build from running queue", async () => {
+                after("remove build from running queue", async function (): Promise<void> {
+                    this.timeout(timeoutConfigs.defaultInterval);
                     await utils.setBuildStatus(projData, projectTemplate, projectLang);
                 });
 


### PR DESCRIPTION
### Description

Closes https://github.com/eclipse/codewind/issues/2044

Have a slight delay when setting the build status which triggers the build from being removed from the running build queue. This is needed because some tests are so fast, that if we reset the build status before without waiting, the next test will overwrite it by adding it to the queue again. A next build starts before even the next 5s interval check happens so the status is now build in progress and the condition will to remove the build from running queue fails and the queue keeps getting clogged.

Signed-off-by: ssh24 <sakib@ibm.com>