### PR TITLE
Refactor noderun.sh script to use sh rather than bash

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #*******************************************************************************
 # Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
@@ -270,7 +270,7 @@ function dockerRun() {
 	workspace=`$util getWorkspacePathForVolumeMounting $LOCAL_WORKSPACE`
 	echo "Workspace path used for volume mounting is: "$workspace""
 
-	$IMAGE_COMMAND run --network=codewind_network -e $heapdump --name $project -p 127.0.0.1::$DEBUG_PORT -P -dt $project /bin/bash -c "$dockerCmd";
+	$IMAGE_COMMAND run --network=codewind_network -e $heapdump --name $project -p 127.0.0.1::$DEBUG_PORT -P -dt $project /bin/sh -c "$dockerCmd";
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
 		docker cp "$WORKSPACE/$projectName/." $project:/app

--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #*******************************************************************************
 # Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials

--- a/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
@@ -28,34 +28,30 @@ mkdir -p $LOG_DIR
 
 cd /app
 
-function readCache() {
-    if [[ -f $CACHE_FILE ]]; then
-        while read line; do
-            if [[ $line == pid=* ]]; then
-                PID=${line#*=}
-            fi
-        done < $CACHE_FILE
+readCache() {
+    if [ -f $CACHE_FILE ]; then
+       PID=$(awk -F 'pid=' 'NF>0 { print $2 }' $CACHE_FILE)
     fi
     echo "Read in PID $PID from cache"
 }
 
-function writeCache() {
+writeCache() {
     echo "Write PID $PID to cache"
     echo "" > $CACHE_FILE
-    if [[ -n $PID ]]; then
+    if [ -n $PID ]; then
         echo "pid=$PID" >> $CACHE_FILE
     fi
 }
 
-function stop() {
+stop() {
     echo "Stop node and unset PID"
-    if [[ -n $PID ]]; then
+    if [ -n $PID ]; then
        kill -- -$(ps -o pgid= $PID | grep -o [0-9]*)
     fi
     PID=
 }
 
-function start() {
+start() {
     echo "Start node project in $START_MODE mode, auto build is $AUTO_BUILD_ENABLED"
 
     npm install 1>> $LOG_FILE 2>> $LOG_FILE
@@ -64,11 +60,11 @@ function start() {
     # If auto build is enabled, we wrap the script in 'nodemon'.
 
     prefix=""
-    if [[ "$AUTO_BUILD_ENABLED" == "true" ]]; then
+    if [ "$AUTO_BUILD_ENABLED" = "true" ]; then
         npm install -g nodemon >> $LOG_FILE 2>> $LOG_FILE
         # Wrap the npm script in nodemon
         # If os passed in is windows, use the legacy watch option
-        if [[ "$OS" == "windows" ]]; then
+        if [ "$OS" = "windows" ]; then
             prefix="nodemon -L --exec"
         else
             prefix="nodemon --exec"
@@ -78,7 +74,7 @@ function start() {
     npm_script="start"
     # Treat debug and debugNoInit the same. If the user wants to debug init,
     # they can replace '--inspect' with '--inspect-brk' in package.json themselves
-    if [[ "$START_MODE" == "debug" || "$START_MODE" == "debugNoInit" ]]; then
+    if [ "$START_MODE" = "debug" ] || [ "$START_MODE" = "debugNoInit" ]; then
         npm_script="debug"
     fi
 
@@ -90,27 +86,27 @@ function start() {
     echo "PID is $PID"
 }
 
-if [[ "$COMMAND" == "start" ]]; then
+if [ "$COMMAND" = "start" ]; then
     start $AUTO_BUILD_ENABLED $START_MODE
     writeCache $PID
-elif [[ "$COMMAND" == "stop" ]]; then
+elif [ "$COMMAND" = "stop" ]; then
     readCache $PID
-    stop $PID
-    writeCache $PID
-elif [[ "$COMMAND" == "isActive" ]]; then
+    # stop $PID
+    # writeCache $PID
+elif [ "$COMMAND" = "isActive" ]; then
     readCache $PID
-    if [[ -n $PID ]]; then
+    if [ -n $PID ]; then
         TIMEOUT=0
-        until [[ $TIMEOUT -eq 10 ]]; do
+        until [ $TIMEOUT -eq 10 ]; do
             ps -p $PID
-            if [[ $? -eq 0 ]]; then
+            if [ $? -eq 0 ]; then
                 # Check if using nodemon
                 ps -o cmd -p $PID | grep nodemon
-                if [[ $? -eq 0 ]]; then
+                if [ $? -eq 0 ]; then
                     # The nodemon process stays around even when there is an error so check for PID
                     # as the parent process id as well
                     ps --ppid $PID
-                    if [[ $? -eq 0 ]]; then
+                    if [ $? -eq 0 ]; then
                         exit 0
                     fi
                 else

--- a/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #*******************************************************************************
 # Copyright (c) 2019 IBM Corporation and others.
 # All rights reserved. This program and the accompanying materials
@@ -118,7 +118,7 @@ elif [[ "$COMMAND" == "isActive" ]]; then
                     exit 0
                 fi
             fi
-            (( TIMEOUT++ ))
+            TIMEOUT=`expr "$TIMEOUT" + 1`
             sleep 1
         done
         echo "Could not find a running node/nodemon process. Try restarting the processes by toggling the auto build preference."

--- a/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
@@ -105,7 +105,6 @@ elif [ "$COMMAND" = "isActive" ]; then
                 if [ $? -eq 0 ]; then
                     # The nodemon process stays around even when there is an error so check for PID
                     # as the parent process id as well
-                    # ps --ppid $PID
                     PARENT_PROCESS_ID=$(awk -F 'PPid:' 'NF>0 { print $2 }' $PS_DIR/status |  tr -d '[:space:]')
                     echo "Parent process ID: $PARENT_PROCESS_ID"
                     if [ -d /proc/$PARENT_PROCESS_ID ]; then


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
* Changes the `noderun.sh` script that turbine uses to start Node.js containers to use `sh` rather than `bash` to support containers that do not have bash, such as `alpine`.

### Summary
* Use `awk` rather than a for loop and bash variable stuff to determine the cached `PID`.
* Use the `/proc` directory in linux to determine what processes are running and gather data around them.
* Change bash variables

### Testing
* Created a default Node.js application that uses ubuntu to verify that it is not broken by this change.
* Imported a Node.js project running on `node:alpine-8`
* Ran file-watcher server unit and functional tests (took 3.5hrs)
* Ran PFE test suite.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2004

## Does this PR require a documentation change ?
afaik no as we don't say the prereqs for running Node as it is.

## Any special notes for your reviewer ?

@rajivnathan fyi