### PR TITLE
[0.9.0] Include non-persisted fields in JSONified Project object.

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -55,7 +55,7 @@ const MAX_BUILDS = parseInt(process.env.MC_MAX_BUILDS) || 3;
 const BUILD_KEY = "projectStatusController.buildRank";
 
 // timeout to ping build projects
-setInterval(checkBuildQueue, 5000);
+setInterval(checkBuildQueue, constants.buildQueueInterval);
 
 /**
  * @see [[Filewatcher.getProjectTypes]]

--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -456,7 +456,7 @@ export async function addProjectToBuildQueue(project: BuildQueueType): Promise<v
 
 /**
  * @function
- * @description Check the build queue periodically (every 5 seconds) and once a project has been created.
+ * @description Check the build queue periodically (every 5 seconds). This function makes sure that all builds in the running queue and build queue are unique so that no one project can be in the same queue more than once at any given time. Builds are only pushed into the running queue when there is space for it and meets the uniqueness criteria.
  *
  * @returns void
  */
@@ -477,13 +477,31 @@ async function checkBuildQueue(): Promise<void> {
             if (runningBuilds.length < MAX_BUILDS) {
                 logger.logDebug("Space available to trigger the next build");
 
-                // remove the first project off the queue
-                const buildToBeTriggered = buildQueue.shift();
+                // only push to running build queue if the running build queue doesn't already have the same project building
+                const firstBuildInQueue = buildQueue[0];
+                const uniqueBuildsRunning = runningBuilds.filter((project: BuildQueueType) => {
+                    const projectID = project.operation.projectInfo.projectID;
+                    return projectID === firstBuildInQueue.operation.projectInfo.projectID;
+                }).length === 0;
 
-                logger.logDebug("Metadata for next build: " + JSON.stringify(buildToBeTriggered));
+                if (uniqueBuildsRunning) {
+                    logger.logDebug("All builds in the running queue are unique. Adding next build to the queue.");
 
-                runningBuilds.push(buildToBeTriggered);
-                triggerBuild(buildToBeTriggered, changedFilesMap.get(buildToBeTriggered.operation.projectInfo.projectID));
+                    // remove the first project off the queue
+                    const buildToBeTriggered = buildQueue.shift();
+
+                    logger.logDebug("Metadata for next build: " + JSON.stringify(buildToBeTriggered));
+
+                    runningBuilds.push(buildToBeTriggered);
+                    triggerBuild(buildToBeTriggered, changedFilesMap.get(buildToBeTriggered.operation.projectInfo.projectID));
+                } else {
+                    logger.logDebug("Next build to be triggered already exists in the running queue. Skip adding it and move it to the end of the build queue.");
+                    // we move the first element in the build queue to the last
+                    // this is done because: e.g if we have 3 builds in the running = [p1,p2,p3] and 3 builds in the waiting queue = [p3,p4,p5]. Now the next build on the queue is p3, however, p3 is the running build queue - so we will skip adding it to the running build queue.
+                    // If e.g p2 finishes before p3, build running queue becomes = [p1, p3]. Now we have a space in the running queue but we can't utilize that spot because the first project in the build queue is p3.
+                    // So we remove the first project and add it at the back of the queue making space for the next project to be added to the running builds queue (e.g in this example p4 will be added to the running builds queue and it will look like [p1, p3, p4]
+                    buildQueue.push(buildQueue.shift());
+                }
             }
         }
         done();
