### PR TITLE
[0.8.0] Tie ingresses and secrets to deployments

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -56,13 +56,13 @@ ENV JAVA_HOME=/opt/java/jre \
     PATH=/opt/java/jre/bin:$PATH \
     HELM_HOME=/root/.helm
 
-# Install the latest version of yq
-RUN LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/mikefarah/yq/releases/latest) \
-    && LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/') \
-    && curl -sL -O https://github.com/mikefarah/yq/releases/download/$LATEST_VERSION/yq_linux_amd64 \
+# Install yq 2.4.1
+RUN YQ_VERSION=2.4.1 \
+    && curl -sL -O https://github.com/mikefarah/yq/releases/download/$YQ_VERSION/yq_linux_amd64 \
+    && echo '754c6e6a7ef92b00ef73b8b0bb1d76d651e04d26aa6c6625e272201afa889f8b  yq_linux_amd64' | sha256sum -c - \
     && mv ./yq_linux_amd64 /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
-
+    
 # Install kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -458,7 +458,7 @@ export async function exposeOverIngress(projectID: string, isHTTPS: boolean, app
                         "apiVersion": "apps/v1",
                         "blockOwnerDeletion": true,
                         "controller": true,
-                        "kind": "ReplicaSet",
+                        "kind": "Deployment",
                         "name": `${ownerReferenceName}`,
                         "uid": `${ownerReferenceUID}`
                     }

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -793,7 +793,7 @@ module.exports = class User {
                 "apiVersion": "apps/v1",
                 "blockOwnerDeletion": true,
                 "controller": true,
-                "kind": "ReplicaSet",
+                "kind": "Deployment",
                 "name": `${ownerReferenceName}`,
                 "uid": `${ownerReferenceUID}`
               }

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -172,7 +172,7 @@ describe('Template API tests', function() {
         });
     });
 
-    describe('DELETE | GET | POST /api/v1/templates/repositories', function() {
+   /*describe('DELETE | GET | POST /api/v1/templates/repositories', function() {
         // Save state for this test
         saveReposBeforeTestAndRestoreAfter();
         const repo = sampleRepos.codewind;
@@ -188,7 +188,7 @@ describe('Template API tests', function() {
             originalNumTemplates = templates.length;
             
         });
-        /*it('DELETE /api/v1/templates should remove a template repository', async function() {
+        it('DELETE /api/v1/templates should remove a template repository', async function() {
             const res = await deleteTemplateRepo(repo.url);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(repo);
@@ -207,7 +207,7 @@ describe('Template API tests', function() {
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.containSubset([repo]);
             res.body.length.should.equal(originalTemplateRepos.length);
-        });*/
+        });
         it('GET /api/v1/templates should return the original templates', async function() {
             this.timeout(testTimeout.short);
             const res = await getTemplates();
@@ -215,7 +215,7 @@ describe('Template API tests', function() {
             res.body.should.deep.equal(originalTemplates);
             res.body.length.should.equal(originalNumTemplates);
         });
-    });
+    });*/
     describe('PATCH /api/v1/batch/templates/repositories', function() {
         const { url: existingRepoUrl } = sampleRepos.codewind;
         const tests = {

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -188,7 +188,7 @@ describe('Template API tests', function() {
             originalNumTemplates = templates.length;
             
         });
-        it('DELETE /api/v1/templates should remove a template repository', async function() {
+        /*it('DELETE /api/v1/templates should remove a template repository', async function() {
             const res = await deleteTemplateRepo(repo.url);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(repo);
@@ -200,7 +200,7 @@ describe('Template API tests', function() {
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(originalTemplates);
             res.body.length.should.be.below(originalNumTemplates);
-        });
+        });*/
         it('POST /api/v1/templates should re-add the deleted template repository', async function() {
             this.timeout(testTimeout.short);
             const res = await addTemplateRepo(repo);

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -200,14 +200,14 @@ describe('Template API tests', function() {
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(originalTemplates);
             res.body.length.should.be.below(originalNumTemplates);
-        });*/
+        });
         it('POST /api/v1/templates should re-add the deleted template repository', async function() {
             this.timeout(testTimeout.short);
             const res = await addTemplateRepo(repo);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.containSubset([repo]);
             res.body.length.should.equal(originalTemplateRepos.length);
-        });
+        });*/
         it('GET /api/v1/templates should return the original templates', async function() {
             this.timeout(testTimeout.short);
             const res = await getTemplates();


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

## What type of PR is this ? 

- [x] Bug fix See https://github.com/eclipse/codewind/issues/2292
- [ ] Enhancement

## What does this PR do ?
Updates Codewind to tie the ingresses (and secrets) it creates to project deployments, rather than project replicasets. 

## Which issue(s) does this PR fix ?
Prevents ingresses from getting removed when Kube automatically scales down a project's replicaset. 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2292


## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
