### PR TITLE
remove duplicate updatestatus statement

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -476,7 +476,6 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
                         }
 
                         projectInfo.error = errorMsg;
-                        await projectStatusController.updateProjectStatus(STATE_TYPES.buildState, projectID, BuildState.failed, "buildscripts.buildFail");
                         io.emitOnListener(event, projectInfo);
                         logger.logProjectInfo("Emitted event: " + event + "\n" + JSON.stringify(projectInfo), projectID, projectName);
                         return;


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

## What type of PR is this ? 

- [x] Bug fix 


## What does this PR do ?
This PR removes the duplicate statement of `updateProjectStatus`. 
It only needs to update the status to be `buildfail` if the exitcode=1 (microprofile specific, since idc returns exitcode=1), other failures will be handled in the build script

## Which issue(s) does this PR fix ?
#2328 

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
