### PR TITLE
.hcd filepath fix

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -350,8 +350,14 @@ module.exports = class LoadRunner {
       await this.waitForHealth(true);
     }
 
+    const mkdirCommand = `mkdir -p ${loadTestDir}`;
+    const mkdirArray = ['bash', '-c', mkdirCommand];
+    
+    await cwUtils.spawnContainerProcess(this.project, mkdirArray);
+
     const healthCentercommand = `export javapid=(\`pidof java\`); java -jar $JAVA_HOME/jre/lib/ext/healthcenter.jar ID=\${javapid[-1]} level=headless -Dcom.ibm.java.diagnostics.healthcenter.headless.run.number.of.runs=1 -Dcom.ibm.java.diagnostics.healthcenter.headless.run.duration=${durationInMins} -Dcom.ibm.java.diagnostics.healthcenter.headless.output.directory=${loadTestDir} -Dcom.ibm.diagnostics.healthcenter.data.memory=off -Dcom.ibm.diagnostics.healthcenter.data.memorycounters=off -Dcom.ibm.diagnostics.healthcenter.data.cpu=off -Dcom.ibm.diagnostics.healthcenter.data.environment=off -Dcom.ibm.diagnostics.healthcenter.data.locking=off -Dcom.ibm.diagnostics.healthcenter.data.memory=off -Dcom.ibm.diagnostics.healthcenter.data.threads=off`;
     const healthCenterArray = ['bash', '-c', healthCentercommand];
+
     try {
       await cwUtils.spawnContainerProcess(this.project, healthCenterArray);
     } catch (error) {
@@ -381,6 +387,7 @@ module.exports = class LoadRunner {
     log.info("getJavaHealthCenterData: .hcd copied to PFE");
     const data = { projectID: this.project.projectID,  status: 'hcdReady', timestamp: this.metricsFolder};
     this.user.uiSocket.emit('runloadStatusChanged', data);
+    this.project = null;
   }
 
   async getLibertyJavaVersion() {


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix

- [ ] Enhancement

## What does this PR do ?
Adds in a mkdir command to LoadTest.js before the Java health center agent is attached.

Whenever a load test was started and the load-test directory did not exist in the project pod, the health center agent would use a default location to save the .hcd profiling file. 

This only affected the first run of a new project, as PFE would create a load-test folder in the project workspace after a load test, which would be synced across on a project restart or rebuild.

Ensuring that the folder exists before starting the health center agent ensures the .hcd will always be saved in the correct place.

I'm also ensuring that the project is made null after finding the .hcd file. Not doing so could cause issues where the load run was still considered to be in progress, preventing me from starting others.

## Which issue(s) does this PR fix ?
No issue made.
