### PR TITLE
Fix the assert condition that asserts the running build queue is unique when checking for the builds

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -586,11 +586,9 @@ async function triggerBuild(project: BuildQueueType, changedFiles?: IFileChangeE
 function checkInProgressBuilds(): void {
     lock.acquire("runningBuildsLock", async done => {
         // we must assert here that the running builds queue is always unique
+        // we do this by converting the running build queue into a set and making sure the length matches
         if (buildQueue.length > 0) {
-            logger.assert(runningBuilds.filter((project: BuildQueueType) => {
-                const projectID = project.operation.projectInfo.projectID;
-                return projectID === buildQueue[0].operation.projectInfo.projectID;
-            }).length === 0, "Builds in running queue must be unique");
+            logger.assert(new Set(runningBuilds).size === runningBuilds.length, "Builds in running queue must be unique");
         }
 
         // filter out all projects that are completed and reduce the build in progress by 1 for each such project


### PR DESCRIPTION
### Description

Related to #2075 

The assert condition we have under `checkInProgressBuilds` previously was kind of right but there is an edge case where it will throw the assert error. The case is when the running build has only one project, and the build queue has the same project - it will throw the error saying the running builds queue is not unique. That check is valid before inserting into the running queue but not when asserting in the code that the running queue is unique.

The correct way of the new check is to see if all elements in the running builds queue is unique. We do that by converting it into a set (taking the unique elements) and seeing if that is the exactly the same length the overall queue, then we can deduce the running builds queue is unique.

This comes from the logs I noticed that John mentioned in https://github.com/eclipse/codewind/issues/2075#issuecomment-584796382

```
[91m[11/02/20 17:34:21 Turbine] [ERROR][39m [File Name: /file-watcher/server/dist/utils/logger.js | Function Name: assert | Line Number: 127] Builds in running queue must be unique
[32m[11/02/20 17:34:21 mygo] [INFO][39m Project e5890eb0-4cf3-11ea-b908-57d1d8facf80 file changed
```

I don't know if this actually caused that failure but it should not have failed on the assert at that point specifically because running builds queue only had the go project and build queue only had the same go project waiting to be built again.

We should also backport this to 0.9.0.

Signed-off-by: ssh24 <sakib@ibm.com>