### PR TITLE
Internal port test to check -1 setting won't work for ODO projects

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
@@ -327,6 +327,8 @@ export function projectSpecificationTest(socket: SocketIO, projData: projectsCon
         }).timeout(timeoutConfigs.defaultTimeout);
 
         it(`set internalPort to ${constants.disablePingPort} in .cw-settings file to check for serverless app`, async () => {
+            if (projectTemplate === app_configs.codewindTemplates.odo) return; // internal port settings are not available for odo projects
+
             let events, eventDatas;
 
             const projectInfo = await projectUtil.getProjectInfo(projData.projectID);


### PR DESCRIPTION
Closes https://github.com/eclipse/codewind/issues/2112

Signed-off-by: ssh24 <sakib@ibm.com>