### PR TITLE
[0.9.0] Change load test defaults.

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -758,9 +758,9 @@ module.exports = class Project {
     }
     let config = {
       path: contextRoot,
-      requestsPerSecond: "100",
-      concurrency: "20",
-      maxSeconds: "20"
+      requestsPerSecond: "1",
+      concurrency: "1",
+      maxSeconds: "180"
     };
     await fs.ensureDir(this.loadTestPath);
     const filePath = join(this.loadTestPath, 'config.json');

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -656,9 +656,9 @@ describe('Project.js', () => {
 
             const expectedConfig = {
                 path: '/',
-                requestsPerSecond: '100',
-                concurrency: '20',
-                maxSeconds: '20',
+                requestsPerSecond: '1',
+                concurrency: '1',
+                maxSeconds: '180',
             };
             config.should.deep.equal(expectedConfig);
             fs.existsSync(path.join(tempLoadDir, 'config.json')).should.be.true;
@@ -731,9 +731,9 @@ describe('Project.js', () => {
             const config = await fs.readJson(configPath);
             const expectedConfig = {
                 path: '/',
-                requestsPerSecond: '100',
-                concurrency: '20',
-                maxSeconds: '20',
+                requestsPerSecond: '1',
+                concurrency: '1',
+                maxSeconds: '180',
             };
             config.should.deep.equal(expectedConfig);
         });


### PR DESCRIPTION
Change the load test defaults to a set of lower numbers that won't swamp applications with more requests than they can handle but will run for long enough to generate profiling data.

Backport of https://github.com/eclipse/codewind/pull/2069 to the 0.9.0 branch.