### PR TITLE
Update Loadrunner to use timed metrics

### DIFF
--- a/src/performance/.eslintrc.json
+++ b/src/performance/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2018,
+    "sourceType": "module"
   },
   "env": {
       "es6": true,

--- a/src/performance/dashboard/src/components/status/StatusPanel.jsx
+++ b/src/performance/dashboard/src/components/status/StatusPanel.jsx
@@ -1,0 +1,63 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+******************************************************************************/
+
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+import { SocketEvents } from '../../utils/sockets/SocketEvents';
+import SocketContext from '../../utils/sockets/SocketContext';
+
+import './StatusPanel.scss';
+
+class StatusPanel extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            showOutOfDateMetrics: false
+        }
+    }
+
+    componentDidMount() {
+        this.props.socket.on(SocketEvents.RUNLOAD_STATUS_CHANGED, data => {
+            if (data.projectID === this.props.projectID) {
+                switch (data.status) {
+                    case 'app-is-using-old-metrics': {
+                        this.setState({ showOutOfDateMetrics: true });
+                        break;
+                    }
+                }
+            }
+        });
+    }
+
+    render() {
+        const { showOutOfDateMetrics } = this.state;
+        return (
+            <Fragment>
+                {showOutOfDateMetrics ? <div className="StatusPanelWarning">An old version of Appmetrics has been detected. Results may be inaccurate until you update Appmetrics within your project.</div> : <Fragment />}
+            </Fragment>
+        )
+    }
+}
+
+// Add UI SocketContext via props
+const StatusPanelWithSocket = props => (
+    <SocketContext.Consumer>
+        {socket => <StatusPanel {...props} socket={socket} />}
+    </SocketContext.Consumer>
+)
+
+StatusPanel.propTypes = {
+    projectID: PropTypes.string.isRequired
+}
+
+export default StatusPanelWithSocket;

--- a/src/performance/dashboard/src/components/status/StatusPanel.scss
+++ b/src/performance/dashboard/src/components/status/StatusPanel.scss
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+******************************************************************************/
+
+.StatusPanelWarning {
+    padding: 7px;
+    margin: 20px;
+    color: #f1c21b;
+    border: 1px dashed #f1c21d;
+    text-align: center;
+    line-height: 20px;
+}
+
+.StatusPanelMessage {
+    padding: 10px;
+    margin: 20px;
+    background-color: #da1e28;
+    color: white;
+    font-weight: bold;
+}
+

