### PR TITLE
Always re-inject metrics

### DIFF
--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -37,15 +37,10 @@ async function inject(req, res) {
     }
 
     const projectDir = path.join(project.workspace, project.directory);
-    let projType = project.projectType;
-    if (project.projectType === 'docker' && project.language === 'java') {
-      projType = 'openLiberty'
-      // this is the best we can do at the moment
-    }
     if (injectMetrics) {
-      await metricsService.injectMetricsCollectorIntoProject(projType, projectDir);
+      await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, projectDir);
     } else {
-      await metricsService.removeMetricsCollectorFromProject(projType, projectDir);
+      await metricsService.removeMetricsCollectorFromProject(project.projectType, project.language, projectDir);
     }
 
     await user.projectList.updateProject({

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -97,6 +97,13 @@ async function removeMetricsCollectorFromJvmOptions(projectDir) {
   }
 }
 
+async function deleteBackupPomXml(projectDir) {
+  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
+  if (await fs.exists(pathToBackupPomXml)) {
+    await fs.remove(pathToBackupPomXml);
+  }
+}
+
 async function removeMetricsCollectorFromSpringProject(projectDir) {
   await removeMetricsCollectorFromPomXml(projectDir);
   await removeMetricsCollectorFromMainAppClassFile(projectDir);
@@ -122,7 +129,7 @@ async function injectMetricsCollectorIntoLibertyProject(projectDir) {
   let jvmOptionsPresent = false;
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
   const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
-  if ((await fs.exists(pathToBackupPomXml)) || (await fs.exists(pathToBackupJvmOptions))) {
+  if (await fs.exists(pathToBackupPomXml)) {
     throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
   }
 
@@ -141,7 +148,7 @@ async function injectMetricsCollectorIntoLibertyProject(projectDir) {
 async function injectMetricsCollectorIntoSpringProject(projectDir) {
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
   const pathToBackupMainAppClassFile = getPathToBackupMainAppClassFile(projectDir);
-  if ((await fs.exists(pathToBackupPomXml)) || (await fs.exists(pathToBackupMainAppClassFile))) {
+  if (await fs.exists(pathToBackupPomXml)) {
     throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
   }
 
@@ -555,4 +562,5 @@ module.exports = {
   injectMetricsCollectorIntoProject,
   removeMetricsCollectorFromProject,
   metricsCollectorInjectionFunctions,
+  deleteBackupPomXml,
 }

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -36,20 +36,30 @@ const metricsCollectorRemovalFunctions = {
   spring: removeMetricsCollectorFromSpringProject,
 }
 
-async function injectMetricsCollectorIntoProject(projectType, projectDir) {
-  if (!metricsCollectorInjectionFunctions.hasOwnProperty(projectType)) {
-    throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
+async function identifyProject(projectType, projectLanguage) {
+  if (projectType === 'docker' && projectLanguage === 'java') {
+    return 'openLiberty';
+    // this is the best we can do at the moment
   }
-  await metricsCollectorInjectionFunctions[projectType](projectDir);
-  log.debug(`Successfully injected metrics collector into ${projectType} project`);
+  return projectType
 }
 
-async function removeMetricsCollectorFromProject(projectType, projectDir) {
-  if (!metricsCollectorRemovalFunctions.hasOwnProperty(projectType)) {
-    throw new Error(`Injection of metrics collector is not supported for projects of type '${projectType}'`);
+async function injectMetricsCollectorIntoProject(projectType, projectLanguage, projectDir) {
+  let projType = await identifyProject(projectType, projectLanguage);
+  if (!metricsCollectorInjectionFunctions.hasOwnProperty(projType)) {
+    throw new Error(`Injection of metrics collector is not supported for projects of type '${projType}'`);
   }
-  await metricsCollectorRemovalFunctions[projectType](projectDir);
-  log.debug(`Successfully removed metrics collector from ${projectType} project`);
+  await metricsCollectorInjectionFunctions[projType](projectDir);
+  log.debug(`Successfully injected metrics collector into ${projType} project`);
+}
+
+async function removeMetricsCollectorFromProject(projectType, projectLanguage, projectDir) {
+  let projType = await identifyProject(projectType, projectLanguage);
+  if (!metricsCollectorRemovalFunctions.hasOwnProperty(projType)) {
+    throw new Error(`Injection of metrics collector is not supported for projects of type '${projType}'`);
+  }
+  await metricsCollectorRemovalFunctions[projType](projectDir);
+  log.debug(`Successfully removed metrics collector from ${projType} project`);
 }
 
 const getPathToPomXml = (projectDir) => path.join(projectDir, 'pom.xml');

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -75,11 +75,9 @@ async function removeMetricsCollectorFromLibertyProject(projectDir) {
 
 async function removeMetricsCollectorFromPomXml(projectDir) {
   const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
-  const backupPomXml = await fs.readFile(pathToBackupPomXml);
-
   const pathToPomXml = getPathToPomXml(projectDir);
-  await fs.writeFile(pathToPomXml, backupPomXml);
-  log.debug(`Restored project's pom.xml to ${util.inspect(backupPomXml)}`);
+  await fs.copy(pathToBackupPomXml, pathToPomXml)
+  log.debug(`Restored project's pom.xml from ${util.inspect(pathToBackupPomXml)}`);
   await fs.remove(pathToBackupPomXml);
 }
 
@@ -87,20 +85,12 @@ async function removeMetricsCollectorFromJvmOptions(projectDir) {
   const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
   const pathToJvmOptions = getPathToJvmOptions(projectDir);
   if (await fs.exists(pathToBackupJvmOptions)) {
-    const backupJvmOptions = await fs.readFile(pathToBackupJvmOptions);
-    await fs.writeFile(pathToJvmOptions, backupJvmOptions);
-    log.debug(`Restored project's jvm.options to ${util.inspect(backupJvmOptions)}`);
+    await fs.copy(pathToBackupJvmOptions, pathToJvmOptions);
+    log.debug(`Restored project's jvm.options from ${util.inspect(pathToBackupJvmOptions)}`);
     await fs.remove(pathToBackupJvmOptions);
   } else {
     log.debug(`No backup jvm.options. Deleting ${pathToJvmOptions}`);
     await fs.remove(pathToJvmOptions);
-  }
-}
-
-async function deleteBackupPomXml(projectDir) {
-  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
-  if (await fs.exists(pathToBackupPomXml)) {
-    await fs.remove(pathToBackupPomXml);
   }
 }
 
@@ -114,50 +104,42 @@ const getPathToBackupMainAppClassFile = (projectDir) => path.join(projectDir, 'c
 async function removeMetricsCollectorFromMainAppClassFile(projectDir) {
   const pathToMainAppClassFile = await getPathToMainAppClassFile(projectDir);
   const pathToBackupClassFile = getPathToBackupMainAppClassFile(projectDir);
-  const backupClassFile = await fs.readFile(pathToBackupClassFile);
-  await fs.writeFile(pathToMainAppClassFile, backupClassFile);
-  log.debug(`Restored project's main app class file to ${util.inspect(backupClassFile)}`);
+  await fs.copy(pathToBackupClassFile, pathToMainAppClassFile);
+  log.debug(`Restored project's main app class file from ${util.inspect(pathToBackupClassFile)}`);
   await fs.remove(pathToBackupClassFile);
-}
-
-async function backUpFile(pathToOriginal, pathToBackup) {
-  const originalFileData = await fs.readFile(pathToOriginal);
-  await fs.outputFile(pathToBackup, originalFileData);
 }
 
 async function injectMetricsCollectorIntoLibertyProject(projectDir) {
   let jvmOptionsPresent = false;
-  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
-  const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
-  if (await fs.exists(pathToBackupPomXml)) {
-    throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
-  }
 
   const pathToPomXml = getPathToPomXml(projectDir);
-  await backUpFile(pathToPomXml, pathToBackupPomXml);
+  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
+  await fs.remove(pathToBackupPomXml);
+  await fs.copy(pathToPomXml, pathToBackupPomXml);
   await injectMetricsCollectorIntoPomXml(pathToPomXml);
 
   const pathToJvmOptions = getPathToJvmOptions(projectDir);
+  const pathToBackupJvmOptions = getPathToBackupJvmOptions(projectDir);
+  await fs.remove(pathToBackupJvmOptions);
   if (await fs.exists(pathToJvmOptions)) {
-    await backUpFile(pathToJvmOptions, pathToBackupJvmOptions);
+    await fs.copy(pathToJvmOptions, pathToBackupJvmOptions);
     jvmOptionsPresent = true;
   }
   await injectMetricsCollectorIntoJvmOptions(pathToJvmOptions, jvmOptionsPresent);
 }
 
 async function injectMetricsCollectorIntoSpringProject(projectDir) {
-  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
-  const pathToBackupMainAppClassFile = getPathToBackupMainAppClassFile(projectDir);
-  if (await fs.exists(pathToBackupPomXml)) {
-    throw new Error('project files already backed up (i.e. we have already injected metrics collector)');
-  }
 
   const pathToPomXml = getPathToPomXml(projectDir);
-  await backUpFile(pathToPomXml, pathToBackupPomXml);
+  const pathToBackupPomXml = getPathToBackupPomXml(projectDir);
+  await fs.remove(pathToBackupPomXml);
+  await fs.copy(pathToPomXml, pathToBackupPomXml);
   await injectMetricsCollectorIntoPomXmlForSpring(pathToPomXml);
 
   const pathToMainAppClassFile = await getPathToMainAppClassFile(projectDir);
-  await backUpFile(pathToMainAppClassFile, pathToBackupMainAppClassFile);
+  const pathToBackupMainAppClassFile = getPathToBackupMainAppClassFile(projectDir);
+  await fs.remove(pathToBackupMainAppClassFile);
+  await fs.copy(pathToMainAppClassFile, pathToBackupMainAppClassFile);
   await injectMetricsCollectorIntoMainAppClassFile(pathToMainAppClassFile);
 }
 
@@ -562,5 +544,4 @@ module.exports = {
   injectMetricsCollectorIntoProject,
   removeMetricsCollectorFromProject,
   metricsCollectorInjectionFunctions,
-  deleteBackupPomXml,
 }

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -273,7 +273,7 @@ async function uploadEnd(req, res) {
 
       if (project.injectMetrics) {
         try {
-          await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
+          await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, path.join(project.workspace, project.directory));
         } catch (error) {
           log.warn(error);
         }
@@ -431,7 +431,7 @@ async function bindEnd(req, res) {
 
     if (project.injectMetrics) {
       try {
-        await metricsService.injectMetricsCollectorIntoProject(project.projectType, path.join(project.workspace, project.directory));
+        await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, path.join(project.workspace, project.directory));
       } catch (error) {
         log.warn(error);
       }

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -272,8 +272,13 @@ async function uploadEnd(req, res) {
       await cwUtils.copyProject(pathToTempProj, path.join(project.workspace, project.directory), getMode(project));
 
       if (project.injectMetrics) {
+        const projectDir = path.join(project.workspace, project.directory);
+        if (modifiedList.includes("pom.xml")) {
+          // we'll need to inject this new pom.xml; to do this, remove the backup pom.
+          await metricsService.deleteBackupPomXml(projectDir);
+        }
         try {
-          await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, path.join(project.workspace, project.directory));
+          await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, projectDir);
         } catch (error) {
           log.warn(error);
         }

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -273,11 +273,9 @@ async function uploadEnd(req, res) {
 
       if (project.injectMetrics) {
         const projectDir = path.join(project.workspace, project.directory);
-        if (modifiedList.includes("pom.xml")) {
-          // we'll need to inject this new pom.xml; to do this, remove the backup pom.
-          await metricsService.deleteBackupPomXml(projectDir);
-        }
         try {
+          // We will have replaced any injected files with their original version when we did
+          // cwUtils.copyProject above. We must re-inject metrics here before building.
           await metricsService.injectMetricsCollectorIntoProject(project.projectType, project.language, projectDir);
         } catch (error) {
           log.warn(error);

--- a/test/src/unit/controllers/metrics.controller.test.js
+++ b/test/src/unit/controllers/metrics.controller.test.js
@@ -17,7 +17,7 @@ const { suppressLogOutput } = require('../../../modules/log.service');
 
 chai.should();
 
-describe.only('metrics.controller.js', () => {
+describe('metrics.controller.js', () => {
     suppressLogOutput(metricsController);
     describe('inject(req, res)', () => {
         it('returns 404 if the specified project does not exist', async() => {

--- a/test/src/unit/controllers/metrics.controller.test.js
+++ b/test/src/unit/controllers/metrics.controller.test.js
@@ -17,7 +17,7 @@ const { suppressLogOutput } = require('../../../modules/log.service');
 
 chai.should();
 
-describe('metrics.controller.js', () => {
+describe.only('metrics.controller.js', () => {
     suppressLogOutput(metricsController);
     describe('inject(req, res)', () => {
         it('returns 404 if the specified project does not exist', async() => {

--- a/test/src/unit/modules/metricsService.test.js
+++ b/test/src/unit/modules/metricsService.test.js
@@ -104,7 +104,7 @@ describe('metricsService/index.js', () => {
         // console.log(util.inspect(expectedPomXmlForLiberty, { showHidden: false, depth: null }));
     });
 
-    describe('injectMetricsCollectorIntoProject(projectType, projectDir)', () => {
+    describe('injectMetricsCollectorIntoProject(projectType, project.language, projectDir)', () => {
         afterEach(() => {
             fs.removeSync(projectDir);
         });
@@ -114,7 +114,7 @@ describe('metricsService/index.js', () => {
                     fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
                 });
                 it(`injects metrics collector into the project's package.json, and saves a back up`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('nodejs', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('nodejs', 'nodejs', projectDir);
 
                     fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithCollector);
                     fs.readJSONSync(pathToBackupPackageJson).should.deep.equal(packageJsonWithoutCollector);
@@ -126,7 +126,7 @@ describe('metricsService/index.js', () => {
                     fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('nodejs', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('nodejs', 'nodejs', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithoutCollector);
@@ -141,7 +141,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToJvmOptions, originalJvmOptions);
                 });
                 it(`injects metrics collector into the project's jvm.options and pom.xml, and saves backups`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('liberty', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('liberty', 'java', projectDir);
 
                     const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                     outputJvmOptions.should.equal(expectedJvmOptions);
@@ -163,7 +163,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToBackupJvmOptions, originalJvmOptions);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('liberty', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('liberty', 'java', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readFileSync(pathToJvmOptions, 'utf8')
@@ -185,7 +185,7 @@ describe('metricsService/index.js', () => {
                     fs.removeSync(pathToJvmOptions);
                 });
                 it(`injects metrics collector into the project's jvm.options and pom.xml, and saves backups`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('openLiberty', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('openLiberty', 'java', projectDir);
 
                     const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                     outputJvmOptions.should.equal(expectedNewJvmOptions);
@@ -207,7 +207,7 @@ describe('metricsService/index.js', () => {
                     fs.removeSync(pathToBackupJvmOptions);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('openLiberty', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('docker', 'java', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readFileSync(pathToJvmOptions, 'utf8')
@@ -228,7 +228,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToMainAppClassFile, originalMainAppClassFile);
                 });
                 it(`injects metrics collector into the project's main app class file and pom.xml`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('spring', projectDir);
+                    await metricsService.injectMetricsCollectorIntoProject('spring', 'java', projectDir);
 
                     const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
                     outputClassFile.should.equal(expectedMainAppClassFile);
@@ -250,7 +250,7 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToBackupMainAppClassFile, originalMainAppClassFile);
                 });
                 it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('spring', projectDir)
+                    await metricsService.injectMetricsCollectorIntoProject('spring', 'java', projectDir)
                         .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
 
                     fs.readFileSync(pathToMainAppClassFile, 'utf8')
@@ -270,13 +270,13 @@ describe('metricsService/index.js', () => {
                 fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
             });
             it(`throws a useful error`, () => {
-                const funcToTest = () => metricsService.injectMetricsCollectorIntoProject('unsupportedProjectType', projectDir);
+                const funcToTest = () => metricsService.injectMetricsCollectorIntoProject('unsupportedProjectType', 'unknown', projectDir);
                 return funcToTest().should.be.rejectedWith(`Injection of metrics collector is not supported for projects of type 'unsupportedProjectType'`);
             });
         });
     });
 
-    describe('removeMetricsCollectorFromProject(projectType, projectDir)', () => {
+    describe('removeMetricsCollectorFromProject(projectType, projectLanguage, projectDir)', () => {
         afterEach(() => {
             fs.removeSync(projectDir);
         });
@@ -286,7 +286,7 @@ describe('metricsService/index.js', () => {
                 fs.outputJSONSync(pathToBackupPackageJson, packageJsonWithoutCollector);
             });
             it(`removes metrics collector from the project's package.json`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('nodejs', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('nodejs', 'nodejs', projectDir);
 
                 fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithoutCollector);
                 fs.existsSync(pathToBackupPackageJson).should.be.false;
@@ -301,7 +301,7 @@ describe('metricsService/index.js', () => {
                 fs.outputFileSync(pathToBackupJvmOptions, originalJvmOptions);
             });
             it(`removes metrics collector from the project's jvm.options and pom.xml`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('liberty', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('liberty', 'java', projectDir);
 
                 const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
                 outputJvmOptions.should.equal(originalJvmOptions);
@@ -321,7 +321,7 @@ describe('metricsService/index.js', () => {
                 fs.removeSync(pathToBackupJvmOptions);
             });
             it(`removes metrics collector from the project's jvm.options and pom.xml`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('openLiberty', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('docker', 'java', projectDir);
 
                 fs.pathExistsSync(pathToJvmOptions).should.be.false;
                 fs.pathExistsSync(pathToBackupJvmOptions).should.be.false;
@@ -340,7 +340,7 @@ describe('metricsService/index.js', () => {
                 fs.outputFileSync(pathToBackupMainAppClassFile, originalMainAppClassFile);
             });
             it(`removes metrics collector from the project's main app class file and pom.xml`, async() => {
-                await metricsService.removeMetricsCollectorFromProject('spring', projectDir);
+                await metricsService.removeMetricsCollectorFromProject('spring', 'java', projectDir);
 
                 const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
                 outputClassFile.should.equal(originalMainAppClassFile);
@@ -357,7 +357,7 @@ describe('metricsService/index.js', () => {
                 fs.outputJSONSync(pathToBackupPackageJson, packageJsonWithoutCollector);
             });
             it(`throws a useful error`, () => {
-                const funcToTest = () => metricsService.removeMetricsCollectorFromProject('unsupportedProjectType', projectDir);
+                const funcToTest = () => metricsService.removeMetricsCollectorFromProject('unsupportedProjectType', 'unknown', projectDir);
                 return funcToTest().should.be.rejectedWith(`Injection of metrics collector is not supported for projects of type 'unsupportedProjectType'`);
             });
         });

--- a/test/src/unit/modules/metricsService.test.js
+++ b/test/src/unit/modules/metricsService.test.js
@@ -125,11 +125,10 @@ describe('metricsService/index.js', () => {
                     fs.outputJSONSync(pathToBackupPackageJson, packageJsonWithoutCollector);
                     fs.outputJSONSync(pathToPackageJson, packageJsonWithoutCollector);
                 });
-                it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('nodejs', 'nodejs', projectDir)
-                        .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
+                it(`should re-inject without error`, async() => {
+                    await metricsService.injectMetricsCollectorIntoProject('nodejs', 'nodejs', projectDir);
 
-                    fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithoutCollector);
+                    fs.readJSONSync(pathToPackageJson).should.deep.equal(packageJsonWithCollector);
                     fs.readJSONSync(pathToBackupPackageJson).should.deep.equal(packageJsonWithoutCollector);
                 });
             });
@@ -162,19 +161,18 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToJvmOptions, originalJvmOptions);
                     fs.outputFileSync(pathToBackupJvmOptions, originalJvmOptions);
                 });
-                it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('liberty', 'java', projectDir)
-                        .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
+                it(`should re-inject without error`, async() => {
+                    await metricsService.injectMetricsCollectorIntoProject('liberty', 'java', projectDir);
 
-                    fs.readFileSync(pathToJvmOptions, 'utf8')
-                        .should.equal(originalJvmOptions);
-                    fs.readFileSync(pathToBackupJvmOptions, 'utf8')
-                        .should.equal(originalJvmOptions);
+                    const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
+                    outputJvmOptions.should.equal(expectedJvmOptions);
+                    const outputBackupJvmOptions = fs.readFileSync(pathToBackupJvmOptions, 'utf8');
+                    outputBackupJvmOptions.should.deep.equal(originalJvmOptions);
 
-                    (await readXml(pathToTestPomXml))
-                        .should.deep.equal(originalPomXmlForLiberty);
-                    (await readXml(pathToTestPomXml))
-                        .should.deep.equal(originalPomXmlForLiberty);
+                    const outputPomXml = await readXml(pathToTestPomXml);
+                    outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForLiberty);
+                    const outputBackupPomXml = await readXml(pathToTestBackupPomXml);
+                    outputBackupPomXml.should.deep.equal(originalPomXmlForLiberty);
                 });
             });
         });
@@ -206,18 +204,18 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToJvmOptions, expectedNewJvmOptions);
                     fs.removeSync(pathToBackupJvmOptions);
                 });
-                it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('docker', 'java', projectDir)
-                        .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
+                it(`should re-inject without error`, async() => {
+                    await metricsService.injectMetricsCollectorIntoProject('docker', 'java', projectDir);
 
-                    fs.readFileSync(pathToJvmOptions, 'utf8')
-                        .should.equal(expectedNewJvmOptions);
-                    fs.pathExistsSync(pathToBackupJvmOptions).should.be.false;
+                    const outputJvmOptions = fs.readFileSync(pathToJvmOptions, 'utf8');
+                    outputJvmOptions.should.equal(expectedNewJvmOptions);
+                    const outputBackupJvmOptions = fs.pathExistsSync(pathToBackupJvmOptions);
+                    outputBackupJvmOptions.should.be.true;
 
-                    (await readXml(pathToTestPomXml))
-                        .should.deep.equal(originalPomXmlForOpenLiberty);
-                    (await readXml(pathToTestPomXml))
-                        .should.deep.equal(originalPomXmlForOpenLiberty);
+                    const outputPomXml = await readXml(pathToTestPomXml);
+                    outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForOpenLiberty);
+                    const outputBackupPomXml = await readXml(pathToTestBackupPomXml);
+                    outputBackupPomXml.should.deep.equal(originalPomXmlForOpenLiberty);
                 });
             });
         });
@@ -249,19 +247,18 @@ describe('metricsService/index.js', () => {
                     fs.outputFileSync(pathToMainAppClassFile, originalMainAppClassFile);
                     fs.outputFileSync(pathToBackupMainAppClassFile, originalMainAppClassFile);
                 });
-                it(`throws a useful error`, async() => {
-                    await metricsService.injectMetricsCollectorIntoProject('spring', 'java', projectDir)
-                        .should.be.eventually.rejectedWith('project files already backed up (i.e. we have already injected metrics collector');
+                it(`should re-inject without error`, async() => {
+                    await metricsService.injectMetricsCollectorIntoProject('spring', 'java', projectDir);
 
-                    fs.readFileSync(pathToMainAppClassFile, 'utf8')
-                        .should.equal(originalMainAppClassFile);
-                    fs.readFileSync(pathToBackupMainAppClassFile, 'utf8')
-                        .should.equal(originalMainAppClassFile);
+                    const outputClassFile = fs.readFileSync(pathToMainAppClassFile, 'utf8');
+                    outputClassFile.should.equal(expectedMainAppClassFile);
+                    const outputBackupClassFile = fs.readFileSync(pathToBackupMainAppClassFile, 'utf8');
+                    outputBackupClassFile.should.deep.equal(originalMainAppClassFile);
 
-                    (await readXml(pathToTestPomXml))
-                        .should.deep.equal(originalPomXmlForSpring);
-                    (await readXml(pathToTestPomXml))
-                        .should.deep.equal(originalPomXmlForSpring);
+                    const outputPomXml = await readXml(pathToTestPomXml);
+                    outputPomXml.should.deep.equalInAnyOrder(expectedPomXmlForSpring);
+                    const outputBackupPomXml = await readXml(pathToTestBackupPomXml);
+                    outputBackupPomXml.should.deep.equal(originalPomXmlForSpring);
                 });
             });
         });


### PR DESCRIPTION
This PR just ensures that we always re-inject metrics on a project change.
This is necessary because we always copy all the files from our temporary upload area to the real project directory here:
https://github.com/eclipse/codewind/compare/master...hhellyer:fixOpenLibIdentify4Inject?expand=1#diff-b73b1946195409164e2ccc8a3b7fe79cR272
so the pom.xml or package.json is *always* replaced by the real one without metrics injected.
Always re-injecting actually makes the logic quite a lot simpler.