### PR TITLE
test, docs: decouple logging tests from current PFE state

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1203,13 +1203,20 @@ paths:
                 - level
               properties:
                 level:
-                  type: string
-                  enum: ['trace', 'debug', 'info', 'warn', 'error']
+                  $ref: '#/components/schemas/PfeLogLevel'
       responses:
         200:
           description: Successful
+          content:
+            text/html:
+              schema:
+                type: string
         400:
           description: Bad request
+          content:
+            text/html:
+              schema:
+                type: string
         500:
           description: Internal Error
     get:
@@ -1221,18 +1228,19 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - currentLevel
+                  - defaultLevel
+                  - allLevels
                 properties:
                   currentLevel:
-                    type: string
-                    example: 'debug'
+                    $ref: '#/components/schemas/PfeLogLevel'
                   defaultLevel:
-                    type: string
-                    example: 'info'
+                    $ref: '#/components/schemas/PfeLogLevel'
                   allLevels:
                     type: array
                     items:
-                      type: string
-                      example: ['trace', 'debug', 'info', 'warn', 'error']
+                      $ref: '#/components/schemas/PfeLogLevel'
         500:
           description: Internal Error
 
@@ -2125,6 +2133,9 @@ components:
           type: string
         message:
           type: string
+    PfeLogLevel:
+      type: string
+      enum: ['trace', 'debug', 'info', 'warn', 'error']
 
   responses:
     400:

--- a/test/src/API/logging.test.js
+++ b/test/src/API/logging.test.js
@@ -8,76 +8,65 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-
 const chai = require('chai');
+const chaiResValidator = require('chai-openapi-response-validator');
 
 const reqService = require('../../modules/request.service');
-const { ADMIN_COOKIE } = require('../../config');
+const { 
+    ADMIN_COOKIE,
+    pathToApiSpec,
+} = require('../../config');
 
+chai.use(chaiResValidator(pathToApiSpec));
 chai.should();
 
-const defaultLevel = 'info';
 const validLevels = ['error', 'warn', 'info', 'debug', 'trace'];
 
-const setLoggingLevel = (level) => reqService.chai
-    .put('/api/v1/logging')
-    .set('Cookie', ADMIN_COOKIE)
-    .send(level);
-
-const getLoggingLevel = () => reqService.chai
+const getLogLevel = () => reqService.chai
     .get('/api/v1/logging')
     .set('Cookie', ADMIN_COOKIE);
 
-describe('Logging API tests', function() {
+const setLogLevel = (level) => reqService.chai
+    .put('/api/v1/logging')
+    .set('Cookie', ADMIN_COOKIE)
+    .send({ level });
 
-    describe('PUT /logging', function(){
-        after(`reset logging level to default ('${defaultLevel}')`, async function() {
-            const res = await setLoggingLevel({ level: 'info' });
-            res.should.have.status(200);
-        });
 
-        describe('with body { level : \'unknownLoggingLevel\' }', function(){
-            it('returns 400 and an informative error message', async function() {
-                const res = await setLoggingLevel({ level: 'unknownLoggingLevel' });
-                res.should.have.status(400);
-                res.text.should.include('Invalid logging level requested');
-            });
-        });
+describe('Logging API tests (these `it` blocks depend on each other passing)', function() {
+    let originalLogLevel;
 
-        describe('with body { level : \'debug\' }', function(){
-            it('returns 200', async function() {
-                const res = await setLoggingLevel({ level: 'debug' });
-                res.should.have.status(200);
-            });
-        });
+    after('reset log level to original level', async function() {
+        const res = await setLogLevel(originalLogLevel);
+        res.should.have.status(200);
     });
 
-    describe('GET /logging', function() {
-        afterEach(`reset logging level to default ('${defaultLevel}')`, async function() {
-            const res = await setLoggingLevel({ level: 'info' });
-            res.should.have.status(200);
-        });
+    it('returns 200 and logging info when GET /logging is called', async function() {
+        const res = await getLogLevel();
+        res.should.have.status(200);
+        res.should.satisfyApiSpec;
+        res.body.allLevels.should.have.members(validLevels);
 
-        const expectedLoggingLevel = 'trace';
-        describe(`when logging level is '${expectedLoggingLevel}'`, function(){
+        // save log level to reset after tests
+        originalLogLevel = res.body.currentLevel;
+    });
 
-            before(`set logging level to '${expectedLoggingLevel}'`, async function() {
-                const res = await setLoggingLevel({ level: expectedLoggingLevel });
-                res.should.have.status(200);
-            });
+    it('returns 400 when PUT /logging is called with body { level : unknownLogLevel }', async function() {
+        const res = await setLogLevel('unknownLogLevel');
+        res.should.have.status(400);
+        res.should.satisfyApiSpec;
+        res.text.should.include('Invalid logging level requested');
+    });
 
-            it('returns 200 and { currentLevel, defaultLevel, allLevels }', async function() {
-                const res = await getLoggingLevel();
-                res.should.have.status(200);
-                res.should.have.own.property('body');
-                res.body.currentLevel.should.equal(expectedLoggingLevel);
-                res.body.defaultLevel.should.equal(defaultLevel);
-                res.body.allLevels.should.be.an('array').with.members(validLevels);
-            });
-        });
+    it('returns 200 when PUT /logging is called with body { level : debug }', async function() {
+        const res = await setLogLevel('warn');
+        res.should.have.status(200);
+        res.should.satisfyApiSpec;
+    });
+
+    it('returns 200 when PUT /logging is called with body { level : info }', async function() {
+        const res = await setLogLevel('debug');
+        res.should.have.status(200);
+        res.should.satisfyApiSpec;
     });
 
 });
-
-
-


### PR DESCRIPTION
**3 Problems**

1. Currently, our logging tests fail if at the start of the test suite PFE's logging level is not `info`. This is fine in Jenkins, but if we're developing locally we may set the logging level to `debug`, and if we then run the logging tests they fail. It would be good if our logging tests just test that we can manipulate PFE's logging level correctly, whatever the level was at the start of this test suite.
2. Our logging tests are coupled to each other, so if our `PUT /logging` API were broken then our `GET /logging API` would fail too.
3. Our OpenAPI doc for our logging APIs is not entirely correct

**Solution**
This PR fixes 1-3 in our tests and docs.


Signed-off-by: Richard Waller <Richard.Waller@ibm.com>