### PR TITLE
test: print res.text when res.status fails assertion

### DIFF
--- a/test/src/API/extensions.test.js
+++ b/test/src/API/extensions.test.js
@@ -21,6 +21,6 @@ describe('Extensions API test', function() {
         const res = await reqService.chai
             .get('/api/v1/extensions')
             .set('Cookie', ADMIN_COOKIE);
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
     });
 });

--- a/test/src/API/health.test.js
+++ b/test/src/API/health.test.js
@@ -18,6 +18,6 @@ describe('Health endpoint test', function() {
     it('should return status 200', async function() {
         const res = await reqService.chai
             .get('/health');
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
     });
 });

--- a/test/src/API/ignoredPaths.test.js
+++ b/test/src/API/ignoredPaths.test.js
@@ -24,7 +24,7 @@ describe('ignoredPaths API test', function() {
     describe('Swift', () => {
         it('returns 200 and an array containing a correct example ignored path', async() => {
             const res = await getIgnoredPaths('swift');
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array');
             res.body.should.include('.swift-version');
         });
@@ -32,7 +32,7 @@ describe('ignoredPaths API test', function() {
     describe('Liberty', () => {
         it('returns 200 and an array containing correct example ignored path', async() => {
             const res = await getIgnoredPaths('liberty');
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array');
             res.body.should.include('/libertyrepocache.zip');
         });
@@ -40,7 +40,7 @@ describe('ignoredPaths API test', function() {
     describe('Spring', () => {
         it('returns 200 and an array containing correct example ignored path', async() => {
             const res = await getIgnoredPaths('spring');
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array');
             res.body.should.include('/localm2cache.zip');
         });
@@ -48,7 +48,7 @@ describe('ignoredPaths API test', function() {
     describe('Node.js', () => {
         it('returns 200 and an array containing correct example ignored path', async() => {
             const res = await getIgnoredPaths('node');
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array');
             res.body.should.include('*/node_modules*');
         });
@@ -56,7 +56,7 @@ describe('ignoredPaths API test', function() {
     describe('Docker', () => {
         it('returns 200 and an array containing correct example ignored path', async() => {
             const res = await getIgnoredPaths('docker');
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array');
             res.body.should.include('*/.DS_Store');
         });
@@ -64,10 +64,9 @@ describe('ignoredPaths API test', function() {
     describe('Unknown Type', () => {
         it('returns 200 and an array of default docker ignoredPaths', async() => {
             const res = await getIgnoredPaths('unknown');
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array');
             res.body.should.include('*/.DS_Store');
         });
     });
 });
-

--- a/test/src/API/invalid-name-chars.test.js
+++ b/test/src/API/invalid-name-chars.test.js
@@ -26,7 +26,7 @@ describe('invalidNameChars tests', function() {
         const res = await reqService.chai
             .get('/api/v1/projects/invalidNameChars')
             .set('Cookie', ADMIN_COOKIE);
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
         res.body.illegalNameChars.should.deep.equal(expectedInvalidChars);
     });
 });

--- a/test/src/API/locale.test.js
+++ b/test/src/API/locale.test.js
@@ -21,6 +21,6 @@ describe('Locale API test', function() {
         const res = await reqService.chai.post('/api/v1/locale')
             .set('Cookie', ADMIN_COOKIE)
             .send({ locale: ['en-us', 'en'] });
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
     });
 });

--- a/test/src/API/logging.test.js
+++ b/test/src/API/logging.test.js
@@ -37,12 +37,12 @@ describe('Logging API tests (these `it` blocks depend on each other passing)', f
 
     after('reset log level to original level', async function() {
         const res = await setLogLevel(originalLogLevel);
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
     });
 
     it('returns 200 and logging info when GET /logging is called', async function() {
         const res = await getLogLevel();
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.body.allLevels.should.have.members(validLevels);
 
@@ -52,20 +52,20 @@ describe('Logging API tests (these `it` blocks depend on each other passing)', f
 
     it('returns 400 when PUT /logging is called with body { level : unknownLogLevel }', async function() {
         const res = await setLogLevel('unknownLogLevel');
-        res.should.have.status(400);
+        res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.text.should.include('Invalid logging level requested');
     });
 
     it('returns 200 when PUT /logging is called with body { level : debug }', async function() {
         const res = await setLogLevel('warn');
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
     });
 
     it('returns 200 when PUT /logging is called with body { level : info }', async function() {
         const res = await setLogLevel('debug');
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
     });
 

--- a/test/src/API/projects/bind.test.js
+++ b/test/src/API/projects/bind.test.js
@@ -52,7 +52,7 @@ describe('Bind projects tests', () => {
                 creationTime: Date.now(),
             });
 
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             
             const pathToPfeTempProjectDir = path.join('codewind-workspace', 'cw-temp', projectName);
@@ -67,7 +67,7 @@ describe('Bind projects tests', () => {
             const responses = await projectService.uploadAllFiles(projectID, pathToLocalProject, 'nodejs');
 
             responses.forEach(res => {
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
             });
             const pathToUploadedFile = path.join('codewind-workspace', 'cw-temp', projectName, 'package.json');
@@ -78,7 +78,7 @@ describe('Bind projects tests', () => {
             this.timeout(testTimeout.short);
             
             const res = await projectService.bindEnd(projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             
             const pathToPfeTempProjectDir = path.join('codewind-workspace', 'cw-temp', projectName);
@@ -99,7 +99,7 @@ describe('Bind projects tests', () => {
                 creationTime: Date.now(),
             });
 
-            res.should.have.status(409);
+            res.status.should.equal(409, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const finalNumProjects = await projectService.countProjects();
@@ -109,7 +109,7 @@ describe('Bind projects tests', () => {
             this.timeout(testTimeout.short);
             
             const res = await projectService.unbind(projectID);
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             
             const pathToPfeTempProjectDir = path.join('codewind-workspace', 'cw-temp', projectName);
@@ -132,7 +132,7 @@ describe('Bind projects tests', () => {
                     path: 'valid/path',
                     creationTime: Date.now(),
                 });
-                res.should.have.status(400);
+                res.status.should.equal(400, res.text); // print res.text if assertion fails
                 res.body.message.should.equal('Project name is invalid: invalid characters : ["&"]');
             });
             it('returns 400 if projectType is invalid', async function() {
@@ -144,7 +144,7 @@ describe('Bind projects tests', () => {
                     path: 'valid/path',
                     creationTime: Date.now(),
                 });
-                res.should.have.status(400);
+                res.status.should.equal(400, res.text); // print res.text if assertion fails
                 res.text.should.equal('projects must specify a valid project type');
             });
         });
@@ -159,7 +159,7 @@ describe('Bind projects tests', () => {
                     pathToLocalProject,
                     'package.json',
                 );
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
             });
         });
@@ -170,7 +170,7 @@ describe('Bind projects tests', () => {
                 this.timeout(testTimeout.short);
                 const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
                 const res = await projectService.bindEnd(idMatchingNoProjects);
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
             });
@@ -182,7 +182,7 @@ describe('Bind projects tests', () => {
                 this.timeout(testTimeout.short);
                 const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
                 const res = await projectService.unbind(idMatchingNoProjects, 404);
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
             });

--- a/test/src/API/projects/build.test.js
+++ b/test/src/API/projects/build.test.js
@@ -42,7 +42,7 @@ describe('Project Build Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.buildProject(projectID, 'build');
             
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Trying to build project ${projectID} with action build`);
         });
@@ -51,7 +51,7 @@ describe('Project Build Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.buildProject(projectID, 'enableautobuild');
             
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Trying to build project ${projectID} with action enableautobuild`);
         });
@@ -60,7 +60,7 @@ describe('Project Build Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.buildProject(projectID, 'disableautobuild');
             
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Trying to build project ${projectID} with action disableautobuild`);
         });
@@ -69,7 +69,7 @@ describe('Project Build Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.buildProject(projectID, 'unknown action');
             
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal('Error while validating request: request.body.action should be equal to one of the allowed values');
         });
@@ -79,7 +79,7 @@ describe('Project Build Tests', function() {
             const projectID = '00000000-0000-0000-0000-000000000000';
             const res = await projectService.buildProject(projectID, 'build');
             
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Unable to find project ${projectID}`);
         });

--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -110,27 +110,27 @@ describe('Load Runner Tests', function() {
                 it('fails with 400 to POST/loadtest/config when an input field is missing', async function() {
                     this.timeout(testTimeout.short);
                     const res = await writeToLoadTestConfig(projectID, configOptions);
-                    res.should.have.status(400);
+                    res.status.should.equal(400, res.text); // print res.text if assertion fails
                 });
 
                 it('fails with 400 to POST/loadtest/config when an input field is the wrong type', async function() {
                     this.timeout(testTimeout.short);
                     configOptions.path = true;
                     const res = await writeToLoadTestConfig(projectID, configOptions);
-                    res.should.have.status(400);
+                    res.status.should.equal(400, res.text); // print res.text if assertion fails
                 });
 
                 it('fails with 400 to POST/loadtest/config when input path is non-absolute', async function() {
                     this.timeout(testTimeout.short);
                     configOptions.path = 'test';
                     const res = await writeToLoadTestConfig(projectID, configOptions);
-                    res.should.have.status(400);
+                    res.status.should.equal(400, res.text); // print res.text if assertion fails
                 });
 
                 it('fails with 404 to POST/loadtest/config when project does not exist', async function() {
                     this.timeout(testTimeout.short);
                     const res = await writeToLoadTestConfig('falseID', configOptions);
-                    res.should.have.status(404);
+                    res.status.should.equal(404, res.text); // print res.text if assertion fails
                     res.should.satisfyApiSpec;
                 });
             });
@@ -146,7 +146,7 @@ describe('Load Runner Tests', function() {
             it('fails with 404 to GET/loadtest/config when project does not exist', async function() {
                 this.timeout(testTimeout.short);
                 const res = await readLoadTestConfig('falseID');
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
             });
         });
@@ -156,14 +156,14 @@ describe('Load Runner Tests', function() {
         it('fails with 404 to run load against a project with an invalid id', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.runLoad('invalidID');
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
 
         it('fails with 404 to cancel load on a project with an invalid id', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.cancelLoad('invalidID');
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
 
@@ -173,7 +173,7 @@ describe('Load Runner Tests', function() {
         it.skip('returns 202 and starts running load against a project', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.runLoad(projectID, 'Load test run to test running load against a project.');
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
 
@@ -183,14 +183,14 @@ describe('Load Runner Tests', function() {
         it.skip('fails with 409 to run load when load is already running', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.runLoad(projectID);
-            res.should.have.status(409);
+            res.status.should.equal(409, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
 
         it('fails with 503 to run load when project is not running', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.runLoad(projectID);
-            res.should.have.status(503);
+            res.status.should.equal(503, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
 
@@ -204,7 +204,7 @@ describe('Load Runner Tests', function() {
         it("fails with 409 to cancel load that isn't being run", async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.cancelLoad(projectID);
-            res.should.have.status(409);
+            res.status.should.equal(409, res.text); // print res.text if assertion fails
         });
     });
 });

--- a/test/src/API/projects/metrics.test.js
+++ b/test/src/API/projects/metrics.test.js
@@ -59,7 +59,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
 
         it('returns 200 and the available metric types', async function() {
             const res = await getProjectMetrics(projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.body.length.should.equal(METRIC_TYPES.length);
             const expectedResBody = METRIC_TYPES.map(type => ({
@@ -71,7 +71,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
 
         it('returns 404 when the given project does not exist', async function() {
             const res = await getProjectMetrics('blahblah-project');
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
         });
     });
 
@@ -103,7 +103,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const invalidUpdateOptions = { noDescription: 'noDescription' };
                 const res = await updateProjectMetrics(projectID, originalLoadTest.testRunTime, invalidUpdateOptions);
                 
-                res.should.have.status(400);
+                res.status.should.equal(400, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.message.should.equal('request body has no \'description\' field');
             });
@@ -116,7 +116,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const timeOfNonExistentLoadTest = '1234567891234';
                 const res = await updateProjectMetrics(projectID, timeOfNonExistentLoadTest, updateOptions);
                 
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.message.should.include(`Unable to find metrics for project ${projectID}`);
                 res.body.message.should.include(`found no load-test metrics from time ${timeOfNonExistentLoadTest}`);
@@ -130,7 +130,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const idOfNonExistentProject = 'nonexistentproject';
                 const res = await updateProjectMetrics(idOfNonExistentProject, originalLoadTest.testRunTime, updateOptions);
                 
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.message.should.equal(`Unable to find project ${idOfNonExistentProject}`);
             });
@@ -143,7 +143,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const updateOptions = { description: newDescription };
                 const res = await updateProjectMetrics(projectID, originalLoadTest.testRunTime, updateOptions);
 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.description.should.equal(newDescription);
 
@@ -163,7 +163,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const updateOptions = { description: '' };
                 const res = await updateProjectMetrics(projectID, originalLoadTest.testRunTime, updateOptions);
 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.description.should.equal('');
 
@@ -227,7 +227,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const timeOfNonExistentLoadTest = '20150101000000';
                 const res = await deleteProjectMetrics(projectID, timeOfNonExistentLoadTest);
                 
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.message.should.include(`Unable to find metrics for project ${projectID}`);
                 res.body.message.should.include(`found no load-test metrics from time ${timeOfNonExistentLoadTest}`);
@@ -240,7 +240,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const idOfNonExistentProject = 'nonexistentproject';
                 const res = await deleteProjectMetrics(idOfNonExistentProject, originalLoadTest.testRunTime);
                 
-                res.should.have.status(404);
+                res.status.should.equal(404, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
                 res.body.message.should.equal(`Unable to find project ${idOfNonExistentProject}`);
             });
@@ -252,7 +252,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
 
                 const res = await deleteProjectMetrics(projectID, originalLoadTest.testRunTime);
                 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.should.satisfyApiSpec;
 
                 // and we can get all the original metrics except for the one we deleted
@@ -283,7 +283,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 const timeOfNonExistentLoadTest = '20190326155249';
                 const res = await deleteProjectMetrics(projectID, timeOfNonExistentLoadTest);
                 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 
                 const closestNeighborDir = `${parseInt(timeOfNonExistentLoadTest, 10) - 1}`;
                 const pathToClosestNeighborDir = path.join(pathToProjectLoadTestDir, closestNeighborDir);
@@ -312,7 +312,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 this.timeout(testTimeout.med);
                 const res = await getProjectMetricsByType(projectID, type);
                 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.body.should.be.an('array');
 
                 // copy the project's load-test dir to a temp dir to compare them in this test
@@ -346,14 +346,14 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
         it('returns 404 when the given metric does not exist', async function() {
             this.timeout(testTimeout.med);
             const res = await getProjectMetricsByType(projectID, 'blahblah');
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
         });
 
         it('returns 422 when the load test directory does not exist', async function() {
             this.timeout(testTimeout.short);
             await containerService.removeDir(pathToProjectLoadTestDir);
             const res = await getProjectMetricsByType(projectID, 'cpu');
-            res.should.have.status(422);
+            res.status.should.equal(422, res.text); // print res.text if assertion fails
         });
     });
 
@@ -363,7 +363,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
             const validTypes = ['cpu','memory'];
             const res = await postProjectsMetricsTypes(projectID, validTypes);
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             const receivedTypes = res.body.map(metricsObj => metricsObj.type);
             receivedTypes.should.have.members(validTypes);
         });

--- a/test/src/API/projects/metricsCompare.test.js
+++ b/test/src/API/projects/metricsCompare.test.js
@@ -63,7 +63,7 @@ describe('Metrics Comparison tests (/projects/{id}/metrics/compare)', function()
             const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
             const res = await getProjectComparisonData(idMatchingNoProjects);
             
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
         });
@@ -72,7 +72,7 @@ describe('Metrics Comparison tests (/projects/{id}/metrics/compare)', function()
             this.timeout(testTimeout.short);
             const res = await getProjectComparisonData(projectID);
             
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.body.should.deep.equal([
                 {
@@ -107,7 +107,7 @@ describe('Metrics Comparison tests (/projects/{id}/metrics/compare)', function()
             await removeCpuDataFromMetricsJson(loadTest1);
 
             const res = await getProjectComparisonData(projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             res.body.forEach((dataObj) => {
@@ -125,7 +125,7 @@ describe('Metrics Comparison tests (/projects/{id}/metrics/compare)', function()
             await deleteDataFromLoadTestRun(loadTest2);
 
             const res = await getProjectComparisonData(projectID);
-            res.should.have.status(422);
+            res.status.should.equal(422, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
     });

--- a/test/src/API/projects/metricsInject.test.js
+++ b/test/src/API/projects/metricsInject.test.js
@@ -37,7 +37,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         this.timeout(testTimeout.short);
         const res = await postMetricsInject(projectID, { enable: true });
         
-        res.should.have.status(404);
+        res.status.should.equal(404, res.text); // print res.text if assertion fails
         res.text.should.equal(`Unable to find project ${projectID}`);
     });
     
@@ -59,7 +59,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsInject(projectID, { enable: true });
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
         
             const { body: project } = await projectService.getProject(projectID);
             project.should.containSubset({
@@ -81,7 +81,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsInject(projectID, { enable: false });
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
         
             const { body: project } = await projectService.getProject(projectID);
             project.should.containSubset({
@@ -119,7 +119,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsInject(projectID, { enable: true });
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
         
             const { body: project } = await projectService.getProject(projectID);
             project.should.containSubset({
@@ -141,7 +141,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsInject(projectID, { enable: false });
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
         
             const { body: project } = await projectService.getProject(projectID);
             project.should.containSubset({
@@ -179,7 +179,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         it('returns 202 to /metrics/inject and starts injecting metrics into the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsInject(projectID, { enable: true });
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
         
             const { body: project } = await projectService.getProject(projectID);
             project.should.containSubset({
@@ -201,7 +201,7 @@ describe('Metrics Inject tests (/api/v1/projects/{id}/metrics/inject)', function
         it('returns 202 to /metrics/inject and starts removing injected metrics from the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsInject(projectID, { enable: false });
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
         
             const { body: project } = await projectService.getProject(projectID);
             project.should.containSubset({

--- a/test/src/API/projects/metricsStatus.test.js
+++ b/test/src/API/projects/metricsStatus.test.js
@@ -28,7 +28,7 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
         this.timeout(testTimeout.short);
 
         const res = await getMetricsStatus('invalidId');
-        res.should.have.status(404);
+        res.status.should.equal(404, res.text); // print res.text if assertion fails
     });
 
     describe('Node.js project with appmetrics-dash', function() {
@@ -62,7 +62,7 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
             project.metricsAvailable.should.be.true;
 
             const res = await getMetricsStatus(project.projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.metricsAvailable.should.be.true;
 
             // save projectID for cleanup
@@ -111,7 +111,7 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
             project.metricsAvailable.should.be.false;
 
             const res = await getMetricsStatus(project.projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.metricsAvailable.should.be.false;
 
             // save projectID for cleanup
@@ -145,7 +145,7 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 projectType: 'nodejs',
                 creationTime: Date.now(),
             });
-            resToBind.should.have.status(400);
+            resToBind.status.should.equal(400, resToBind.text); // print res.text if assertion fails
             resToBind.should.satisfyApiSpec;
             resToBind.body.should.deep.equal({
                 name: 'MetricsStatusError',
@@ -186,7 +186,7 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
             project.metricsAvailable.should.be.true;
 
             const res = await getMetricsStatus(project.projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.metricsAvailable.should.be.true;
 
             // save projectID for cleanup
@@ -225,7 +225,7 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
             project.metricsAvailable.should.be.false;
 
             const res = await getMetricsStatus(project.projectID);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.metricsAvailable.should.be.false;
 
             // save projectID for cleanup

--- a/test/src/API/projects/openclose.test.js
+++ b/test/src/API/projects/openclose.test.js
@@ -42,7 +42,7 @@ describe('Open/Close Project Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.closeProject(projectID);
             
-            res.should.have.status(202);
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.body.msg.should.equal(`Now trying to close project ${projectName} (${projectID})`); 
         });
@@ -51,7 +51,7 @@ describe('Open/Close Project Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.closeProject(projectID);
             
-            res.should.have.status(409);
+            res.status.should.equal(409, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.body.msg.should.include('Already closing'); 
         });
@@ -61,7 +61,7 @@ describe('Open/Close Project Tests', function() {
             const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
             const res = await projectService.closeProject(idMatchingNoProjects);
             
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.body.msg.should.equal(`Unable to find project ${idMatchingNoProjects}`);
         });
@@ -72,7 +72,7 @@ describe('Open/Close Project Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.openProject(projectID);
             
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Project ${projectName} (${projectID}) opened. Will now build and run it`);
         });
@@ -81,7 +81,7 @@ describe('Open/Close Project Tests', function() {
             this.timeout(testTimeout.short);
             const res = await projectService.openProject(projectID);
             
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Project ${projectName} (${projectID}) opened. Will now build and run it`);
         });
@@ -91,7 +91,7 @@ describe('Open/Close Project Tests', function() {
             const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
             const res = await projectService.openProject(idMatchingNoProjects);
             
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
         });

--- a/test/src/API/projects/projects.test.js
+++ b/test/src/API/projects/projects.test.js
@@ -64,7 +64,7 @@ describe('Projects API tests', function() {
             this.timeout(testTimeout.short);
             const idMatchingNoProjects = '00000000-0000-0000-0000-000000000000';
             const res = await projectService.getProject(idMatchingNoProjects, 404);
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal('Not Found');
         });

--- a/test/src/API/projects/restart.test.js
+++ b/test/src/API/projects/restart.test.js
@@ -42,7 +42,7 @@ describe('Project Restart Tests (POST /projects/{id}/restart)', function() {
         this.timeout(testTimeout.short);
         const res = await projectService.restartProject(projectID, 'run');
 
-        res.should.have.status(400);
+        res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.body.message.should.equal(`Request error for project ${projectID}. Restart is invalid when the project is building.`);
     });
@@ -51,7 +51,7 @@ describe('Project Restart Tests (POST /projects/{id}/restart)', function() {
         this.timeout(testTimeout.short);
         const res = await projectService.restartProject(projectID, 'debugNoInit');
 
-        res.should.have.status(400);
+        res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.body.message.should.equal(`Request error for project ${projectID}. Restart is invalid when the project is building.`);
     });
@@ -60,7 +60,7 @@ describe('Project Restart Tests (POST /projects/{id}/restart)', function() {
         this.timeout(testTimeout.short);
         const res = await projectService.restartProject(projectID, 'debug');
 
-        res.should.have.status(400);
+        res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.body.message.should.equal(`Request error for project ${projectID}. Node.js projects do not support restarting in debug mode.`);
     });
@@ -69,7 +69,7 @@ describe('Project Restart Tests (POST /projects/{id}/restart)', function() {
         this.timeout(testTimeout.short);
         const res = await projectService.restartProject(projectID, 'unknownMode');
 
-        res.should.have.status(400);
+        res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.text.should.equal('Error while validating request: request.body.startMode should be equal to one of the allowed values');
     });
@@ -79,7 +79,7 @@ describe('Project Restart Tests (POST /projects/{id}/restart)', function() {
         const projectID = '00000000-0000-0000-0000-000000000000';
         const res = await projectService.restartProject(projectID, 'run');
 
-        res.should.have.status(404);
+        res.status.should.equal(404, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
         res.body.msg.should.equal(`Unable to find project ${projectID}`);
     });

--- a/test/src/API/projects/uploadEnd.test.js
+++ b/test/src/API/projects/uploadEnd.test.js
@@ -58,7 +58,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 pathFromDirToModifiedFile,
             );
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToModifiedFile);
@@ -78,7 +78,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const pathToFileInPfeProjectDir = path.join('codewind-workspace', projectName, pathFromDirToModifiedFile);
@@ -118,7 +118,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 pathFromDirToNewFile,
             );
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToNewFile);
@@ -141,7 +141,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToNewFile);
@@ -188,7 +188,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const pathToFileInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToDeletedFile);
@@ -237,7 +237,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
 
             const pathToDirInPfeTempDir = path.join('codewind-workspace', 'cw-temp', projectName, pathFromDirToDeletedDir);
@@ -275,7 +275,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
             };
             const res = await projectService.uploadEnd(projectID, options);
 
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
     });
@@ -290,7 +290,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 timeStamp: Date.now(),
             };
             const res = await projectService.uploadEnd(projectID, options);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.equal('Error while validating request: request.body should have required property \'fileList\'');
         });
 
@@ -303,7 +303,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 timeStamp: Date.now(),
             };
             const res = await projectService.uploadEnd(projectID, options);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.equal('Error while validating request: request.body should have required property \'directoryList\'');
         });
 
@@ -316,7 +316,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 timeStamp: Date.now(),
             };
             const res = await projectService.uploadEnd(projectID, options);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.equal('Error while validating request: request.body should have required property \'modifiedList\'');
         });
 
@@ -329,7 +329,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 modifiedList: null,
             };
             const res = await projectService.uploadEnd(projectID, options);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.equal('Error while validating request: request.body should have required property \'timeStamp\'');
         });
 
@@ -343,7 +343,7 @@ describe('Sync tests (POST projects/{id}/upload/end)', () => {
                 timeStamp: Date.now(),
             };
             const res = await projectService.uploadEnd(idMatchingNoProjects, options);
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
         });
     });

--- a/test/src/API/projects/watchList-fileChanges.test.js
+++ b/test/src/API/projects/watchList-fileChanges.test.js
@@ -41,7 +41,7 @@ describe('watchList and file-changes route tests', function() {
             this.timeout(testTimeout.med);
             const res = await projectService.getWatchList();
             
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             const project = res.body.projects.find(project => project.projectID === projectID);
             project.should.containSubset({
                 projectID,
@@ -87,7 +87,7 @@ describe('watchList and file-changes route tests', function() {
                 .query({ clientUuid });
             const res = await reqService.makeReq(req);
             
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.equal('Error while validating request: request.body should have required property \'success\'');
         });
 
@@ -101,7 +101,7 @@ describe('watchList and file-changes route tests', function() {
                 .send({ success: true });
 
             const res = await reqService.makeReq(req);
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.text.should.equal(`Unable to find project ${idMatchingNoProjects}`);
         });
         
@@ -114,7 +114,7 @@ describe('watchList and file-changes route tests', function() {
                 .send({ success: true });
 
             const res = await reqService.makeReq(req);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
         });
     });
 });

--- a/test/src/API/registry.test.js
+++ b/test/src/API/registry.test.js
@@ -76,7 +76,7 @@ describe.skip('Deployment Registry route tests', function() {
 
         // Get the watch list for workspace config dir
         const res = await getWatchList();
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
         const projectsWatchList = res.body.projects;
         for (let i = 0; i < projectsWatchList.length; i++) {
             if (projectsWatchList[i].pathToMonitor.includes('.config')) {
@@ -105,7 +105,7 @@ describe.skip('Deployment Registry route tests', function() {
             this.timeout(testTimeout.med);
             await containerService.unlink(workspace_settings_file);
             const res = await getRegistryStatus();
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.deploymentRegistry.should.equal(false);
         });
 
@@ -119,7 +119,7 @@ describe.skip('Deployment Registry route tests', function() {
             fs.unlinkSync(content_file);
 
             const res = await getRegistryStatus();
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.deploymentRegistry.should.equal(false);
         });
 
@@ -133,7 +133,7 @@ describe.skip('Deployment Registry route tests', function() {
             fs.unlinkSync(content_file);
 
             const res = await getRegistryStatus();
-            res.should.have.status(500);
+            res.status.should.equal(500, res.text); // print res.text if assertion fails
             res.body.deploymentRegistry.should.equal(false);
         });
 
@@ -147,7 +147,7 @@ describe.skip('Deployment Registry route tests', function() {
             fs.unlinkSync(content_file);
 
             const res = await getRegistryStatus();
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.deploymentRegistry.should.equal(true);
         });
     });
@@ -157,7 +157,7 @@ describe.skip('Deployment Registry route tests', function() {
             this.timeout(testTimeout.med);
 
             const res = await testRegistry();
-            res.should.have.status(500);
+            res.status.should.equal(500, res.text); // print res.text if assertion fails
             res.body.imagePushRegistryTest.should.equal(false);
         });
 
@@ -166,10 +166,10 @@ describe.skip('Deployment Registry route tests', function() {
 
             const newRegistry = 'localhost:5000';
             const setRes = await setRegistry(newRegistry);
-            setRes.should.have.status(200);
+            setRes.status.should.equal(200, setRes.text); // print res.text if assertion fails
 
             const statusRes = await getRegistryStatus();
-            statusRes.should.have.status(200);
+            statusRes.status.should.equal(200, statusRes.text); // print res.text if assertion fails
             statusRes.body.deploymentRegistry.should.equal(true);
 
             const settings = await containerService.readJson(workspace_settings_file);

--- a/test/src/API/registrySecrets.test.js
+++ b/test/src/API/registrySecrets.test.js
@@ -79,7 +79,7 @@ describe('Registry Secrets route tests', function() {
             this.timeout(testTimeout.med);
             
             const res = await getRegistrySecrets();
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array').to.have.lengthOf(0);
         });
 
@@ -93,7 +93,7 @@ describe('Registry Secrets route tests', function() {
             await containerService.copyTo(docker_registry_secret_garbage_file, docker_registry_file);
 
             const res = await getRegistrySecrets();
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array').to.have.lengthOf(2);
         });
 
@@ -107,7 +107,7 @@ describe('Registry Secrets route tests', function() {
             await containerService.copyTo(docker_registry_secret_bad_file, docker_registry_file);
 
             const res = await getRegistrySecrets();
-            res.should.have.status(500);
+            res.status.should.equal(500, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
     });
@@ -145,7 +145,7 @@ describe('Registry Secrets route tests', function() {
             const encodedDockerCredentials = Buffer.from(credentials_string).toString('base64');
 
             const res = await setRegistrySecret(dockerAddress, encodedDockerCredentials);
-            res.should.have.status(201);
+            res.status.should.equal(201, res.text); // print res.text if assertion fails
             res.body.should.be.an('array').to.have.lengthOf(1);
             res.body[0].address.should.equal(fullyQualifiedDockerRegistryAddress);
             res.body[0].username.should.equal(dockerUsername);
@@ -162,7 +162,7 @@ describe('Registry Secrets route tests', function() {
             const encodedDockerCredentials = Buffer.from(credentials_string).toString('base64');
 
             const res = await setRegistrySecret(dockerAddress, encodedDockerCredentials);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
 
@@ -178,14 +178,14 @@ describe('Registry Secrets route tests', function() {
             let encodedDockerCredentials = Buffer.from(credentials_string).toString('base64');
 
             let res = await setRegistrySecret(dockerAddress, encodedDockerCredentials);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
 
             // invalid encoded credential object with bad JSON
             encodedDockerCredentials = 'garbage'.concat(encodedDockerCredentials);
 
             res = await setRegistrySecret(dockerAddress, encodedDockerCredentials);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
 
@@ -206,7 +206,7 @@ describe('Registry Secrets route tests', function() {
             const encodedDockerCredentials = Buffer.from(credentials_string).toString('base64');
 
             const res = await setRegistrySecret(dockerAddress, encodedDockerCredentials);
-            res.should.have.status(500);
+            res.status.should.equal(500, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
     });
@@ -238,7 +238,7 @@ describe('Registry Secrets route tests', function() {
             const dockerAddress = 'docker.io';
 
             const res = await removeRegistrySecret(dockerAddress);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
 
@@ -255,13 +255,13 @@ describe('Registry Secrets route tests', function() {
             const encodedDockerCredentials = Buffer.from(credentials_string).toString('base64');
 
             let res = await setRegistrySecret(dockerAddress, encodedDockerCredentials);
-            res.should.have.status(201);
+            res.status.should.equal(201, res.text); // print res.text if assertion fails
             res.body.should.be.an('array').to.have.lengthOf(1);
             res.body[0].address.should.equal(fullyQualifiedDockerRegistryAddress);
             res.body[0].username.should.equal(dockerUsername);
 
             res = await removeRegistrySecret(invalidDockerAddress);
-            res.should.have.status(400);
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
 
@@ -277,7 +277,7 @@ describe('Registry Secrets route tests', function() {
             const dockerAddress = 'docker.io';
 
             const res = await removeRegistrySecret(dockerAddress);
-            res.should.have.status(500);
+            res.status.should.equal(500, res.text); // print res.text if assertion fails
             res.text.should.be.not.empty;
         });
 
@@ -292,7 +292,7 @@ describe('Registry Secrets route tests', function() {
             const dockerAddress = 'docker.io';
 
             const res = await removeRegistrySecret(dockerAddress);
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
             res.body.should.be.an('array').to.have.lengthOf(1);
         });
     });

--- a/test/src/API/root.test.js
+++ b/test/src/API/root.test.js
@@ -18,6 +18,6 @@ describe('Root endpoint test', function() {
     it('should return status 200', async function() {
         const res = await reqService.chai
             .get('/');
-        res.should.have.status(200);
+        res.status.should.equal(200, res.text); // print res.text if assertion fails
     });
 });

--- a/test/src/API/security/sanitize.test.js
+++ b/test/src/API/security/sanitize.test.js
@@ -27,7 +27,7 @@ describe('XSS Attack Tests', function() {
         it('should succeed (with status 200) when sanitising input', async function() {
             this.timeout(testTimeout.short);
             const res = await makeExampleXSSAttack();
-            res.should.have.status(200);
+            res.status.should.equal(200, res.text); // print res.text if assertion fails
         });
     });        
 });

--- a/test/src/API/templates/enableRepo.test.js
+++ b/test/src/API/templates/enableRepo.test.js
@@ -51,7 +51,7 @@ describe.skip('Batch enabling repositories', function() {
                 const repoUrls = testRepos.map(repo => repo.url);
                 const res = await disableTemplateRepos(repoUrls);
 
-                res.should.have.status(207);
+                res.status.should.equal(207, res.text); // print res.text if assertion fails
                 res.body.forEach(subResponse =>
                     subResponse.status.should.equal(200)
                 );
@@ -66,20 +66,20 @@ describe.skip('Batch enabling repositories', function() {
 
                 const res = await getTemplateRepos();
 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.body.should.have.deep.members(disabledRepos);
             });
             it(`checks templates from the disabled repos do not appear in the list of enabled templates`, async function() {
                 this.timeout(30000);
                 const res = await getTemplates({ showEnabledOnly: true });
-                res.should.have.status(204);
+                res.status.should.equal(204, res.text); // print res.text if assertion fails
             });
 
             it(`returns 207 and sub-status 200 for each subrequest when batch enabling ${testRepos.length} repos`, async function() {
                 const repoUrls = testRepos.map(repo => repo.url);
                 const res = await enableTemplateRepos(repoUrls);
 
-                res.should.have.status(207);
+                res.status.should.equal(207, res.text); // print res.text if assertion fails
                 res.body.forEach(subResponse =>
                     subResponse.status.should.equal(200)
                 );
@@ -94,13 +94,13 @@ describe.skip('Batch enabling repositories', function() {
 
                 const res = await getTemplateRepos();
 
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.body.should.have.deep.members(enabledRepos);
             });
             it(`checks templates from the enabled repos do appear in the list of enabled templates`, async function() {
                 this.timeout(30000);
                 const res = await getTemplates({ showEnabledOnly: true });
-                res.should.have.status(200);
+                res.status.should.equal(200, res.text); // print res.text if assertion fails
                 res.body.should.have.deep.members(templatesFromTestRepos);
             });
         });

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -66,7 +66,7 @@ describe('Template API tests', function() {
             it('should return 204 as there exists no templates with the given projectStyle', async function() {
                 this.timeout(testTimeout.short);
                 const res = await getTemplates({ projectStyle: 'unknownStyle' });
-                res.should.have.status(204);
+                res.status.should.equal(204, res.text); // print res.text if assertion fails
                 res.body.should.be.empty;
             });
         });
@@ -115,7 +115,7 @@ describe('Template API tests', function() {
                         url: '/invalid/url',
                         description: 'Invalid url.',
                     });
-                    res.should.have.status(400);
+                    res.status.should.equal(400, res.text); // print res.text if assertion fails
                 });
             });
             describe('a duplicate url', function() {
@@ -131,7 +131,7 @@ describe('Template API tests', function() {
                         description: 'duplicate url',
                     });
                     // Assert
-                    res2.should.have.status(400);
+                    res2.status.should.equal(400, res2.text); // print res.text if assertion fails
                 });
             });
             describe('a valid url that does not point to an index.json', function() {
@@ -141,7 +141,7 @@ describe('Template API tests', function() {
                         url: validUrlNotPointingToIndexJson,
                         description: 'valid url that does not point to an index.json',
                     });
-                    res.should.have.status(400);
+                    res.status.should.equal(400, res.text); // print res.text if assertion fails
                 });
             });
             describe('a valid url', function() {
@@ -172,7 +172,7 @@ describe('Template API tests', function() {
         it('DELETE should try to remove a template repository that doesn\'t exist', async function() {
             this.timeout(testTimeout.short);
             const res = await deleteTemplateRepo('http://something.com/index.json');
-            res.should.have.status(404);
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
         });
     });
 


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
In our tests, print `res.text` when `res.status` fails tests. `res.text` will be the response body as a string. (`res.text` is better than `res.body` because if the response header is text then `res.body` will be null)

## Which issue(s) does this PR fix ?
This helps debug test failures, especially in Jenkins, e.g. https://github.com/eclipse/codewind/issues/2219

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
