### PR TITLE
change appsody java projects to use codewind dashboard

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -162,17 +162,22 @@ module.exports = class Project {
       ? `/performance/charts?project=${this.projectID}`
       : null;
   }
-  
+
   getMetricsDashHost() {
     const isMetricsDashAvailable = this.injectMetrics || this.isOpenLiberty || this.metricsAvailable;
     if (!isMetricsDashAvailable) {
       return null;
     }
-    
-    const shouldShowMetricsDashHostedOnProject = !this.injectMetrics && this.metricsAvailable;
-    return shouldShowMetricsDashHostedOnProject
-      ? METRICS_DASH_HOST.project
-      : METRICS_DASH_HOST.performanceContainer;
+    let shouldShowMetricsDashHostedOnProject = false;
+    if (this.projectType === "appsodyExtension") {
+      if (!(this.language === "java")) {
+        shouldShowMetricsDashHostedOnProject = true;
+      }
+    } else {
+      shouldShowMetricsDashHostedOnProject = !this.injectMetrics && this.metricsAvailable;
+    }
+
+    return shouldShowMetricsDashHostedOnProject ? METRICS_DASH_HOST.project : METRICS_DASH_HOST.performanceContainer;
   }
   
   getMetricsDashPath() {


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

## What type of PR is this ? 

- [x ] Bug fix
- [ ] Enhancement

## What does this PR do ?
The appsody stacks for Java no longer require javametrics, as such we want to default them to using the dashboard that we create under the performance pod.   Checking of whether an appsody app has metrics is still very hit and miss so this change is following the assumption that all appsody java apps will use the performance dashboard - dash link

## Which issue(s) does this PR fix ?
#2317 

## Does this PR require a documentation change ?
None

## Any special notes for your reviewer ?
None