### PR TITLE
fix: stop metrics/inject responding twice on error

### DIFF
--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -24,11 +24,13 @@ const log = new Logger(__filename);
  * @return 500 if internal error
  */
 async function inject(req, res) {
+  let project;
+  let user;
   try {
     const projectID = req.sanitizeParams('id');
     const injectMetrics = req.sanitizeBody('enable');
-    const user = req.cw_user;
-    const project = user.projectList.retrieveProject(projectID);
+    user = req.cw_user;
+    project = user.projectList.retrieveProject(projectID);
     if (!project) {
       const message = `Unable to find project ${projectID}`;
       log.error(message);
@@ -54,13 +56,16 @@ async function inject(req, res) {
     });
 
     res.sendStatus(202);
-
-
-    await syncProjectFilesIntoBuildContainer(project, user);
-
   } catch (err) {
     log.error(err);
     res.status(500).send(err.info || err.message);
+    return;
+  }
+
+  try {
+    await syncProjectFilesIntoBuildContainer(project, user);
+  } catch (err) {
+    log.error(err);
   }
 }
 


### PR DESCRIPTION
**Problem**
During `/metrics/inject` we respond 202 then call `await syncProjectFilesIntoBuildContainer(project, user);`. We catch all errors and respond with 500. The problem is that if we respond 202 then error in `syncProjectFilesIntoBuildContainer` we try to respond again with 500, with throws a `cannot set headers after they are sent` error

**Solution**
Respond with 500 if we catch errors before responding 202, then don't respond again if we catch errors after responding 202

Signed-off-by: Richard Waller <Richard.Waller@ibm.com>