### PR TITLE
[0.9.0] Perf Dashboard - Fix Inline loadtest description

### DIFF
--- a/src/performance/dashboard/src/components/resultsCard/DescriptionEditor.jsx
+++ b/src/performance/dashboard/src/components/resultsCard/DescriptionEditor.jsx
@@ -98,10 +98,9 @@ class DescriptionEditor extends React.Component {
       */
     async handleDescSave() {
         const projectid = this.props.projectID;
-        const formattedTime = formatDateToString(this.props.snapshotTime);
         this.setState({ isBeingSaved: true, editMode: false });
         try {
-            const result = await fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectid}/metrics/${formattedTime}`, {
+            const result = await fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectid}/metrics/${this.props.snapshotID}`, {
                 method: 'put',
                 headers: {
                     'Accept': 'application/json',
@@ -194,7 +193,7 @@ class DescriptionEditor extends React.Component {
 
 DescriptionEditor.propTypes = {
     projectID: PropTypes.string.isRequired, // projectID
-    snapshotTime: PropTypes.number.isRequired, // start time of the snapshot
+    snapshotID: PropTypes.string.isRequired, // ID the snapshot
     text: PropTypes.string,
     alwaysShowEditIcon: PropTypes.bool.isRequired // should the edit icon be visible
 }

--- a/src/performance/dashboard/src/components/resultsCard/ResultsCard.jsx
+++ b/src/performance/dashboard/src/components/resultsCard/ResultsCard.jsx
@@ -102,7 +102,7 @@ export default class ResultsCard extends Component {
                     </div>
                 </div>
                 <div className='metrics-description'>
-                    <DescriptionEditor projectID={this.props.projectID} text={snapshot.desc} snapshotTime={snapshot.time} alwaysShowEditIcon={true} />
+                    <DescriptionEditor projectID={this.props.projectID} text={snapshot.desc} snapshotID={snapshot.id} alwaysShowEditIcon={true} />
                 </div>
                 <div className='metrics-container'>
                     <div className='metrics-types'>

--- a/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
+++ b/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
@@ -226,7 +226,7 @@ class RunTestHistory extends Component {
                                                 <TableCell key={cell.id}>
                                                     {
                                                         cell.info.header === 'desc' ?
-                                                            <DescriptionEditor projectID={this.props.projectID} text={cell.value} snapshotTime={parseInt(row.id)} alwaysShowEditIcon={false} />
+                                                            <DescriptionEditor projectID={this.props.projectID} text={cell.value} snapshotID={row.id} alwaysShowEditIcon={false} />
                                                             :
                                                             <Fragment>{this.getCellValue(row, cell)}</Fragment>
                                                     }


### PR DESCRIPTION
## Problem : 

Fixes a problem where when editing a load run description in the history table, the change was not saved after a page refresh.  Issue : https://github.com/eclipse/codewind/issues/2211

## Solution :

Used the snapshot ID rather than the start time to indent the correct record in the collection. 

Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>