### PR TITLE
Ability to run specific tests by passing runOnly=true

### DIFF
--- a/src/pfe/file-watcher/server/test/functional-test/suites/generic/tests/project.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/generic/tests/project.ts
@@ -30,8 +30,8 @@ export default class ProjectTest {
         });
     }
 
-    private runGetProjectTypes(): void {
-        describe("getProjectTypes function", () => {
+    private runGetProjectTypes(runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("getProjectTypes function", () => {
             it("get project type without a location", async () => {
                 const info: any = await genericLib.getProjectTypes();
                 expect(info);

--- a/src/pfe/file-watcher/server/test/functional-test/suites/generic/tests/workspace.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/generic/tests/workspace.ts
@@ -79,8 +79,8 @@ export default class WorkspaceTest {
         });
     }
 
-    private runReadWorkspaceSettings(socket: SocketIO, settingsPath: string, settingsContent: any, backupSettingsPath: string): void {
-        describe("readWorkspaceSettings function", () => {
+    private runReadWorkspaceSettings(socket: SocketIO, settingsPath: string, settingsContent: any, backupSettingsPath: string, runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("readWorkspaceSettings function", () => {
             after("clear socket events for create test", () => {
                 socket.clearEvents();
             });
@@ -163,8 +163,8 @@ export default class WorkspaceTest {
         });
     }
 
-    private runImagePushRegistryStatus(socket: SocketIO): void {
-        describe("imagePushRegistryStatus function", () => {
+    private runImagePushRegistryStatus(socket: SocketIO, runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("imagePushRegistryStatus function", () => {
             const deploymentRegistryRequest = {
                 "projectID": "1234",
                 "detailedImagePushRegistryStatus": "some status"
@@ -230,8 +230,8 @@ export default class WorkspaceTest {
         });
     }
 
-    private runSetImagePushRegistry(): void {
-        describe("writeWorkspaceSettings function", () => {
+    private runSetImagePushRegistry(runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("writeWorkspaceSettings function", () => {
             const self = this;
 
             before("remove image push registry", async function(): Promise<void> {
@@ -245,8 +245,8 @@ export default class WorkspaceTest {
         });
     }
 
-    private runRemoveImagePushRegistry(settingsContent: any): void {
-        describe("removeImagePushRegistry function", () => {
+    private runRemoveImagePushRegistry(settingsContent: any, runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("removeImagePushRegistry function", () => {
             const self = this;
 
             before("set image push registry", async function(): Promise<void> {
@@ -268,8 +268,8 @@ export default class WorkspaceTest {
         });
     }
 
-    private runTestImagePushRegistry(settingsContent: any): void {
-        describe("testImagePushRegistry function", () => {
+    private runTestImagePushRegistry(settingsContent: any, runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("testImagePushRegistry function", () => {
             const invalidPullImage = "someimage";
             const self = this;
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/create.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/create.ts
@@ -54,8 +54,8 @@ export default class CreateTest {
         });
     }
 
-    private runCreateWithoutProjectID(projData: projectsController.ICreateProjectParams): void {
-        it("create a project without projectID", async () => {
+    private runCreateWithoutProjectID(projData: projectsController.ICreateProjectParams, runOnly?: boolean): void {
+        (runOnly ? it.only : it)("create a project without projectID", async () => {
             const invalidData = _.cloneDeep(projData);
             delete invalidData.projectID;
             const info: any = await createProject(invalidData);
@@ -68,8 +68,8 @@ export default class CreateTest {
         });
     }
 
-    private runCreateWithoutProjectType(projData: projectsController.ICreateProjectParams): void {
-        it("create a project without projectType", async () => {
+    private runCreateWithoutProjectType(projData: projectsController.ICreateProjectParams, runOnly?: boolean): void {
+        (runOnly ? it.only : it)("create a project without projectType", async () => {
             const invalidData = _.cloneDeep(projData);
             delete invalidData.projectType;
             const info: any = await createProject(invalidData);
@@ -82,8 +82,8 @@ export default class CreateTest {
         });
     }
 
-    runCreateWithValidData(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        it("create project", async () => {
+    runCreateWithValidData(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        (runOnly ? it.only : it)("create project", async () => {
             const odoDeploymentConfigSelector = `cw-${appConfigs.projectPrefix}${projectTemplate}-${projectLang}-app`;
 
             process.env.IN_K8 ? (projectTemplate === appConfigs.codewindTemplates.odo ? await utils.checkForKubeResources("deploymentconfig", odoDeploymentConfigSelector, ["pods"], false) : await utils.checkForKubeResources("projectID", projData.projectID, ["deployments", "pods", "services"], false)) : await utils.checkForDockerResources(projData.projectID, false);
@@ -104,7 +104,7 @@ export default class CreateTest {
             expect(info.logs).to.exist;
             expect(info.logs.build).to.exist;
 
-            await waitForCreationEvent(projData.projectType, projectTemplate);
+            await waitForCreationEvent(projectTemplate);
             await waitForProjectStartedEvent();
 
             if (process.env.TURBINE_PERFORMANCE_TEST) {
@@ -117,7 +117,7 @@ export default class CreateTest {
             process.env.IN_K8 ? (projectTemplate === appConfigs.codewindTemplates.odo ? await utils.checkForKubeResources("deploymentconfig", odoDeploymentConfigSelector, ["pods"]) : await utils.checkForKubeResources("projectID", projData.projectID)) : await utils.checkForDockerResources(projData.projectID);
         }).timeout(timeoutConfigs.createTestTimeout);
 
-        async function waitForCreationEvent(projectType: string, projectTemplate: string): Promise<void> {
+        async function waitForCreationEvent(projectTemplate: string): Promise<void> {
             const targetEvent = eventConfigs.events.creation;
             const event = await utils.waitForEvent(socket, targetEvent);
             if (event) {

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/delete.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/delete.ts
@@ -46,8 +46,8 @@ export default class DeleteTest {
         });
     }
 
-    private runDeleteWithMissingProjectID(): void {
-        it("delete a project with missing id", async () => {
+    private runDeleteWithMissingProjectID(runOnly?: boolean): void {
+        (runOnly ? it.only : it)("delete a project with missing id", async () => {
             const invalidId: any = undefined;
             const info: any = await deleteProject(invalidId);
             expect(info).to.exist;
@@ -59,8 +59,8 @@ export default class DeleteTest {
         });
     }
 
-    private runDeleteWithInvalidProjectID(): void {
-        it("delete a project with invalid id", async () => {
+    private runDeleteWithInvalidProjectID(runOnly?: boolean): void {
+        (runOnly ? it.only : it)("delete a project with invalid id", async () => {
             const invalidId = "invalidId";
             const info: any = await deleteProject(invalidId);
             expect(info).to.exist;
@@ -72,8 +72,8 @@ export default class DeleteTest {
         });
     }
 
-    private runDeleteWithValidData(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        it("delete project", async () => {
+    private runDeleteWithValidData(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        (runOnly ? it.only : it)("delete project", async () => {
             const odoDeploymentConfigSelector = `cw-${appConfigs.projectPrefix}${projectTemplate}-${projectLang}-app`;
 
             process.env.IN_K8 ? (projectTemplate === appConfigs.codewindTemplates.odo ? await utils.checkForKubeResources("deploymentconfig", odoDeploymentConfigSelector, ["pods"]) : await utils.checkForKubeResources("projectID", projData.projectID)) : await utils.checkForDockerResources(projData.projectID);

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/logs.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/logs.ts
@@ -22,8 +22,8 @@ import * as eventConfigs from "../../../configs/event.config";
 import * as timeoutConfigs from "../../../configs/timeout.config";
 import { fail } from "assert";
 
-export function logsTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-    describe("getProjectLogs function", () => {
+export function logsTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+    (runOnly ? describe.only : describe)("getProjectLogs function", () => {
         it("get project logs with missing id", async () => {
             const info: any = await getProjectLogs(undefined);
             expect(info);
@@ -61,7 +61,7 @@ export function logsTest(socket: SocketIO, projData: projectsController.ICreateP
         }).timeout(timeoutConfigs.defaultTimeout);
     });
 
-    describe("checkNewLogFile function", () => {
+    (runOnly ? describe.only : describe)("checkNewLogFile function", () => {
         const combinations: any = {
             "combo1": {
                 "projectID": undefined,

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-action.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-action.ts
@@ -24,7 +24,7 @@ import { fail } from "assert";
 
 import * as utils from "../../../lib/utils";
 
-export function projectActionTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
+export function projectActionTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
     const data: any = {
         action: "restart",
         projectType: projData.projectType,
@@ -127,7 +127,7 @@ export function projectActionTest(socket: SocketIO, projData: projectsController
         });
     }
 
-    describe("projectAction function", () => {
+    (runOnly ? describe.only : describe)("projectAction function", () => {
         afterEach("clear socket events", () => {
             socket.clearEvents();
         });

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-event.ts
@@ -25,8 +25,8 @@ import * as timeoutConfigs from "../../../configs/timeout.config";
 import { projectLanguges } from "../../../configs/app.config";
 import { fail } from "assert";
 
-export function projectEventTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-    describe("updateProjectForNewChange function", () => {
+export function projectEventTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+    (runOnly ? describe.only : describe)("updateProjectForNewChange function", () => {
         afterEach("clear socket events", () => {
             socket.clearEvents();
         });

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
@@ -30,10 +30,9 @@ import * as constants from "../../../../../src/projects/constants";
 
 import * as utils from "../../../lib/utils";
 
-export function projectSpecificationTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-    describe("projectSpecification function", () => {
+export function projectSpecificationTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+    (runOnly ? describe.only : describe)("projectSpecification function", () => {
         const cwSettingsPath = path.join(projData.location, ".cw-settings");
-
         const data: any = {
             "projectID": projData.projectID
         };

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project.ts
@@ -44,8 +44,8 @@ export default class ProjectTest {
         });
     }
 
-    private runProjectCapabilityTest(projectID: string, projectTemplate: string, projectLang: string): void {
-        describe("getProjectCapabilities function", () => {
+    private runProjectCapabilityTest(projectID: string, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        (runOnly ? describe.only : describe)("getProjectCapabilities function", () => {
             it("get project capability with undefined project id", async () => {
                 const info: any = await getProjectCapabilities(undefined);
                 expect(info);
@@ -67,23 +67,23 @@ export default class ProjectTest {
         });
     }
 
-    private runProjectActionTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        projectActionTest(socket, projData, projectTemplate, projectLang);
+    private runProjectActionTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        projectActionTest(socket, projData, projectTemplate, projectLang, runOnly);
     }
 
-    private runProjectSpecificationTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        projectSpecificationTest(socket, projData, projectTemplate, projectLang);
+    private runProjectSpecificationTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        projectSpecificationTest(socket, projData, projectTemplate, projectLang, runOnly);
     }
 
-    private runProjectLogsTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        logsTest(socket, projData, projectTemplate, projectLang);
+    private runProjectLogsTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        logsTest(socket, projData, projectTemplate, projectLang, runOnly);
     }
 
-    private runUpdateStatusTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        updateStatusTest(socket, projData, projectTemplate, projectLang);
+    private runUpdateStatusTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        updateStatusTest(socket, projData, projectTemplate, projectLang, runOnly);
     }
 
-    private runProjectEventTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-        projectEventTest(socket, projData, projectTemplate, projectLang);
+    private runProjectEventTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+        projectEventTest(socket, projData, projectTemplate, projectLang, runOnly);
     }
 }

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
@@ -24,8 +24,8 @@ import { fail } from "assert";
 import * as utils from "../../../lib/utils";
 import { codewindTemplates } from "../../../configs/app.config";
 
-export function updateStatusTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string): void {
-    describe("updateStatus function", () => {
+export function updateStatusTest(socket: SocketIO, projData: projectsController.ICreateProjectParams, projectTemplate: string, projectLang: string, runOnly?: boolean): void {
+    (runOnly ? describe.only : describe)("updateStatus function", () => {
         const projectID = projData.projectID;
         const data: any = {
             "projectID": projectID,


### PR DESCRIPTION
### Description

Closes https://github.com/eclipse/codewind/issues/2054

This PR enables the ability to run specific suite of tests from the higher level by passing the arg value of `runOnly` true instead of manually going in there and changing it to `it.only` or `describe.only`.