### PR TITLE
Fix: Incorrectly named LoadTest test

### DIFF
--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -177,7 +177,17 @@ describe('Load Runner Tests', function() {
             res.should.satisfyApiSpec;
         });
 
-        it('fails with 503 to run load when load is already running', async function() {
+        /**
+         * Test disabled because we don't wait for test project to run, so PFE rejects requests to run load.
+         */
+        it.skip('fails with 409 to run load when load is already running', async function() {
+            this.timeout(testTimeout.short);
+            const res = await projectService.runLoad(projectID);
+            res.should.have.status(409);
+            res.should.satisfyApiSpec;
+        });
+
+        it('fails with 503 to run load when project is not running', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.runLoad(projectID);
             res.should.have.status(503);


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Changes the description of the LoadTest test expecting a 503 to be correct and not say it's expecting a 409.

Add a test for response 409 trying to run a load already in progress. Currently disabled as our test project is never in a running state, so will always return 503.
