### PR TITLE
Remote Profiling

### DIFF
--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -128,6 +128,17 @@ module.exports.copyFile = async function copyFile(project, fileToCopy, projectRo
   await exec(dockerCommand);
 }
 
+module.exports.copyFileFromContainer = async function copyFile(project, destinationPath, projectRoot, relativePathOfFile) {
+  const dockerCommand = `docker cp ${project.containerId}:${projectRoot}/${relativePathOfFile} ${destinationPath}`;
+  log.info(`[docker cp command] ${dockerCommand}`);
+  try {
+    await exec(dockerCommand); 
+  } catch (error) {
+    log.error(`copyFileFromContainer: Error copying file ${relativePathOfFile} from ${project.containerId}`);
+    throw(error);
+  }
+}
+
 module.exports.deleteFile = async function deleteFile(project, projectRoot, relativePathOfFile) {
   const dockerCommand = `docker exec ${project.containerId} rm -rf ${projectRoot}/${relativePathOfFile}`;
   log.debug(`[docker rm command] ${dockerCommand}`);

--- a/src/pfe/portal/modules/utils/errors/ProjectMetricsError.js
+++ b/src/pfe/portal/modules/utils/errors/ProjectMetricsError.js
@@ -42,6 +42,9 @@ function constructMessage(code, identifier, message) {
   case 'PROFILING_NOT_FOUND':
     output = `Unable to find profiling.json saved in project ${identifier}`;
     break;
+  case 'STREAM_FAILED':
+    output = `Unable to create read stream for file ${identifier}`;
+    break;
   default:
     output = `Unknown project metrics error`;
   }

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -528,7 +528,7 @@ describe('Project.js', () => {
         it('Fails to get a profiling file using an invalid time stamp', () => {
             const project = createDefaultProjectAndCheckIsAnObject();
             project.loadTestPath = loadTestResources;
-            return project.getProfilingByTime('123')
+            project.getProfilingByTime('123456')
                 .should.be.eventually.rejectedWith(`Unable to find metrics for project ${project.projectID}`)
                 .and.be.an.instanceOf(ProjectMetricsError)
                 .and.have.property('code', 'NOT_FOUND');
@@ -574,7 +574,8 @@ describe('Project.js', () => {
         it('Fails to get a profiling.json path using an invalid time stamp', () => {
             const project = createDefaultProjectAndCheckIsAnObject();
             project.loadTestPath = loadTestResources;
-            return project.getPathToProfilingFile('123')
+            project.language = 'nodejs';
+            project.getPathToProfilingFile('123')
                 .should.be.eventually.rejectedWith(`Unable to find metrics for project ${project.projectID}`)
                 .and.be.an.instanceOf(ProjectMetricsError)
                 .and.have.property('code', 'NOT_FOUND');
@@ -584,13 +585,6 @@ describe('Project.js', () => {
             project.loadTestPath = loadTestResources;
             project.language = 'nodejs';
             const profilingFilePath = await project.getPathToProfilingFile('20190326154749');
-            fs.existsSync(profilingFilePath).should.be.true;
-        });
-        it('Gets a profiling.json path using a valid time stamp which is larger than an existing filename', async() => {
-            const project = createDefaultProjectAndCheckIsAnObject();
-            project.loadTestPath = loadTestResources;
-            project.language = 'nodejs';
-            const profilingFilePath = await project.getPathToProfilingFile('30000000000000');
             fs.existsSync(profilingFilePath).should.be.true;
         });
         it('Fails to get an .hcd path when java project pod is not running', () => {


### PR DESCRIPTION
Ability to fetch profiling data from remote projects:
- Changing all docker exec commands used within LoadRunner.js to use cwUtils, calling either docker or kube commands depending on deployment
- Kube and Docker versions of a CopyFileFromContainer helper function in cwUtils

To be used with [457](https://github.com/eclipse/codewind-vscode/pull/457) to enable saving of remote profiling data to local workspace.

Tested with node and java projects, local and remote and received profiling data back from both. 