### PR TITLE
Fix file path condition on new file create for lagom test

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -78,7 +78,7 @@ export function projectEventTest(socket: SocketIO, projData: projectsController.
                     }
 
                     const fileToChange = file;
-                    const pathFileToChange = projectLang.toLowerCase() === projectLanguges.lagom ? path.join(projData.location, "hello-impl", fileToChange) : path.join(projData.location, fileToChange);
+                    const pathFileToChange = projectLang.toLowerCase() === projectLanguges.lagom && type.toLowerCase() === "create" ? path.join(projData.location, "hello-impl", fileToChange) : path.join(projData.location, fileToChange);
 
                     if (file.toLowerCase() === "dockerfile") {
                         const dockerFileContents = await fs.readFileSync(pathFileToChange).toString();


### PR DESCRIPTION
### Description

Closes https://github.com/eclipse/codewind/issues/2053

The filepath for creating a new file in lagom should be tailored to the `create` operation only. This PR fixes it with the new condition.

Signed-off-by: ssh24 <sakib@ibm.com>