### PR TITLE
More default mpMetrics on dashboard

### DIFF
--- a/src/performance/monitor/public/graphmetrics/js/memPoolsChart.js
+++ b/src/performance/monitor/public/graphmetrics/js/memPoolsChart.js
@@ -329,7 +329,9 @@ function updateMemPoolsData(mempoolsRequest) {
   d.used = +d.usedHeap / (1024 * 1024);
   d.native = +d.usedNative / (1024 * 1024);
   d.aftergc = +d.usedHeapAfterGC / (1024 * 1024);
-  d.total = d.used + d.native;
+  if (d.native > 0) {
+    d.total = d.used + d.native;
+  }
   mempoolsData.push(d);
   if (mempoolsData.length === 2) {
     // second data point - remove "No Data Available" label
@@ -348,7 +350,11 @@ function updateMemPoolsData(mempoolsRequest) {
     return d.date;
   }));
   mempools_yScale.domain([0, Math.ceil(d3.extent(mempoolsData, function(d) {
-    return d.total;
+    if (d.total && !Number.isNaN(d.total)) {
+      return d.total;
+    } else {
+      return d.used;
+    }
   })[1] / 100) * 100]);
   mempools_xAxis.tickFormat(getTimeFormat());
   // Select the section we want to apply our changes to

--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -209,40 +209,45 @@
 
     function updateGraphs(metrics) {
       const time = Date.now();
-      const usedNative = 0;
-      const usedHeapAfterGC = 0;
       const cpuData = { time };
       const gcData = { time };
-      const memPoolsData = { time, usedNative, usedHeapAfterGC };
+      const memPoolsData = { time };
       const httpRequestData = { time };
       for (const metric of metrics) {
         const metricsObj = metric.metrics[0];
         const metricValue = metricsObj.value;
+        let numMetricValue = metricValue * 1;
+        if (Number.isNaN(numMetricValue)) {
+          numMetricValue = 0;
+        }
         if (['base:cpu_process_cpu_load_percent', 'base_cpu_processCpuLoad_percent', 'process_cpu_used_ratio '].includes(metric.name)) {
-          cpuData.process = metricValue;
+          cpuData.process = numMetricValue;
         } else if (['base:cpu_system_load_average', 'base_cpu_systemLoadAverage', 'os_cpu_used_ratio'].includes(metric.name)) { // ignored if -1 (not available)
-          cpuData.system = metricValue;
+          cpuData.system = numMetricValue;
 
         } else if (['base:gc_global_time_seconds', 'time_in_gc_percentage'].includes(metric.name)) {
-          gcData.gcTime = metricValue;
+          gcData.gcTime = numMetricValue;
         } else if (['base_gc_time_seconds'].includes(metric.name)) {
           const correctMetricsObj = metric.metrics.find(obj => obj.labels.name === 'global');
           gcData.gcTime = correctMetricsObj.value;
+          if (Number.isNaN(gcData.gcTime)) {
+            gcData.gcTime = 0;
+        }
 
         } else if (['base_memory_usedHeap_bytes', 'process_heap_memory_used_bytes', 'base:memory_used_heap_bytes'].includes(metric.name)) {
-          memPoolsData.usedHeap = metricValue * 0.5;
+          memPoolsData.usedHeap = numMetricValue;
         } else if (metric.name === 'process_native_memory_used_bytes') {
-          memPoolsData.usedNative = metricValue;
+          memPoolsData.usedNative = numMetricValue;
         } else if (metric.name === 'process_heap_memory_used_after_GC_bytes') {
-          memPoolsData.usedHeapAfterGC = metricValue;
+          memPoolsData.usedHeapAfterGC = numMetricValue;
         } else if (metric.name === 'http_requests_duration_max_microseconds') {
-          httpRequestData.longest = metricValue;
+          httpRequestData.longest = numMetricValue;
           // only ever one url
           httpRequestData.url = metric.metrics[0].labels.handler;
         } else if (metric.name === 'http_requests_duration_average_microseconds') {
-          httpRequestData.average = metricValue;
+          httpRequestData.average = numMetricValue;
         } else if (metric.name === 'http_requests_total') {
-          httpRequestData.total = metricValue;
+          httpRequestData.total = numMetricValue;
         }
       }
 

--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -209,9 +209,11 @@
 
     function updateGraphs(metrics) {
       const time = Date.now();
+      const usedNative = 0;
+      const usedHeapAfterGC = 0;
       const cpuData = { time };
       const gcData = { time };
-      const memPoolsData = { time };
+      const memPoolsData = { time, usedNative, usedHeapAfterGC };
       const httpRequestData = { time };
       for (const metric of metrics) {
         const metricsObj = metric.metrics[0];
@@ -227,9 +229,8 @@
           const correctMetricsObj = metric.metrics.find(obj => obj.labels.name === 'global');
           gcData.gcTime = correctMetricsObj.value;
 
-        } else if (['base_memory_usedHeap_bytes', 'process_heap_memory_used_bytes'].includes(metric.name)) {
-          memPoolsData.usedHeap = metricValue;
-           memPoolsData.usedHeap = metricValue;
+        } else if (['base_memory_usedHeap_bytes', 'process_heap_memory_used_bytes', 'base:memory_used_heap_bytes'].includes(metric.name)) {
+          memPoolsData.usedHeap = metricValue * 0.5;
         } else if (metric.name === 'process_native_memory_used_bytes') {
           memPoolsData.usedNative = metricValue;
         } else if (metric.name === 'process_heap_memory_used_after_GC_bytes') {


### PR DESCRIPTION
This PR takes all presentable metrics obtained from Liberty's `/metrics` endpoint and displays them on the performance container's application monitoring dashboard. It also ensures that the data transferred is in a numerical format where expected, that NaN entries are zeroed out so that the graph lines do not disappear, and that the scale of y-axis of the Memory graph can be set without all memory data available.
Please squash and merge.
Fixes https://github.com/eclipse/codewind/issues/1963