### PR TITLE
fix: don't write infLockFlag to project.inf

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -341,7 +341,11 @@ module.exports = class Project {
 
   static filterNonPersistentFields(key, value) {
     // Strip out fields we don't want to save in the .inf file.
-    const nonPersistentFields = ["capabilitiesReady", "detailedAppStatus"];
+    const nonPersistentFields = [
+      'capabilitiesReady',
+      'detailedAppStatus',
+      'infLockFlag'
+    ];
     if (nonPersistentFields.includes(key)) {
       return undefined;
     }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Stops us writing the `infLockFlag` to the project.inf. We should not write `infLockFlag` to disk because it should reflect the live state of whether the project.inf is locked down or not.

## Which issue(s) does this PR fix ?
No issue created because I just spotted this problem and fixed it. This problem is in the area of this intermittent bug https://github.com/eclipse/codewind/issues/2219, but I can't see why this problem would cause that bug.

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?