### PR TITLE
[Master] Tie ingresses and secrets to deployments

### DIFF
--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -462,7 +462,7 @@ export async function exposeOverIngress(projectID: string, projectName: string, 
                         "apiVersion": "apps/v1",
                         "blockOwnerDeletion": true,
                         "controller": true,
-                        "kind": "ReplicaSet",
+                        "kind": "Deployment",
                         "name": `${ownerReferenceName}`,
                         "uid": `${ownerReferenceUID}`
                     }

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -824,7 +824,7 @@ module.exports = class User {
                 "apiVersion": "apps/v1",
                 "blockOwnerDeletion": true,
                 "controller": true,
-                "kind": "ReplicaSet",
+                "kind": "Deployment",
                 "name": `${ownerReferenceName}`,
                 "uid": `${ownerReferenceUID}`
               }


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

## What type of PR is this ? 

- [x] Bug fix See https://github.com/eclipse/codewind/issues/2292
- [ ] Enhancement

## What does this PR do ?
Updates Codewind to tie the ingresses (and secrets) it creates to project deployments, rather than project replicasets. 

## Which issue(s) does this PR fix ?
Prevents ingresses from getting removed when Kube automatically scales down a project's replicaset. 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2292


## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
