### PR TITLE
Transform build queues from arrays to set datastructure

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -700,10 +700,10 @@ export async function deleteProject(projectID: string): Promise<IDeleteProjectSu
 
         await lock.acquire("runningBuildsLock", async done => {
             // remove the project from in-progress queue only if the project deleted was in the in-progress build
-            runningBuilds.forEach((buildQueueItem: BuildQueueType) => {
-                if (buildQueueItem.operation.projectInfo.projectID === projectID) {
+            runningBuilds.forEach((runningQueueItem: BuildQueueType) => {
+                if (runningQueueItem.operation.projectInfo.projectID === projectID) {
                     logger.logProjectInfo("Removing " + projectID + " from running builds due to a delete request", projectID, projectName);
-                    runningBuilds.delete(buildQueueItem);
+                    runningBuilds.delete(runningQueueItem);
                 }
             });
             done();


### PR DESCRIPTION
### Description

Closes https://github.com/eclipse/codewind/issues/2139

This PR converts the existing datastructure for both the type of build queues - running and waiting, to set datastructure. This allows us to have a unique set of builds in each queue and removes the overhead to check if the queues are always unique.