@@ -567,6 +585,14 @@ async function triggerBuild(project: BuildQueueType, changedFiles?: IFileChangeE
  */
 function checkInProgressBuilds(): void {
     lock.acquire("runningBuildsLock", async done => {
+        // we must assert here that the running builds queue is always unique
+        if (buildQueue.length > 0) {
+            logger.assert(runningBuilds.filter((project: BuildQueueType) => {
+                const projectID = project.operation.projectInfo.projectID;
+                return projectID === buildQueue[0].operation.projectInfo.projectID;
+            }).length === 0, "Builds in running queue must be unique");
+        }
+
         // filter out all projects that are completed and reduce the build in progress by 1 for each such project
         runningBuilds = runningBuilds.filter((project: BuildQueueType) => {
             const projectID = project.operation.projectInfo.projectID;

--- a/src/pfe/file-watcher/server/src/projects/constants.ts
+++ b/src/pfe/file-watcher/server/src/projects/constants.ts
@@ -38,3 +38,5 @@ export enum ControlCommands { stop = "stop", start = "start", restart = "restart
 export enum MavenFlags { profile = "-P ", properties = "-D " }
 
 export const disablePingPort = "-1";
+
+export const buildQueueInterval = 5000;

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -2129,7 +2129,8 @@ export async function updateDetailedAppStatus(projectID: string, ip: string, por
     pingPathEvent = {
         severity: "INFO",
         message: pingMessage,
-        notify: false
+        notify: false,
+        notificationID: ""
     };
 
     if (oldState === AppState.starting) {

--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -69,7 +69,7 @@
     "appErrorWhenStopping": "An error occurred while the application was stopping. Check the application logs for details.",
     "pingTimeout": "Timeout: {{- pingMessage}}. The application is taking longer than expected to start. Please check the application logs for problems and ensure the project's 'healthCheck' setting is correct. Last error message received: {{- errMsg}}", 
     "pingTimeoutDefaultMessage": "Failed to ping application.",
-    "linkLabel": "Troubleshooting status"
+    "linkLabel": "Application status troubleshooting information"
   },
   "quickfix": {
     "generateMissingFilesName": "Generate missing files",

--- a/src/pfe/file-watcher/server/test/functional-test/configs/timeout.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/timeout.config.ts
@@ -10,9 +10,11 @@
  *******************************************************************************/
 
 import ms from "ms";
+import * as constants from "../../../src/projects/constants";
 
 export const defaultTimeout = ms("5m");
-export const defaultInterval = ms("5s");
+export const defaultInterval = ms("10s");
+export const buildQueueInterval = constants.buildQueueInterval + 2000; // 2 additional seconds on top of the regular build queue interval to wait for the build queue to be cleared
 
 export const createTestTimeout = ms("20m");
 export const deleteTestTimeout = ms("1m");

--- a/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/lib/utils.ts
@@ -212,6 +212,7 @@ export async function setBuildStatus(projData: projectsController.ICreateProject
         });
         expect(info);
         expect(info.statusCode).to.equal(200);
+        await delay(timeoutConfigs.buildQueueInterval);
     }
 }
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/create.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/create.ts
@@ -48,7 +48,8 @@ export default class CreateTest {
             socket.clearEvents();
         });
 
-        after("remove build from running queue", async () => {
+        after("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
     }

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-action.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-action.ts
@@ -157,7 +157,8 @@ export function projectActionTest(socket: SocketIO, projData: projectsController
             await utils.callProjectAction(action, mode, socket, projData, targetEvents, targetEventDatas);
         });
 
-        after("remove build from running queue", async () => {
+        after("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/project-specification.ts
@@ -235,7 +235,8 @@ export function projectSpecificationTest(socket: SocketIO, projData: projectsCon
             socket.clearEvents();
         });
 
-        afterEach("remove build from running queue", async () => {
+        afterEach("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
 

--- a/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/suites/project/tests/update-status.ts
@@ -31,7 +31,8 @@ export function updateStatusTest(socket: SocketIO, projData: projectsController.
             "projectID": projectID,
         };
 
-        afterEach("remove build from running queue", async () => {
+        afterEach("remove build from running queue", async function (): Promise<void> {
+            this.timeout(timeoutConfigs.defaultInterval);
             await utils.setBuildStatus(projData, projectTemplate, projectLang);
         });
 
@@ -118,7 +119,8 @@ export function updateStatusTest(socket: SocketIO, projData: projectsController.
                     await utils.callProjectAction(action, mode, socket, projData, targetEvents, targetEventDatas);
                 });
 
-                after("remove build from running queue", async () => {
+                after("remove build from running queue", async function (): Promise<void> {
+                    this.timeout(timeoutConfigs.defaultInterval);
                     await utils.setBuildStatus(projData, projectTemplate, projectLang);
                 });
 

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -23,6 +23,7 @@ const ProjectError = require('./utils/errors/ProjectError');
 const ProjectMetricsError = require('./utils/errors/ProjectMetricsError');
 const Logger = require('./utils/Logger');
 const LogStream = require('./LogStream');
+const metricsService = require('./metricsService');
 
 const log = new Logger(__filename);
 
@@ -35,6 +36,18 @@ const STATES = {
   validating: 'validating',
   closing: 'closing',
   deleting: 'deleting'
+};
+
+const METRICS_DASH_HOST = {
+  project: 'project',
+  performanceContainer: 'performanceContainer',
+};
+
+const pathsToUserHostedMetricsDashboards = {
+  nodejs: 'appmetrics-dash',
+  javascript: 'appmetrics-dash',
+  java: 'javametrics-dash',
+  swift: 'swiftmetrics-dash',
 };
 
 const METRIC_TYPES = ['cpu', 'gc', 'memory', 'http']
@@ -100,6 +113,11 @@ module.exports = class Project {
     // Initialise the project type
     this.projectType = args.projectType;
 
+    // For metrics purposes, we treat java docker project as open liberty projects
+    this.isOpenLiberty = (this.projectType === 'docker' && this.language === 'java');
+    this.canMetricsBeInjected = this.isOpenLiberty
+      || metricsService.metricsCollectorInjectionFunctions.hasOwnProperty(this.projectType);
+
     log.info(`Project ${this.name} initializing (project type: ${this.projectType}, projectID: ${this.projectID})`);
 
     // This is used to delete the log file when the project is deleted.
@@ -148,6 +166,41 @@ module.exports = class Project {
     return {}
   }
 
+  getPerfDashPath() {
+    const isPerfDashAvailable = this.injectMetrics || this.isOpenLiberty || this.metricsAvailable;
+    return isPerfDashAvailable
+      ? `/performance/charts?project=${this.projectID}`
+      : null;
+  }
+  
+  getMetricsDashHost() {
+    const isMetricsDashAvailable = this.injectMetrics || this.isOpenLiberty || this.metricsAvailable;
+    if (!isMetricsDashAvailable) {
+      return null;
+    }
+    
+    const shouldShowMetricsDashHostedOnProject = !this.injectMetrics && this.metricsAvailable;
+    return shouldShowMetricsDashHostedOnProject
+      ? METRICS_DASH_HOST.project
+      : METRICS_DASH_HOST.performanceContainer;
+  }
+  
+  getMetricsDashPath() {
+    const metricsDashHost = this.getMetricsDashHost();
+    if (!metricsDashHost) {
+      return null;
+    }
+    
+    if (metricsDashHost === METRICS_DASH_HOST.project) {
+      return `/${pathsToUserHostedMetricsDashboards[this.language]}/?theme=dark`;
+    }
+
+    if (metricsDashHost === METRICS_DASH_HOST.performanceContainer) {
+      return `/performance/monitor/dashboard/${this.language}?theme=dark&projectID=${this.projectID}`
+    }
+    
+    throw new Error(`unknown metricsDashHost: ${metricsDashHost}`);
+  }
 
   async checkIfMetricsAvailable() {
     let isMetricsAvailable;

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -544,4 +544,5 @@ function getNewPomXmlBuildPlugins(originalBuildPlugins) {
 module.exports = {
   injectMetricsCollectorIntoProject,
   removeMetricsCollectorFromProject,
+  metricsCollectorInjectionFunctions,
 }

--- a/src/pfe/portal/routes/projects/projects.route.js
+++ b/src/pfe/portal/routes/projects/projects.route.js
@@ -41,8 +41,8 @@ router.get('/api/v1/projects/:id', (req, res) => {
 router.get('/api/v1/projects', (req, res) => {
   try {
     const user = req.cw_user;
-    const list = user.projectList.getAsArray();
-    res.status(200).send(list);
+    const projects = user.projectList.retrieveProjects();
+    res.status(200).send(projects);
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/src/pfe/portal/routes/projects/remoteBind.route.js
+++ b/src/pfe/portal/routes/projects/remoteBind.route.js
@@ -254,6 +254,8 @@ async function uploadEnd(req, res) {
       await deletePathsInArray(pathToProj, filesToDelete);
     }
 
+    await project.checkIfMetricsAvailable();
+
     res.sendStatus(200);
     
   } catch (err) {
@@ -439,6 +441,8 @@ async function bindEnd(req, res) {
     let totalbindtime = (timerbindend - timerbindstart) / 1000;
     log.info(`Total time to bind project ${project.name} is ${totalbindtime} seconds`);
     timersyncstart = 0;
+
+    await project.checkIfMetricsAvailable();
 
     let updatedProject = {
       projectID,

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -33,13 +33,17 @@ const sleep = promisify(setTimeout);
 async function createProjectFromTemplate(name, projectType, path, autoBuild = false) {
     const { url, language } = templateOptions[projectType];
 
+    const pfeProjectType = (projectType === 'openliberty')
+        ? 'docker'
+        : projectType;
+
     await cloneProject(url, path);
 
     const res = await bindProject({
         name,
         path,
         language,
-        projectType,
+        projectType: pfeProjectType,
         autoBuild,
         creationTime: Date.now(),
     });

--- a/test/src/API/projects/metricsInject.test.js
+++ b/test/src/API/projects/metricsInject.test.js
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const chai = require('chai');
+const path = require('path');
+const chaiSubset = require('chai-subset');
+const chaiResValidator = require('chai-openapi-response-validator');
+
+const projectService = require('../../../modules/project.service');
+const reqService = require('../../../modules/request.service');
+const { 
+    ADMIN_COOKIE,
+    TEMP_TEST_DIR,
+    testTimeout,
+    pathToApiSpec,
+} = require('../../../config');
+
+chai.use(chaiSubset);
+chai.use(chaiResValidator(pathToApiSpec));
+chai.should();
+
+const postMetricsInject = (projectID, options) => reqService.chai
+    .post(`/api/v1/projects/${projectID}/metrics/inject`)
+    .set('Cookie', ADMIN_COOKIE)
+    .send(options);
+
+describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function() {
+    it('returns 404 to /metrics/inject when project does not exist', async function() {
+        const projectID = '00000000-0000-0000-0000-000000000000';
+        this.timeout(testTimeout.short);
+        const res = await postMetricsInject(projectID, { enable: true });
+        
+        res.should.have.status(404);
+        res.text.should.equal(`Unable to find project ${projectID}`);
+    });
+    
+    describe('Node.js success case (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-node-metrics-inject-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+    
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+    
+        it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: true });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: true,
+                injection: {
+                    injectable: true,
+                    injected: true,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/nodejs?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    
+        it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: false });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: false,
+                injection: {
+                    injectable: true,
+                    injected: false,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'project',
+                    path: `/appmetrics-dash/?theme=dark`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    });
+    
+    describe('Java Liberty success case (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-liberty-metrics-inject-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+    
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'liberty', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+    
+        it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: true });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: true,
+                injection: {
+                    injectable: true,
+                    injected: true,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/java?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    
+        it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: false });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: true,
+                injectMetrics: false,
+                injection: {
+                    injectable: true,
+                    injected: false,
+                },
+                isOpenLiberty: false,
+                metricsDashboard: {
+                    hosting: 'project',
+                    path: `/javametrics-dash/?theme=dark`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    });
+    
+    describe('Java Open Liberty success case (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-open-liberty-metrics-inject-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+    
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'openliberty', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+    
+        it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: true });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: false,
+                injectMetrics: true,
+                injection: {
+                    injectable: true,
+                    injected: true,
+                },
+                isOpenLiberty: true,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/java?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    
+        it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsInject(projectID, { enable: false });
+            res.should.have.status(202);
+        
+            const { body: project } = await projectService.getProject(projectID);
+            project.should.containSubset({
+                metricsAvailable: false,
+                injectMetrics: false,
+                injection: {
+                    injectable: true,
+                    injected: false,
+                },
+                isOpenLiberty: true,
+                metricsDashboard: {
+                    hosting: 'performanceContainer',
+                    path: `/performance/monitor/dashboard/java?theme=dark&projectID=${projectID}`,
+                },
+                perfDashboardPath: `/performance/charts?project=${projectID}`,
+            });
+        });
+    });
+});


### PR DESCRIPTION
We were stripping out fields we didn't want to persist to the project .inf files the same way as we were stripping out fields we couldn't convert to JSON.
This was simple but meant the non-persistent fields were never returned via /api/v1/projects as that just converts the Project object to JSON.
This PR takes advantage of the replacer() function you can pass when writing a JSON file to remove the non-persistent fields.

This is for issue https://github.com/eclipse/codewind/issues/2140 and ports the fix to 0.9.0