--- a/src/performance/dashboard/src/modules/MetricsUtils.js
+++ b/src/performance/dashboard/src/modules/MetricsUtils.js
@@ -15,6 +15,7 @@
  */
 let getLanguageCounters = function (appMetricsName) {
     switch (appMetricsName) {
+        case "javascript": 
         case "nodejs": {
             return {
                 HTTP_AVERAGE_RESPONSE: 'averageResponseTime',
@@ -40,6 +41,7 @@ let getLanguageCounters = function (appMetricsName) {
             }
         }
         default: {
+            console.error(`Unable to determine counter names for ${appMetricsName}`);
             return {
                 HTTP_AVERAGE_RESPONSE: undefined,
                 HTTP_HITS: undefined,

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -28,6 +28,7 @@ import ResultsCard from '../components/resultsCard/ResultsCard';
 import ResultsCard_Blank from '../components/resultsCard/ResultsCard_Blank';
 import RunTestHistory from '../components/runTestHistory/RunTestHistory';
 import SocketContext from '../utils/sockets/SocketContext';
+import StatusPanel from '../components/status/StatusPanel';
 import * as MetricsUtils from '../modules/MetricsUtils';
 
 import './PagePerformance.scss';
@@ -170,6 +171,7 @@ class PagePerformance extends React.Component {
                         </div>
                     </div>
                 </div>
+                <StatusPanel projectID={this.props.projectID} />
                 <div className='results-row' role="complementary" aria-label="Result Summaries">
                     <div className='results-cards'>
                         <div className='results-card_1'>

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -188,6 +188,7 @@ module.exports = class Project {
       metricsContextRoot = 'javametrics';
       break;
     case 'nodejs':
+    case 'javascript':
       metricsContextRoot = 'appmetrics';
       break;
     case 'swift':


### PR DESCRIPTION
## Problem

When load is run against a project during performance testing, the duration metrics are collected for can change significantly depending on the amount of load-pressure being applied to the application. That effect can skew any averages and make it difficult to compare like-for-like between different runs.   This happens because the project container may be under such extreme load that it may not receive the cancel collection instruction from PFE until all of the inflight and queued load runner requests have been serviced (which may be much later than the expected cut of time of the run).  

Reported in issue #954

## Solution

This PR starts the metrics collector in the project with a `seconds` option. AppMetrics-Codewind and JavaMetrics have been updated with new routes that handle this parameter, when the collection starts recording.  With the Metrics collectors in the project now responsible for stopping the timed recording themselves, the exact duration of the collection can be metered regardless of outside load pressure or network saturation. 

After such time that PFE is ready to consume the project metrics, the collected metrics are served from the Project container as before via a temporary JSON File containing just the timed snapshot of figures without overrun. 

## Extras

If the project is running an old version of AppMetrics or JavaMetrics which do not support timed runs,  the Performance Dashboard will display a warning informing of potential unreliable figures, then suggest the user upgrades their project dependancies. 

![Screenshot 2020-02-10 at 08 21 31](https://user-images.githubusercontent.com/28102564/74132389-60f95f80-4bde-11ea-8db0-76e4c785581d.png)

## PFE logs

* Project with the /features route and new timed 20 second load test:   08:55:23  > 08:55:43

```
[10/02/20 08:54:47 node-mymetrics] [INFO] Build completed for f5311c70-4be2-11ea-a43b-8798bbd766a0
[10/02/20 08:55:23 User.js] [INFO] Running load for project: f5311c70-4be2-11ea-a43b-8798bbd766a0 config: {"path":"/","requestsPerSecond":"100","concurrency":"20","maxSeconds":"20","url":"http://172.19.0.5:3000/"}
[10/02/20 08:55:23 /portal/modules/LoadRunner.js] [INFO] Fetching project metrics features
[10/02/20 08:55:23 /portal/modules/LoadRunner.js] [INFO] Connection options:  {"host":"172.19.0.5","port":"3000","path":"/appmetrics/api/v1/collections/features","method":"GET"}
[10/02/20 08:55:23 /portal/modules/LoadRunner.js] [INFO] Status code = 200
[10/02/20 08:55:23 /portal/modules/LoadRunner.js] [INFO] Metrics features are : {"timedMetrics":true}
[10/02/20 08:55:23 /portal/modules/LoadRunner.js] [INFO] createCollection: ID:f5311c70-4be2-11ea-a43b-8798bbd766a0, Host:172.19.0.5, Port:3000, Path:/appmetrics/api/v1/collections/20
[10/02/20 08:55:23 /portal/modules/LoadRunner.js] [INFO] Load run on project f5311c70-4be2-11ea-a43b-8798bbd766a0 started
[10/02/20 08:55:43 /portal/modules/LoadRunner.js] [INFO] Load run on project f5311c70-4be2-11ea-a43b-8798bbd766a0 completed
[10/02/20 08:55:43 /portal/modules/LoadRunner.js] [INFO] Requested metrics from project container reported : 200
```


* Project using old metrics collector that shows 08:58:45 > 08:59:08 = 20 + 3 seconds overspill : 
```
[10/02/20 08:58:45 /portal/modules/LoadRunner.js] [INFO] Fetching project metrics features
[10/02/20 08:58:45 /portal/modules/LoadRunner.js] [INFO] Connection options:  {"host":"172.19.0.4","port":"3000","path":"/appmetrics/api/v1/collections/features","method":"GET"}
[10/02/20 08:58:45 /portal/modules/LoadRunner.js] [INFO] Status code = 404
[10/02/20 08:58:45 /portal/modules/LoadRunner.js] [ERROR] Unable to fetch project metrics features. HTTP Status code : 404
[10/02/20 08:58:45 /portal/modules/LoadRunner.js] [INFO] createCollection: ID:2a6e28d0-49a7-11ea-adca-c5fdb4b2cc32, Host:172.19.0.4, Port:3000, Path:/appmetrics/api/v1/collections
[10/02/20 08:58:45 /portal/modules/LoadRunner.js] [INFO] Load run on project 2a6e28d0-49a7-11ea-adca-c5fdb4b2cc32 started
[10/02/20 08:59:08 /portal/modules/LoadRunner.js] [INFO] Load run on project 2a6e28d0-49a7-11ea-adca-c5fdb4b2cc32 completed
[10/02/20 08:59:08 /portal/modules/LoadRunner.js] [INFO] Requested metrics from project container reported : 200
[10/02/20 08:59:08 /portal/modules/Project.js] [INFO] Returning profiling file stream /codewind-workspace/myFirstNodeProject/load-test/20200210085845/profiling.json for myFirstNodeProject
[10/02/20 08:59:08 /portal/modules/LoadRunner.js] [INFO] recordCollection: Metrics collection deleted
```




## Testing

Ran manually testing with Appmetrics-Codewind to ensure metrics were collected for a fixed time and the temporary files were removed from the project after retrieving the data.

## Prerequisites

* Appmetrics-codewind - PulRequest #4 
* Javametrics - PullRequest # 103



 
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>