### PR TITLE
Add guard to make sure running build queue only has unique projects

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -55,7 +55,7 @@ const MAX_BUILDS = parseInt(process.env.MC_MAX_BUILDS) || 3;
 const BUILD_KEY = "projectStatusController.buildRank";
 
 // timeout to ping build projects
-setInterval(checkBuildQueue, constants.buildQueueInterval);
+setInterval(checkBuildQueue, 5000);
 
 /**
  * @see [[Filewatcher.getProjectTypes]]
@@ -456,7 +456,7 @@ export async function addProjectToBuildQueue(project: BuildQueueType): Promise<v
 
 /**
  * @function
- * @description Check the build queue periodically (every 5 seconds) and once a project has been created.
+ * @description Check the build queue periodically (every 5 seconds). This function makes sure that all builds in the running queue and build queue are unique so that no one project can be in the same queue more than once at any given time. Builds are only pushed into the running queue when there is space for it and meets the uniqueness criteria.
  *
  * @returns void
  */


### PR DESCRIPTION
### Description

Related to https://github.com/eclipse/codewind/issues/2075

Adding a new guard to make sure that all running build in the queue is running unique projects (i.e cannot have the same project building more than 1 once at the same time). 

This goes back to the issue and comment here https://github.com/eclipse/codewind/issues/2075#issuecomment-583079059 where we see that the running build queue has the same project building 3 times. The reason why the build happens 3 times, is discussed here https://github.com/eclipse/codewind/issues/2075#issuecomment-584160104