### PR TITLE
Templates API - 423 Locked

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1103,6 +1103,8 @@ paths:
                   $ref: '#/components/schemas/Template'
         204:
           description: No templates found
+        423:
+          description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
 
   /api/v1/templates/repositories:
     get:
@@ -1116,6 +1118,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TemplateRepo'
+        423:
+          description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
     post:
       summary: Make Codewind aware of a template repository
       requestBody:
@@ -1135,6 +1139,8 @@ paths:
                   $ref: '#/components/schemas/TemplateRepo'
         400:
           description: Bad request
+        423:
+          description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
     delete:
       summary: Remove a template repository from the list Codewind is aware of
       requestBody:
@@ -1165,6 +1171,8 @@ paths:
             text/html:
               schema:
                 type: string
+        423:
+          description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
   /api/v1/batch/templates/repositories:
     patch:
       summary: Batch change settings for a template repository of which Codewind is aware
@@ -1195,6 +1203,8 @@ paths:
                       $ref: '#/components/schemas/TemplateRepoSetting'
                     error:
                       type: string
+        423:
+          description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
   /api/v1/templates/styles:
     get:
       summary: List all project styles for which Codewind has templates
@@ -1223,6 +1233,8 @@ paths:
                   $ref: '#/components/schemas/ProjectTypeDescriptor'
         204:
           description: No templates found
+        423:
+          description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
 
   /api/v1/logging:
     put:

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -185,15 +185,14 @@ module.exports = class ExtensionList {
 async function addExtensionsToTemplates(extensions, templates) {
   // Use a for loop rather than .map and Promise.all as we need these to happen one after the other
   // so that there will not be a conflict with the Templates lock
+  /* eslint-disable no-await-in-loop */
   for (const extension of extensions) {
     try {
       if (extension.templates) {
         log.trace(`Adding Extension ${extension.name}'s repository into the templates`);
-        // eslint-disable-next-line no-await-in-loop
         await templates.addRepository(extension.templates, extension.description);
       } else if (extension.templatesProvider) {
         log.trace(`Adding Extension ${extension.name}'s provider into the templates`);
-        // eslint-disable-next-line no-await-in-loop
         await templates.addProvider(extension.name, extension.templatesProvider);
         delete extension.templatesProvider;
       }
@@ -201,4 +200,5 @@ async function addExtensionsToTemplates(extensions, templates) {
       log.warn(error);
     }
   }
+  /* eslint-enable no-await-in-loop */
 }

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -182,19 +182,23 @@ module.exports = class ExtensionList {
  * @param templates, reference to the templates registry
  * @return Promise
  */
-function addExtensionsToTemplates(extensions, templates) {
-  return Promise.all(extensions.map(async extension => {
+async function addExtensionsToTemplates(extensions, templates) {
+  // Use a for loop rather than .map and Promise.all as we need these to happen one after the other
+  // so that there will not be a conflict with the Templates lock
+  for (const extension of extensions) {
     try {
       if (extension.templates) {
         log.trace(`Adding Extension ${extension.name}'s repository into the templates`);
+        // eslint-disable-next-line no-await-in-loop
         await templates.addRepository(extension.templates, extension.description);
       } else if (extension.templatesProvider) {
         log.trace(`Adding Extension ${extension.name}'s provider into the templates`);
-        templates.addProvider(extension.name, extension.templatesProvider);
+        // eslint-disable-next-line no-await-in-loop
+        await templates.addProvider(extension.name, extension.templatesProvider);
         delete extension.templatesProvider;
       }
     } catch (error) {
       log.warn(error);
     }
-  }));
+  }
 }

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -53,7 +53,7 @@ module.exports = class Templates {
     this.repositoryFile = path.join(workspace, '.config/repository_list.json');
     this.repositoryList = DEFAULT_REPOSITORY_LIST;
     this.providers = {};
-    this.unlock();
+    this._lock = false;
   }
 
   async initializeRepositoryList() {
@@ -86,6 +86,7 @@ module.exports = class Templates {
   }
 
   unlock() {
+    if (this._lock === false) throw new TemplateError('NOT_LOCKED');
     this._lock = false;
   }
 

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -86,7 +86,7 @@ module.exports = class Templates {
   }
 
   unlock() {
-    if (this._lock === false) throw new TemplateError('NOT_LOCKED');
+    if (this._lock !== true) throw new TemplateError('NOT_LOCKED');
     this._lock = false;
   }
 

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -391,9 +391,9 @@ async function getNameAndDescriptionFromRepoTemplatesJSON(url) {
  */
 function getRepositoryFromTemplate(repositoryList, template) {
   const repo = repositoryList.find(repoToFind => (
-    template.sourceId === repoToFind.id ||
-    template.sourceURL === repoToFind.url ||
-    template.source === repoToFind.name)
+    (template.sourceId && template.sourceId === repoToFind.id) ||
+    (template.sourceURL && template.sourceURL === repoToFind.url) ||
+    (template.source && template.source === repoToFind.name))
   );
   return repo || null;
 }

--- a/src/pfe/portal/modules/utils/errors/TemplateError.js
+++ b/src/pfe/portal/modules/utils/errors/TemplateError.js
@@ -21,6 +21,9 @@ module.exports = class TemplateError extends BaseError {
 // Error codes
 module.exports.DUPLICATE_URL = 'DUPLICATE_URL';
 
+// HTTP codes
+module.exports.HTTP_LOCKED = 423;
+
 /**
  * Function to construct an error message based on the given error code
  * @param code, the error code to create the message from

--- a/src/pfe/portal/modules/utils/errors/TemplateError.js
+++ b/src/pfe/portal/modules/utils/errors/TemplateError.js
@@ -51,6 +51,10 @@ function constructMessage(code, identifier, message) {
   case 'LOCKED':
     output = `_lock is already set to true`;
     break;
+  case 'NOT_LOCKED':
+    // Shouldn't happen but this prevents against implementation errors
+    output = `_lock is already set to false`;
+    break;
   default:
     output = 'Unknown template error';
   }

--- a/src/pfe/portal/modules/utils/errors/TemplateError.js
+++ b/src/pfe/portal/modules/utils/errors/TemplateError.js
@@ -45,6 +45,9 @@ function constructMessage(code, identifier, message) {
   case 'REPOSITORY_DOES_NOT_EXIST':
     output = `${identifier} does not exist`;
     break;
+  case 'LOCKED':
+    output = `_lock is already set to true`;
+    break;
   default:
     output = 'Unknown template error';
   }

--- a/src/pfe/portal/routes/projectTypes.route.js
+++ b/src/pfe/portal/routes/projectTypes.route.js
@@ -16,8 +16,6 @@ const TemplateError = require('../modules/utils/errors/TemplateError');
 const router = express.Router();
 const log = new Logger(__filename);
 
-const TEMPLATES_LOCKED_STATUS_CODE = 423;
-
 function sanitizeProjectType(array, type) {
 
   // doesn't even have the expected fields, no-op return
@@ -123,7 +121,7 @@ router.get('/api/v1/project-types', async (req, res) => {
   } catch (err) {
     log.error(err);
     if (err instanceof TemplateError && err.code === 'LOCKED') {
-      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      res.sendStatus(TemplateError.HTTP_LOCKED);
       return;
     }
     res.status(500).send(err);

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -17,6 +17,8 @@ const TemplateError = require('../modules/utils/errors/TemplateError');
 const router = express.Router();
 const log = new Logger(__filename);
 
+const TEMPLATES_LOCKED_STATUS_CODE = 423;
+
 /**
  * API Function to return a list of available templates
  * @return the set of language extensions as a JSON array of strings
@@ -26,7 +28,7 @@ router.get('/api/v1/templates', validateReq, async (req, res, _next) => {
   const projectStyle = req.query['projectStyle'];
   const showEnabledOnly = req.query['showEnabledOnly'] === 'true';
   try {
-    const templates = (projectStyle) 
+    const templates = (projectStyle)
       ? await templateController.getTemplatesByStyle(projectStyle, showEnabledOnly)
       : await templateController.getTemplates(showEnabledOnly);
     if (templates.length == 0) {
@@ -37,6 +39,11 @@ router.get('/api/v1/templates', validateReq, async (req, res, _next) => {
     }
   } catch (error) {
     log.error(error);
+    if (error instanceof TemplateError && error.code === 'LOCKED') {
+      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      return;
+    }
+    log.error(error);
     res.status(500).json(error);
   }
 });
@@ -46,7 +53,16 @@ router.get('/api/v1/templates', validateReq, async (req, res, _next) => {
  * @return the set of language extensions as a JSON array of strings
  */
 router.get('/api/v1/templates/repositories', async (req, res, _next) => {
-  await sendRepositories(req, res, _next);
+  try {
+    await sendRepositories(req, res, _next);
+  } catch (error) {
+    log.error(error);
+    if (error instanceof TemplateError && error.code === 'LOCKED') {
+      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      return;
+    }
+    res.status(500).send(error.message);
+  }
 });
 
 router.post('/api/v1/templates/repositories', validateReq, async (req, res, _next) => {
@@ -70,6 +86,9 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
     if (error instanceof TemplateError && knownErrorCodes.includes(error.code)) {
       res.status(400).send(error.message);
       return;
+    } else if (error instanceof TemplateError && error.code === 'LOCKED') {
+      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      return;
     }
     res.status(500).send(error.message);
   }
@@ -86,22 +105,34 @@ router.delete('/api/v1/templates/repositories', validateReq, async (req, res, _n
     if (error instanceof TemplateError && error.code === 'REPOSITORY_DOES_NOT_EXIST') {
       res.status(404).send(error.message);
       return;
+    } else if (error instanceof TemplateError && error.code === 'LOCKED') {
+      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      return;
     }
     res.status(500).send(error.message);
   }
 });
 
-async function sendRepositories(req, res, _next) {
+function sendRepositories(req, res, _next) {
   const { templates: templatesController } = req.cw_user;
-  const repositoryList = await templatesController.getRepositories();
+  const repositoryList = templatesController.getRepositories();
   res.status(200).json(repositoryList);
 }
 
 router.patch('/api/v1/batch/templates/repositories', validateReq, async (req, res) => {
   const { templates: templatesController } = req.cw_user;
   const requestedOperations = req.body;
-  const operationResults = await templatesController.batchUpdate(requestedOperations);
-  res.status(207).json(operationResults);
+  try {
+    const operationResults = await templatesController.batchUpdate(requestedOperations);
+    res.status(207).json(operationResults);
+  } catch(error) {
+    log.error(error);
+    if (error instanceof TemplateError && error.code === 'LOCKED') {
+      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      return;
+    }
+    res.status(500).send(error.message);
+  }
 });
 
 /**
@@ -109,8 +140,16 @@ router.patch('/api/v1/batch/templates/repositories', validateReq, async (req, re
  */
 router.get('/api/v1/templates/styles', validateReq, async (req, res, _next) => {
   const { templates: templatesController } = req.cw_user;
-  const styles = await templatesController.getAllTemplateStyles();
-  res.status(200).json(styles);
+  try {
+    const styles = await templatesController.getAllTemplateStyles();
+    res.status(200).json(styles);
+  } catch(error) {
+    if (error instanceof TemplateError && error.code === 'LOCKED') {
+      res.sendStatus(TEMPLATES_LOCKED_STATUS_CODE);
+      return;
+    }
+    res.status(500).send(error.message);
+  }
 });
 
 module.exports = router;

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -246,7 +246,6 @@ function setupReposAndTemplatesForTesting() {
     });
     after(async function() {
         this.timeout(testTimeout.med);
-
         // Restore orignal list
         await setTemplateReposTo(originalTemplateRepos);
     });

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -184,6 +184,18 @@ async function getTemplates(queryParams) {
     return res;
 }
 
+async function getNumberOfTemplates(queryParams) {
+    const { statusCode, body: templates } = await getTemplates(queryParams);
+    // If we get a 204 HTTP Code the templates list is empty
+    if (statusCode === 204) {
+        return 0;
+    } else if (statusCode === 200) {
+        return templates.length;
+    }
+    // If we haven't got a 204 or 200 we cannot report the number of templates
+    throw new Error(`getNumberOfTemplates - Unknown status code received: ${statusCode}`);
+}
+
 /**
  * Removes all templates repos known to PFE, and adds the supplied repos
  * @param {[JSON]} repoList
@@ -266,6 +278,7 @@ module.exports = {
     enableTemplateRepos,
     disableTemplateRepos,
     getTemplates,
+    getNumberOfTemplates,
     setTemplateReposTo,
     getTemplateStyles,
     saveReposBeforeTestAndRestoreAfter,

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -192,13 +192,15 @@ async function setTemplateReposTo(repoList) {
     const ignoreDefaultAppsodyRepo = repo => (!('id' in repo) || repo.id !== 'incubator');
     const reposToDelete = (await getTemplateRepos()).body;
     if (reposToDelete.length > 0) {
-        await Promise.all(reposToDelete.filter(ignoreDefaultAppsodyRepo).map(repo =>
-            deleteTemplateRepo(repo.url)
-        ));
+        const filteredReposToDelete = reposToDelete.filter(ignoreDefaultAppsodyRepo);
+        for (const repo of filteredReposToDelete) {
+            await deleteTemplateRepo(repo.url);
+        }
     }
-    await Promise.all(repoList.filter(ignoreDefaultAppsodyRepo).map(repo =>
-        addTemplateRepo(repo)
-    ));
+    const filteredReposToAdd = repoList.filter(ignoreDefaultAppsodyRepo);
+    for (const repo of filteredReposToAdd) {
+        await addTemplateRepo(repo);
+    }
 }
 
 async function getTemplateStyles() {

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -201,16 +201,13 @@ async function getNumberOfTemplates(queryParams) {
  * @param {[JSON]} repoList
  */
 async function setTemplateReposTo(repoList) {
-    const ignoreDefaultAppsodyRepo = repo => (!('id' in repo) || repo.id !== 'incubator');
     const reposToDelete = (await getTemplateRepos()).body;
     if (reposToDelete.length > 0) {
-        const filteredReposToDelete = reposToDelete.filter(ignoreDefaultAppsodyRepo);
-        for (const repo of filteredReposToDelete) {
+        for (const repo of reposToDelete) {
             await deleteTemplateRepo(repo.url);
         }
     }
-    const filteredReposToAdd = repoList.filter(ignoreDefaultAppsodyRepo);
-    for (const repo of filteredReposToAdd) {
+    for (const repo of repoList) {
         await addTemplateRepo(repo);
     }
 }

--- a/test/src/API/extensions.test.js
+++ b/test/src/API/extensions.test.js
@@ -9,18 +9,25 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 const chai = require('chai');
+const chaiSubset = require('chai-subset');
 
 const reqService = require('../../modules/request.service');
 const { ADMIN_COOKIE } = require('../../config');
 
 chai.should();
+chai.use(chaiSubset);
 
 describe('Extensions API test', function() {
-
     it('should return status 200', async function() {
+        // For each extension to check for add an object with a name property (or additional properties to check for)
+        const wantedExtensions = [
+            { name: 'appsodyExtension' },
+        ];
         const res = await reqService.chai
             .get('/api/v1/extensions')
             .set('Cookie', ADMIN_COOKIE);
         res.status.should.equal(200, res.text); // print res.text if assertion fails
+        const { body: extensions } = res;
+        extensions.should.deep.containSubset(wantedExtensions);
     });
 });

--- a/test/src/API/projectTypes.test.js
+++ b/test/src/API/projectTypes.test.js
@@ -35,7 +35,6 @@ describe('Project Types API tests', function() {
             'spring',
             'swift',
             'docker',
-            'appsodyExtension',
         ]);
     });
 });

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -20,6 +20,7 @@ const {
     sampleRepos,
     batchPatchTemplateRepos,
     getTemplateRepos,
+    getNumberOfTemplates,
     getTemplates,
     addTemplateRepo,
     deleteTemplateRepo,
@@ -36,7 +37,7 @@ chai.use(deepEqualInAnyOrder);
 
 chai.use(chaiResValidator(pathToApiSpec));
 
-describe('Template API tests', function() {
+describe.only('Template API tests', function() {
     // Set the default timeout for all tests
     this.timeout(testTimeout.short);
     // Save the state of the repos before any test and restore the exact state after
@@ -135,9 +136,7 @@ describe('Template API tests', function() {
                     await deleteTemplateRepo(sampleRepos.codewind.url);
                     const { body: repos } = await getTemplateRepos();
                     originalTemplateReposLength = repos.length;
-
-                    const { body: templates } = await getTemplates();
-                    originalTemplatesLength = templates.length;
+                    originalTemplatesLength = await getNumberOfTemplates();
                 });
                 it('should add a template repository and update the templates', async function() {
                     const addTemplateRepoRes = await addTemplateRepo(sampleRepos.codewind);
@@ -187,10 +186,8 @@ describe('Template API tests', function() {
             res.body.length.should.equal(originalTemplateRepos.length - 1);
         });
         it('GET /api/v1/templates should return fewer templates', async function() {
-            const res = await getTemplates();
-            res.should.have.status(200).and.satisfyApiSpec;
-            res.body.should.not.deep.include(originalTemplates);
-            res.body.length.should.be.below(originalNumTemplates);
+            const numberOfTemplates = await getNumberOfTemplates();
+            numberOfTemplates.should.be.below(originalNumTemplates);
         });
         it('POST /api/v1/templates should re-add the deleted template repository', async function() {
             const res = await addTemplateRepo(repo);

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -23,10 +23,10 @@ const {
     getTemplates,
     addTemplateRepo,
     deleteTemplateRepo,
-    setTemplateReposTo,
     getTemplateStyles,
     saveReposBeforeTestAndRestoreAfter,
     saveReposBeforeEachTestAndRestoreAfterEach,
+    setupReposAndTemplatesForTesting,
 } = require('../../../modules/template.service');
 const { pathToApiSpec, testTimeout } = require('../../../config');
 
@@ -37,24 +37,19 @@ chai.use(deepEqualInAnyOrder);
 chai.use(chaiResValidator(pathToApiSpec));
 
 describe('Template API tests', function() {
+    // Set the default timeout for all tests
+    this.timeout(testTimeout.short);
     // Save the state of the repos before any test and restore the exact state after
     saveReposBeforeTestAndRestoreAfter();
     describe('GET /api/v1/templates', function() {
-        before(async function() {
-            this.timeout(testTimeout.short);
-            await setTemplateReposTo([
-                { ...sampleRepos.codewind },
-            ]);
-        });
+        setupReposAndTemplatesForTesting();
         describe('?projectStyle=', function() {
             it('should return at least the default Codewind templates as no projectStyle is given', async function() {
-                this.timeout(testTimeout.short);
                 const res = await getTemplates();
                 res.should.have.status(200).and.satisfyApiSpec;
                 res.body.length.should.be.at.least(defaultCodewindTemplates.length);
             });
             it('should return only Codewind templates as projectStyle is Codewind', async function() {
-                this.timeout(testTimeout.short);
                 const res = await getTemplates({ projectStyle: 'Codewind' });
                 res.should.have.status(200).and.satisfyApiSpec;
                 res.body.forEach(template => {
@@ -64,7 +59,6 @@ describe('Template API tests', function() {
                 });
             });
             it('should return 204 as there exists no templates with the given projectStyle', async function() {
-                this.timeout(testTimeout.short);
                 const res = await getTemplates({ projectStyle: 'unknownStyle' });
                 res.status.should.equal(204, res.text); // print res.text if assertion fails
                 res.body.should.be.empty;
@@ -72,13 +66,11 @@ describe('Template API tests', function() {
         });
         describe('?showEnabledOnly=', function() {
             it('should return all templates (from enabled and disabled repos)', async function() {
-                this.timeout(testTimeout.short);
                 const res = await getTemplates({ showEnabledOnly: false });
                 res.should.have.status(200).and.satisfyApiSpec;
                 res.body.length.should.be.at.least(defaultCodewindTemplates.length);
             });
             it('should return only templates from enabled repos', async function() {
-                this.timeout(testTimeout.short);
                 const res = await getTemplates({ showEnabledOnly: true });
                 res.should.have.status(200).and.satisfyApiSpec;
                 res.body.length.should.be.at.least(defaultCodewindTemplates.length);
@@ -87,14 +79,8 @@ describe('Template API tests', function() {
     });
 
     describe('GET /api/v1/templates/repositories', function() {
-        before(async function() {
-            this.timeout(testTimeout.short);
-            await setTemplateReposTo([
-                { ...sampleRepos.codewind },
-            ]);
-        });
+        setupReposAndTemplatesForTesting();
         it('should return 200 and a list of available template repositories', async function() {
-            this.timeout(testTimeout.short);
             const res = await getTemplateRepos();
             for (let i = 0; i < res.body.length; i++) {
                 const element = res.body[i];
@@ -107,10 +93,10 @@ describe('Template API tests', function() {
     });
 
     describe('POST /api/v1/templates/repositories', function() {
+        setupReposAndTemplatesForTesting();
         describe('when trying to add a repository with', function() {
             describe('an invalid url', function() {
                 it('should return 400', async function() {
-                    this.timeout(testTimeout.short);
                     const res = await addTemplateRepo({
                         url: '/invalid/url',
                         description: 'Invalid url.',
@@ -120,23 +106,21 @@ describe('Template API tests', function() {
             });
             describe('a duplicate url', function() {
                 it('should return 400', async function() {
-                    this.timeout(testTimeout.short);
                     // Arrange
                     const res = await getTemplateRepos();
                     const originalTemplateRepos = res.body;
                     const duplicateRepoUrl = originalTemplateRepos[0].url;
                     // Act
-                    const res2 = await addTemplateRepo({
+                    const duplicateUrlRes = await addTemplateRepo({
                         url: duplicateRepoUrl,
                         description: 'duplicate url',
                     });
                     // Assert
-                    res2.status.should.equal(400, res2.text); // print res.text if assertion fails
+                    duplicateUrlRes.should.have.status(400, duplicateUrlRes.text);
                 });
             });
             describe('a valid url that does not point to an index.json', function() {
                 it('should return 400', async function() {
-                    this.timeout(testTimeout.short);
                     const res = await addTemplateRepo({
                         url: validUrlNotPointingToIndexJson,
                         description: 'valid url that does not point to an index.json',
@@ -146,45 +130,49 @@ describe('Template API tests', function() {
             });
             describe('a valid url', function() {
                 let originalTemplateReposLength;
+                let originalTemplatesLength;
                 before(async function() {
-                    this.timeout(testTimeout.short);
+                    await deleteTemplateRepo(sampleRepos.codewind.url);
                     const { body: repos } = await getTemplateRepos();
                     originalTemplateReposLength = repos.length;
+
+                    const { body: templates } = await getTemplates();
+                    originalTemplatesLength = templates.length;
                 });
-                it('should add a template repository', async function() {
-                    this.timeout(testTimeout.short);
-                    const repoToAdd = {
-                        // Use an early version of kabanero-io collections to avoid clashes inside the Appsody CLI
-                        url: 'https://github.com/kabanero-io/collections/releases/download/v0.0.6/kabanero-index.json',
-                        description: 'Additional Codewind templates',
-                        protected: false,
-                    };
-                    const res = await addTemplateRepo(repoToAdd);
-                    res.should.have.status(200).and.satisfyApiSpec;
-                    res.body.should.deep.containSubset([repoToAdd]);
-                    res.body.length.should.equal(originalTemplateReposLength + 1);
+                it('should add a template repository and update the templates', async function() {
+                    const addTemplateRepoRes = await addTemplateRepo(sampleRepos.codewind);
+                    addTemplateRepoRes.should.have.status(200).and.satisfyApiSpec;
+                    addTemplateRepoRes.body.should.deep.containSubset([sampleRepos.codewind]);
+                    addTemplateRepoRes.body.length.should.equal(originalTemplateReposLength + 1);
+
+                    const getTemplatesRes = await getTemplates();
+                    getTemplatesRes.should.have.status(200).and.satisfyApiSpec;
+                    getTemplatesRes.body.length.should.be.above(originalTemplatesLength);
                 });
             });
         });
     });
 
     describe('DELETE /api/v1/templates/repositories', function() {
+        setupReposAndTemplatesForTesting();
         it('DELETE should try to remove a template repository that doesn\'t exist', async function() {
-            this.timeout(testTimeout.short);
             const res = await deleteTemplateRepo('http://something.com/index.json');
             res.status.should.equal(404, res.text); // print res.text if assertion fails
+        });
+        it('DELETE removes a template repository', async function() {
+            const res = await deleteTemplateRepo(sampleRepos.codewind.url);
+            res.should.have.status(200);
         });
     });
 
     describe('DELETE | GET | POST /api/v1/templates/repositories', function() {
         // Save state for this test
-        saveReposBeforeTestAndRestoreAfter();
+        setupReposAndTemplatesForTesting();
         const repo = sampleRepos.codewind;
         let originalTemplateRepos;
         let originalTemplates;
         let originalNumTemplates;
         before(async function() {
-            this.timeout(testTimeout.short);
             const { body: repos } = await getTemplateRepos();
             originalTemplateRepos = repos;
             const { body: templates } = await getTemplates();
@@ -193,28 +181,24 @@ describe('Template API tests', function() {
 
         });
         it('DELETE /api/v1/templates should remove a template repository', async function() {
-            this.timeout(testTimeout.short);
             const res = await deleteTemplateRepo(repo.url);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(repo);
             res.body.length.should.equal(originalTemplateRepos.length - 1);
         });
         it('GET /api/v1/templates should return fewer templates', async function() {
-            this.timeout(testTimeout.short);
             const res = await getTemplates();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.not.deep.include(originalTemplates);
             res.body.length.should.be.below(originalNumTemplates);
         });
         it('POST /api/v1/templates should re-add the deleted template repository', async function() {
-            this.timeout(testTimeout.short);
             const res = await addTemplateRepo(repo);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.containSubset([repo]);
             res.body.length.should.equal(originalTemplateRepos.length);
         });
         it('GET /api/v1/templates should return the original templates', async function() {
-            this.timeout(testTimeout.short);
             const res = await getTemplates();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.deep.equalInAnyOrder(originalTemplates);
@@ -222,6 +206,7 @@ describe('Template API tests', function() {
         });
     });
     describe('PATCH /api/v1/batch/templates/repositories', function() {
+        setupReposAndTemplatesForTesting();
         const { url: existingRepoUrl } = sampleRepos.codewind;
         const tests = {
             'enable an existing repo': {
@@ -290,7 +275,6 @@ describe('Template API tests', function() {
         saveReposBeforeEachTestAndRestoreAfterEach();
         for (const [testName, test] of Object.entries(tests)) {
             it(`should ${testName} and return 207 and the expected operations info`, async function() {
-                this.timeout(testTimeout.short);
                 const res = await batchPatchTemplateRepos(test.input);
                 res.should.have.status(207).and.satisfyApiSpec;
                 res.body.should.deep.equal(test.output);
@@ -298,8 +282,8 @@ describe('Template API tests', function() {
         }
     });
     describe('GET /api/v1/templates/styles', function() {
+        setupReposAndTemplatesForTesting();
         it('should return a list of available template styles', async function() {
-            this.timeout(testTimeout.short);
             const res = await getTemplateStyles();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.have.members(['Codewind', 'Appsody']);

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -37,7 +37,7 @@ chai.use(deepEqualInAnyOrder);
 
 chai.use(chaiResValidator(pathToApiSpec));
 
-describe.only('Template API tests', function() {
+describe('Template API tests', function() {
     // Set the default timeout for all tests
     this.timeout(testTimeout.short);
     // Save the state of the repos before any test and restore the exact state after
@@ -283,7 +283,7 @@ describe.only('Template API tests', function() {
         it('should return a list of available template styles', async function() {
             const res = await getTemplateStyles();
             res.should.have.status(200).and.satisfyApiSpec;
-            res.body.should.have.members(['Codewind', 'Appsody']);
+            res.body.should.include.members(['Codewind']);
         });
     });
 });

--- a/test/src/unit/modules/ExtensionList.test.js
+++ b/test/src/unit/modules/ExtensionList.test.js
@@ -25,7 +25,7 @@ const Templates = rewire('../../../../src/pfe/portal/modules/Templates');
 const { templateRepositoryURL } = require('./../../../modules/template.service');
 const { suppressLogOutput } = require('../../../modules/log.service');
 const { testTimeout } = require('../../../config');
-const { 
+const {
     createCodewindYamlFile,
     createTemplatesProviderFile,
 } = require('../../../modules/extension.service');
@@ -36,7 +36,9 @@ const should = chai.should();
 
 const EXTENSION_DIR =  `${__dirname}/extensionlist_temp`;
 
-describe('ExtensionList.js', () => {
+describe('ExtensionList.js', function() {
+    // Set the default timeout for all tests
+    this.timeout(testTimeout.short);
     suppressLogOutput(Extension);
     suppressLogOutput(ExtensionList);
     suppressLogOutput(Templates);
@@ -44,7 +46,6 @@ describe('ExtensionList.js', () => {
         fs.ensureDirSync(EXTENSION_DIR);
     });
     after(function() {
-        this.timeout(5000);
         execSync(`rm -rf ${EXTENSION_DIR}`);
     });
     describe('Class functions', () => {
@@ -88,7 +89,6 @@ describe('ExtensionList.js', () => {
                 list.should.have.property('extension');
             });
             it('Loads an extension which contains a template repository URL', async function() {
-                this.timeout(testTimeout.short);
                 createCodewindYamlFile(path.join(EXTENSION_DIR, 'extensionWithURL'), { name: 'extensionWithURL', templates: templateRepositoryURL });
                 const extensionList = new ExtensionList();
                 await extensionList.initialise(EXTENSION_DIR, templateController);
@@ -96,17 +96,16 @@ describe('ExtensionList.js', () => {
                 list.should.have.property('extensionWithURL');
                 const { extensionWithURL } = list;
                 extensionWithURL.should.have.property('templates');
-    
+
                 // Ensure template repository has been added
-                await templateController.getRepository(extensionWithURL.templates).should.be.fulfilled;
+                templateController.getRepository(extensionWithURL.templates).should.not.equal(null);
             });
             it('Loads an extension which contains a templateProvider.js file and no template repository URL', async function() {
-                this.timeout(testTimeout.short);
                 const extensionName = 'extensionWithTemplateProvider';
                 createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName });
                 createTemplatesProviderFile(path.join(EXTENSION_DIR, extensionName));
                 const extensionList = new ExtensionList();
-    
+
                 await extensionList.initialise(EXTENSION_DIR, templateController);
                 const { _list: list } = extensionList;
                 list.should.have.property(extensionName);
@@ -117,7 +116,6 @@ describe('ExtensionList.js', () => {
                 templateController.providers.should.have.property(extensionName);
             });
             it('Loads an extension which contains both a template repository URL and a templateProvider.js file (ignores the templateProvider.js file)', async function() {
-                this.timeout(testTimeout.short);
                 const extensionName = 'extensionWithBoth';
                 createCodewindYamlFile(path.join(EXTENSION_DIR, extensionName), { name: extensionName, templates: templateRepositoryURL });
                 createTemplatesProviderFile(path.join(EXTENSION_DIR, extensionName));
@@ -129,7 +127,7 @@ describe('ExtensionList.js', () => {
                 const { extensionWithBoth } = list;
                 
                 // Ensure template repository has been added
-                await templateController.getRepository(extensionWithBoth.templates).should.be.fulfilled;
+                templateController.getRepository(extensionWithBoth.templates).should.not.equal(null);
     
                 // Ensure provider has not been added
                 templateController.providers.should.not.have.property(extensionName);
@@ -418,7 +416,8 @@ describe('ExtensionList.js', () => {
                 extension.templates = 'invalidURL';
                 const templateController = new Templates(EXTENSION_DIR);
                 await addExtensionsToTemplates([extension], templateController);
-                await templateController.getRepository(extension.templates).should.be.rejected;
+                const repo = templateController.getRepository(extension.templates);
+                should.equal(repo, null);
             });
             it('Successfully adds the extension templates field as a repository when it exists', async() => {
                 const extension = new Extension({ name: 'extension' });
@@ -428,7 +427,7 @@ describe('ExtensionList.js', () => {
                 await addExtensionsToTemplates([extension], templateController);
 
                 // Ensure template repository has been added
-                await templateController.getRepository(extension.templates).should.be.fulfilled;
+                templateController.getRepository(extension.templates).should.not.equal(null);
             });
             it('Successfully adds the extension templateProvider as a provider', async() => {
                 const extension = new Extension({ name: 'extension' });

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -153,6 +153,12 @@ describe('Templates.js', function() {
                 const error = new TemplateError('NOT_LOCKED');
                 assert.throws(() => templateController.unlock(), error);
             });
+            it('should throw an error if the value of _lock is something other than true', () => {
+                const templateController = new Templates(workspace);
+                templateController._lock = 'notvalid';
+                const error = new TemplateError('NOT_LOCKED');
+                assert.throws(() => templateController.unlock(), error);
+            });
         });
         describe('getTemplates(showEnabledOnly)', function() {
             const workspace = getWorkspaceAndDeleteAfterEach(this.title);

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -147,6 +147,12 @@ describe('Templates.js', function() {
                 templateController.unlock();
                 templateController._lock.should.be.false;
             });
+            it('should throw an error if the value of _lock is already false', () => {
+                const templateController = new Templates(workspace);
+                templateController._lock = false;
+                const error = new TemplateError('NOT_LOCKED');
+                assert.throws(() => templateController.unlock(), error);
+            });
         });
         describe('getTemplates(showEnabledOnly)', function() {
             const workspace = getWorkspaceAndDeleteAfterEach(this.title);

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -164,8 +164,8 @@ describe('Templates.js', function() {
                     repository.enabled.should.be.false;
                 }
                 await templateController.initializeRepositoryList();
-                const enabledTmplateList = await templateController.getTemplates(true);
-                enabledTmplateList.length.should.equal(0);
+                const enabledTemplateList = await templateController.getTemplates(true);
+                enabledTemplateList.length.should.equal(0);
                 const templateList = await templateController.getTemplates(false);
                 templateList.length.should.be.at.least(defaultCodewindTemplates.length);
             });
@@ -788,7 +788,7 @@ describe('Templates.js', function() {
                 const repository = await constructRepositoryObject(url, description, name, protected);
                 repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'protected', 'projectStyles');
             });
-            it('returns a repository object only a url is given - gets the name, description from the url and does not have a protected field', async() => {
+            it('returns a repository object when only a url is given - gets the name, description from the url and does not have a protected field', async() => {
                 const { url } = sampleRepos.codewind;
                 const repository = await constructRepositoryObject(url);
                 repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'projectStyles');

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -1659,5 +1659,27 @@ describe('Templates.js', function() {
                 });
             }
         });
+        describe('updateRepositoryList(currentRepositoryList, updatedRepositories)', function() {
+            const updateRepositoryList = Templates.__get__('updateRepositoryList');
+            it('returns an updated repositoryList in which the given updatedRepository is enabled', () => {
+                const repositoryList = [...mockRepoList];
+                const updatedRepo = {
+                    ...mockRepos.disabled,
+                    enabled: true,
+                };
+                const updatedList = updateRepositoryList(repositoryList, [updatedRepo]);
+                updatedList.should.include(updatedRepo);
+            });
+            it('returns the original repositoryList as the updated repository is not in the orignal list', () => {
+                const repositoryList = [...mockRepoList];
+                const updatedRepo = {
+                    url: 'na',
+                    enabled: true,
+                };
+                const updatedList = updateRepositoryList(repositoryList, [updatedRepo]);
+                updatedList.should.not.include(updatedRepo);
+                updatedList.should.deep.equal(repositoryList);
+            });
+        });
     });
 });

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -14,10 +14,12 @@ const chaiSubset = require('chai-subset');
 const fs = require('fs-extra');
 const path = require('path');
 const rewire = require('rewire');
+const assert = require('assert');
 
 global.codewind = { RUNNING_IN_K8S: false };
 
 const Templates = rewire('../../../src/pfe/portal/modules/Templates');
+const TemplateError = require('../../../src/pfe/portal/modules/utils/errors/TemplateError');
 const {
     styledTemplates,
     defaultCodewindTemplates,
@@ -31,8 +33,9 @@ const { testTimeout } = require('../../config');
 chai.use(chaiAsPromised);
 chai.use(chaiSubset);
 chai.should();
+const should = chai.should();
 
-const testWorkspaceDir = './src/unit/temp/';
+const testWorkspaceDir = path.join(__dirname, '/templateTestTemp/');
 const testWorkspaceConfigDir = path.join(testWorkspaceDir, '.config/');
 const testRepositoryFile = path.join(testWorkspaceConfigDir, 'repository_list.json');
 
@@ -55,13 +58,29 @@ const mockRepos = {
         description: '3',
     },
 };
+
+const checkTemplateError = (err, expectedCode) => {
+    const { name, code } = err;
+    name.should.equal('TemplateError');
+    code.should.equal(expectedCode);
+};
+
+function getWorkspaceAndDeleteAfterEach(testFolderName) {
+    const workspace = path.join(testWorkspaceDir, testFolderName);
+    afterEach(() => {
+        fs.removeSync(workspace);
+    });
+    return workspace;
+};
+
 const mockRepoList = Object.values(mockRepos);
 describe('Templates.js', function() {
+    // Set the default timeout for all tests
+    this.timeout(testTimeout.short);
     suppressLogOutput(Templates);
     describe('Class functions', function() {
         describe('initializeRepositoryList()', function() {
-            this.timeout(testTimeout.short);
-            const workspace = path.join(__dirname, 'initializeRepositoryList');
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
             const customRepoFile = path.join(workspace, 'custom_repo_file.json');
             beforeEach(() => {
                 fs.ensureDirSync(workspace);
@@ -73,59 +92,86 @@ describe('Templates.js', function() {
             });
             it('initializes a Templates Class and creates a repository file', async function() {
                 const templateController = new Templates(workspace);
-                fs.pathExistsSync(templateController.repositoryFile).should.be.false;
+                const existsPre = await fs.pathExists(templateController.repositoryFile);
+                existsPre.should.be.false;
 
                 await templateController.initializeRepositoryList();
 
                 templateController.repositoryList.length.should.equal(2);
-                fs.pathExistsSync(templateController.repositoryFile).should.be.true;
+                const existsPost = await fs.pathExists(templateController.repositoryFile);
+                existsPost.should.be.true;
             });
             it('reads an existing repository list file', async function() {
                 const templateController = new Templates(workspace);
-                templateController.projectTemplatesNeedsRefresh = false;
                 templateController.repositoryFile = customRepoFile;
 
                 await templateController.initializeRepositoryList();
-                const { repositoryFile, repositoryList, projectTemplatesNeedsRefresh } = templateController;
-                fs.readJsonSync(repositoryFile).should.deep.equal([sampleRepos.codewind]);
+
+                const { repositoryFile, repositoryList } = templateController;
+                const contents = await fs.readJson(repositoryFile);
+                contents.should.deep.equal([sampleRepos.codewind]);
                 repositoryList.should.deep.equal([sampleRepos.codewind]);
-                projectTemplatesNeedsRefresh.should.be.true;
+            });
+        });
+        describe('lock()', function() {
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
+            it('should update the value of _lock to be true', () => {
+                const templateController = new Templates(workspace);
+                templateController._lock = false;
+                templateController.lock();
+                templateController._lock.should.be.true;
+            });
+            it('should throw an error if the value of _lock is already true', () => {
+                const templateController = new Templates(workspace);
+                templateController._lock = true;
+                const error = new TemplateError('LOCKED');
+                assert.throws(() => templateController.lock(), error);
+            });
+        });
+        describe('unlock()', function() {
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
+            it('should update the value of _lock to be false', () => {
+                const templateController = new Templates(workspace);
+                templateController._lock = true;
+                templateController.unlock();
+                templateController._lock.should.be.false;
             });
         });
         describe('getTemplates(showEnabledOnly)', function() {
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
             it('Gets all templates', async function() {
-                this.timeout(testTimeout.short);
-                const templateController = new Templates('');
-                const templateList = await templateController.getTemplates(false);
+                const templateController = new Templates(workspace);
+                await templateController.initializeRepositoryList();
+                const templateList = templateController.getTemplates(false);
                 templateList.length.should.be.at.least(defaultCodewindTemplates.length);
             });
             it('gets only enabled templates', async function() {
-                this.timeout(testTimeout.short);
-                const templateController = new Templates('');
+                const templateController = new Templates(workspace);
                 const { repositoryList } = templateController;
                 for (const repository of repositoryList) {
                     repository.enabled = false;
                     repository.enabled.should.be.false;
                 }
+                await templateController.initializeRepositoryList();
                 const templateList = await templateController.getTemplates(true);
                 templateList.length.should.equal(0);
             });
             it('gets all templates after enabled templates', async function() {
-                this.timeout(testTimeout.short);
-                const templateController = new Templates('');
+                const templateController = new Templates(workspace);
                 const { repositoryList } = templateController;
                 for (const repository of repositoryList) {
                     repository.enabled = false;
                     repository.enabled.should.be.false;
                 }
+                await templateController.initializeRepositoryList();
                 const enabledTmplateList = await templateController.getTemplates(true);
                 enabledTmplateList.length.should.equal(0);
                 const templateList = await templateController.getTemplates(false);
                 templateList.length.should.be.at.least(defaultCodewindTemplates.length);
             });
             it('gets enabled templates after all templates', async function() {
-                this.timeout(testTimeout.short);
-                const templateController = new Templates('');
+                const templateController = new Templates(workspace);
+                await templateController.initializeRepositoryList();
                 const templateList = await templateController.getTemplates(false);
                 templateList.length.should.be.at.least(defaultCodewindTemplates.length);
                 const { repositoryList } = templateController;
@@ -133,14 +179,16 @@ describe('Templates.js', function() {
                     repository.enabled = false;
                     repository.enabled.should.be.false;
                 }
+                await templateController.initializeRepositoryList();
                 const enabledTemplateList = await templateController.getTemplates(true);
                 enabledTemplateList.length.should.equal(0);
             });
             describe('verifies the Codewind default templates are there and all others contain the required keys', function() {
                 it('returns the default templates', async function() {
                     this.timeout(testTimeout.med);
-                    const templateController = new Templates('');
-                    const output = await templateController.getTemplates(false, false);
+                    const templateController = new Templates(workspace);
+                    await templateController.initializeRepositoryList();
+                    const output = await templateController.getTemplates(false);
                     output.should.contain.deep.members(defaultCodewindTemplates);
                     for (const element of output) {
                         // List of keys required are generated from the API docs
@@ -148,89 +196,51 @@ describe('Templates.js', function() {
                     }
                 });
             });
-            describe('add an invalid template repo', function() {
-                let templateController;
-                before(() => {
-                    templateController = new Templates('');
-                    templateController.repositoryList = [
-                        sampleRepos.codewind,
-                        { url: 'https://www.google.com/' },
-                    ];
-                });
-                it('returns only the default templates', async function() {
-                    const output = await templateController.getTemplates(false, false);
-                    output.should.deep.equal(defaultCodewindTemplates);
-                });
-            });
             describe('and add a provider providing a valid template repo', function() {
                 let templateController;
-                before(() => {
-                    fs.ensureDirSync(testWorkspaceConfigDir);
-                    templateController = new Templates(testWorkspaceConfigDir);
-                    templateController.addProvider('valid repo', {
+                before(async function() {
+                    templateController = new Templates(workspace);
+                    await templateController.addProvider('valid repo', {
                         getRepositories() {
                             return [sampleRepos.appsody];
                         },
                     });
                 });
-                after(() => {
-                    fs.removeSync(testWorkspaceDir);
-                });
                 it('returns more templates than just the default ones', async function() {
-                    this.timeout(testTimeout.short);
-                    const output = await templateController.getTemplates(false, false);
+                    const output = await templateController.getTemplates(false);
                     output.should.include.deep.members(defaultCodewindTemplates);
                     (output.length).should.be.above(defaultCodewindTemplates.length);
                 });
             });
-            describe('and enable a repository and get the new templates', function() {
-                let templateController;
-                before(async function() {
-                    this.timeout(testTimeout.short);
-                    fs.ensureDirSync(testWorkspaceConfigDir);
-                    templateController = new Templates(testWorkspaceConfigDir);
-                    const disabledRepo = { ...sampleRepos.codewind };
-                    disabledRepo.enabled = false;
-                    // Use a disabled repository, getTemplates should return no templates
-                    templateController.repositoryList = [disabledRepo];
-                    templateController.projectTemplatesNeedsRefresh = true;
-                    const templates = await templateController.getTemplates(true);
-                    templates.length.should.equal(0);
-                });
-                after(() => {
-                    fs.removeSync(testWorkspaceDir);
-                });
-                it('returns an updated template list after a repo is enabled', async function() {
-                    this.timeout(testTimeout.short);
-                    // Change repository to be enabled
-                    await templateController.enableOrDisableRepository({ url: sampleRepos.codewind.url, value: true });
-                    // Get templates should return updated list of templates
-                    const templates = await templateController.getTemplates(true);
-                    templates.length.should.not.equal(0);
-                });
-            });
         });
         describe('getTemplatesByStyle(projectStyle, showEnabledOnly = false)', function() {
-            const workspace = path.join(__dirname, 'initializeRepositoryList');
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
+            afterEach(() => {
+                fs.removeSync(workspace);
+            });
             it('gets only templates of a specific style', async function() {
-                this.timeout(testTimeout.short);
                 const templateController = new Templates(workspace);
+                await templateController.initializeRepositoryList();
                 const templateList = await templateController.getTemplatesByStyle('Codewind');
                 templateList.length.should.be.gt(1);
             });
             it('gets no templates for a non-existent style', async function() {
-                this.timeout(testTimeout.short);
                 const templateController = new Templates(workspace);
+                await templateController.initializeRepositoryList();
                 const templateList = await templateController.getTemplatesByStyle('NotAStyle');
                 templateList.length.should.equal(0);
             });
         });
         describe('getAllTemplateStyles()', function() {
-            const workspace = path.join(__dirname, 'initializeRepositoryList');
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
             describe('returns only Codewind templates as it is the style in the projectTemplates', function() {
                 let templateController;
-                before(() => {
+                before(async function() {
                     templateController = new Templates(workspace);
+                    await templateController.initializeRepositoryList();
+                });
+                afterEach(() => {
+                    fs.removeSync(workspace);
                 });
                 it(`returns ['Codewind', 'Appsody']`, async function() {
                     const output = await templateController.getAllTemplateStyles();
@@ -239,60 +249,78 @@ describe('Templates.js', function() {
             });
         });
         describe('getRepositories()', function() {
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
             let templateController;
             before(() => {
-                templateController = new Templates('');
+                templateController = new Templates(workspace);
                 templateController.repositoryList = [...mockRepoList];
             });
-            it('returns all repos', async function() {
-                const output = await templateController.getRepositories();
+            it('returns all repos', function() {
+                const output = templateController.getRepositories();
                 output.should.deep.equal(mockRepoList);
             });
         });
-        describe('getEnabledRepositories()', function() {
-            let templateController;
-            beforeEach(() => {
-                templateController = new Templates('');
-                templateController.repositoryList = [mockRepos.enabled, mockRepos.disabled];
-            });
-            it('returns only enabled repos', async function() {
-                const output = await templateController.getEnabledRepositories();
-                output.should.deep.equal([mockRepos.enabled]);
-            });
-            it('return the repository list with a new, enabled repository', async() => {
-                await templateController.enableOrDisableRepository({ url: '2', value: true });
-                const enabledRepo = { ...mockRepos.disabled };
-                enabledRepo.enabled = true;
-                const output = await templateController.getEnabledRepositories();
-                output[1].should.deep.equal(enabledRepo);
-            });
-        });
-        describe('doesRepositoryExist()', function() {
+        describe('getRepository()', function() {
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
             let templateController;
             before(() => {
-                templateController = new Templates('');
-                templateController.repositoryList = [...mockRepoList];
+                templateController = new Templates(workspace);
+                templateController.repositoryList = [mockRepos.enabled];
             });
-            it('returns true as the repository exists', async function() {
-                const repoExists = await templateController.doesRepositoryExist('1');
-                repoExists.should.be.true;
+            it('returns a repository as it exists in the repositoryList', function() {
+                const repo = templateController.getRepository(mockRepos.enabled.url);
+                repo.should.equal(mockRepos.enabled);
             });
-            it('returns false as the repository does not exist', async function() {
-                const repoExists = await templateController.doesRepositoryExist('http://badurl.com');
-                repoExists.should.be.false;
+            it('returns null as the requested repo does not exist in the repositoryList', function() {
+                const repo = templateController.getRepository(mockRepos.disabled.url);
+                should.equal(repo, null);
             });
         });
         describe('batchUpdate(requestedOperations)', function() {
-            let templateController;
-            beforeEach(() => {
-                fs.ensureDirSync(testWorkspaceConfigDir);
-                templateController = new Templates(testWorkspaceDir);
-                templateController.repositoryList = [...mockRepoList];
-            });
-            afterEach(() => {
-                fs.removeSync(testWorkspaceDir);
+            const workspace = getWorkspaceAndDeleteAfterEach(this.title);
+            describe('when the repository has a valid URL to gather templates', function() {
+                let templateController;
+                let totalNumTemplates;
+                before(async() => {
+                    fs.ensureDirSync(workspace);
+                    templateController = new Templates(workspace);
+                    const disabledCodewindRepo = {
+                        ...sampleRepos.codewind,
+                        enabled: false,
+                    };
+                    templateController.repositoryList = [{ ...disabledCodewindRepo }];
+                    await templateController.initializeRepositoryList();
+                    // templateController should have no enabled templates
+                    templateController.getTemplates(true).length.should.equal(0);
+                    totalNumTemplates = templateController.getTemplates(false).length;
+                });
+                it('enables a disabled repository and updates the templates', async function() {
+                    const operation = {
+                        op: 'enable',
+                        url: sampleRepos.codewind.url,
+                        value: 'true',
+                    };
+                    const output = await templateController.batchUpdate([operation]);
+
+                    output.should.deep.equal([{
+                        status: 200,
+                        requestedOperation: operation,
+                    }]);
+
+                    // templateController should have enabled templates
+                    templateController.getTemplates(true).length.should.equal(totalNumTemplates);
+
+                    const repoFile = fs.readJsonSync(templateController.repositoryFile);
+                    repoFile.should.include.deep.members([sampleRepos.codewind]);
+                });
             });
             describe('when the requested operations are all valid', function() {
+                let templateController;
+                beforeEach(() => {
+                    fs.ensureDirSync(workspace);
+                    templateController = new Templates(workspace);
+                    templateController.repositoryList = [...mockRepoList];
+                });
                 const tests = {
                     'enable 2 existing repos': {
                         input: [
@@ -520,139 +548,6 @@ describe('Templates.js', function() {
                 }
             });
         });
-        describe('performOperationOnRepository(operation)', function() {
-            let templateController;
-            beforeEach(() => {
-                templateController = new Templates('');
-                templateController.repositoryList = [...mockRepoList];
-            });
-            describe('when `operation.url` is an existing url', function() {
-                const tests = {
-                    'enable an existing repo': {
-                        input: {
-                            op: 'enable',
-                            url: '1',
-                            value: 'true',
-                        },
-                        output: {
-                            status: 200,
-                            requestedOperation: {
-                                op: 'enable',
-                                url: '1',
-                                value: 'true',
-                            },
-                        },
-                        expectedRepoDetails: {
-                            url: '1',
-                            description: '1',
-                            enabled: true,
-                        },
-                    },
-                    'disable an existing repo': {
-                        input: {
-                            op: 'enable',
-                            url: '1',
-                            value: 'false',
-                        },
-                        output: {
-                            status: 200,
-                            requestedOperation: {
-                                op: 'enable',
-                                url: '1',
-                                value: 'false',
-                            },
-                        },
-                        expectedRepoDetails: {
-                            url: '1',
-                            description: '1',
-                            enabled: false,
-                        },
-                    },
-                };
-                for (const [testName, test] of Object.entries(tests)) {
-                    describe(testName, function() { // eslint-disable-line no-loop-func
-                        it(`returns the expected operation info and correctly updates the repository file`, async function() {
-                            const output = await templateController.performOperationOnRepository(test.input);
-                            output.should.deep.equal(test.output);
-                        });
-                    });
-                }
-            });
-            describe('when `operation.url` is an unknown url', function() {
-                const tests = {
-                    'enable an unknown repo': {
-                        input: {
-                            op: 'enable',
-                            url: 'unknownRepoUrl',
-                            value: 'true',
-                        },
-                        output: {
-                            status: 404,
-                            error: 'Unknown repository URL',
-                            requestedOperation: {
-                                op: 'enable',
-                                url: 'unknownRepoUrl',
-                                value: 'true',
-                            },
-                        },
-                    },
-                    'disable an unknown repo': {
-                        input: {
-                            op: 'enable',
-                            url: 'unknownRepoUrl',
-                            value: 'false',
-                        },
-                        output: {
-                            status: 404,
-                            error: 'Unknown repository URL',
-                            requestedOperation: {
-                                op: 'enable',
-                                url: 'unknownRepoUrl',
-                                value: 'false',
-                            },
-                        },
-                    },
-                };
-                for (const [testName, test] of Object.entries(tests)) {
-                    describe(testName, function() { // eslint-disable-line no-loop-func
-                        it(`returns the expected operation info`, async function() {
-                            const output = await templateController.performOperationOnRepository(test.input);
-                            output.should.deep.equal(test.output);
-                        });
-                    });
-                }
-            });
-        });
-        describe('enableOrDisableRepository({ url, value })', () => {
-            it('returns 404 as its status as the repository does not exist', async() => {
-                const templateController = new Templates('');
-                const operationResponse = await templateController.enableOrDisableRepository({ url: 'urlThatDoesNotExist' });
-                operationResponse.should.have.property('status', 404);
-                operationResponse.should.have.property('error', 'Unknown repository URL');
-            });
-            const tests = {
-                'enables a project (Boolean)': { input: true, output: true, testRepo: mockRepos.disabled },
-                'enables a project (String)': { input: 'true', output: true, testRepo: mockRepos.disabled },
-                'disables a project (Boolean)': { input: false, output: false, testRepo: mockRepos.enabled },
-                'disables a project (String)': { input: 'false', output: false, testRepo: mockRepos.enabled },
-            };
-            for (const [testName, test] of Object.entries(tests)) {
-                const { input, output, testRepo } = test;
-                // eslint-disable-next-line no-loop-func
-                it(`returns 200 and ${testName}`, async() => {
-                    const templateController = new Templates('');
-                    templateController.repositoryList = [testRepo];
-
-                    const operationResponse = await templateController.enableOrDisableRepository({ url: testRepo.url, value: input });
-                    operationResponse.should.have.property('status', 200);
-                    operationResponse.should.not.have.property('error');
-                    templateController.projectTemplatesNeedsRefresh.should.be.true;
-
-                    const repoPostChange = await templateController.getRepository(testRepo.url);
-                    repoPostChange.should.have.property('enabled', output);
-                });
-            }
-        });
         describe('addRepository(repoUrl, repoDescription, repoName, isRepoProtected)', function() {
             const mockRepoList = [{ id: 'notanid', url: 'https://made.up/url' }];
             let templateController;
@@ -667,7 +562,6 @@ describe('Templates.js', function() {
             describe('repo without name and description in templates.json', () => {
                 describe('(<invalidUrl>, <validDesc>)', function() {
                     it('throws an error', function() {
-                        this.timeout(testTimeout.short);
                         const url = 'some string';
                         const func = () => templateController.addRepository(url, 'description');
                         return func().should.be.rejectedWith(`Invalid URL: ${url}`);
@@ -675,7 +569,6 @@ describe('Templates.js', function() {
                 });
                 describe('(<existingUrl>, <validDesc>)', function() {
                     it('throws an error', function() {
-                        this.timeout(testTimeout.short);
                         const { url } = mockRepoList[0];
                         const func = () => templateController.addRepository(url, 'description');
                         return func().should.be.rejectedWith(`${url} is already a template repository`);
@@ -683,7 +576,6 @@ describe('Templates.js', function() {
                 });
                 describe('(<validUrlNotPointingToIndexJson>, <validDesc>)', function() {
                     it('throws an error', function() {
-                        this.timeout(testTimeout.short);
                         const url = validUrlNotPointingToIndexJson;
                         const func = () => templateController.addRepository(url, 'description');
                         return func().should.be.rejectedWith(`${url} does not point to a JSON file of the correct form`);
@@ -691,7 +583,6 @@ describe('Templates.js', function() {
                 });
                 describe('(<validUrlPointingToIndexJson>, <validDesc>, <validName>)', function() {
                     it('succeeds', async function() {
-                        this.timeout(testTimeout.short);
                         const func = () => templateController.addRepository(templateRepositoryURL, 'description', 'name');
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{
@@ -709,7 +600,6 @@ describe('Templates.js', function() {
                 });
                 describe('(<validUrlUnprotected>, <validDesc>, <validName>)', function() {
                     it('succeeds', async function() {
-                        this.timeout(testTimeout.short);
                         const isRepoProtected = false;
                         const func = () => templateController.addRepository(templateRepositoryURL, 'description', 'name', isRepoProtected);
                         await (func().should.not.be.rejected);
@@ -731,7 +621,6 @@ describe('Templates.js', function() {
             describe('repo with name and description in templates.json', () => {
                 describe('(<validUrl>, <ValidDesc>, <ValidName>)', function() {
                     it('succeeds, and allows the user to set the name and description', async function() {
-                        this.timeout(testTimeout.short);
                         const func = () => templateController.addRepository(templateRepositoryURL, 'description', 'name', false);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{ ...sampleRepos.codewind,
@@ -743,7 +632,6 @@ describe('Templates.js', function() {
                 });
                 describe('(repo with templates.json, <validUrl>, <NoDesc>, <NoName>)', function() {
                     it('succeeds, and gets the name and description from templates.json', async function() {
-                        this.timeout(testTimeout.short);
                         const func = () => templateController.addRepository(templateRepositoryURL, '', '', false);
                         await (func().should.not.be.rejected);
                         templateController.repositoryList.should.containSubset([{ ...sampleRepos.codewind, protected: false }]);
@@ -775,65 +663,75 @@ describe('Templates.js', function() {
             });
         });
         describe('addProvider(name, provider)', () => {
-            it('ignores the invalid provider', () => {
-                const templateController = new Templates('');
+            const provider = {
+                getRepositories: () => {
+                    return [sampleRepos.codewind];
+                },
+            };
+            it('ignores the invalid provider', async() => {
+                const templateController = new Templates(testWorkspaceDir);
                 const originalProviders = { ...templateController.providers };
-                templateController.addProvider('empty obj', {});
+                await templateController.addProvider('empty obj', {});
                 templateController.providers.should.deep.equal(originalProviders);
             });
-            it('successfully adds a provider', () => {
-                const templateController = new Templates('');
-                const newProvider = {
+            it('fails to add a provider with a getRepositories function that does not return valid repositories', async() => {
+                const templateController = new Templates(testWorkspaceDir);
+                templateController.repositoryList = [];
+                const badProvider = {
                     getRepositories: () => {
-                        return '';
+                        return [1,2,3];
                     },
                 };
+                await templateController.addProvider('badProvider', badProvider);
+            });
+            it('successfully adds a provider', async() => {
+                const templateController = new Templates(testWorkspaceDir);
+                templateController.repositoryList = [];
                 const { providers } = templateController;
-                templateController.addProvider('newProvider', newProvider);
-                providers.should.have.property('newProvider');
-                providers.newProvider.should.containSubset(newProvider);
+                await templateController.addProvider('dummyProvider', provider);
+                providers.should.have.property('dummyProvider');
+                providers.dummyProvider.should.containSubset(provider);
+                // Check repository has been added
+                const { length: repoLength } = templateController.getRepositories();
+                repoLength.should.equal(1);
             });
-        });
-        describe('addRepositoryToProviders(repo)', () => {
-            it('adds a repository to a provider', async() => {
-                const templateController = new Templates('');
-                templateController.providers = {
-                    firstProvider: {
-                        repositories: [],
-                        canHandle() {
-                            return true;
-                        },
-                        addRepository(newRepo) {
-                            this.repositories.push(newRepo);
-                            return this.repositories;
-                        },
+            it('does not add a duplicate repository', async() => {
+                const templateController = new Templates(testWorkspaceDir);
+                templateController.repositoryList = [];
+                await templateController.addRepository(sampleRepos.codewind.url);
+                templateController.repositoryList.length.should.equal(1);
+                await templateController.addProvider('dummyProvider', provider);
+                // Check repository has not been duplicated
+                const { length: repoLength } = templateController.getRepositories();
+                repoLength.should.equal(1);
+            });
+            describe('test adding a provider does not overwrite the existing repository list', () => {
+                let templateController;
+                let originalRepositoriesLength;
+                let originalTemplatesLength;
+                const provider = {
+                    getRepositories: () => {
+                        return [sampleRepos.codewind];
                     },
                 };
-                const { firstProvider } = templateController.providers;
-                firstProvider.repositories.should.have.length(0);
-                await templateController.addRepositoryToProviders({ ...sampleRepos.codewind });
-                firstProvider.repositories.should.have.length(1);
-            });
-        });
-        describe('removeRepositoryFromProviders(repo)', () => {
-            it('removes a repository from a provider', async() => {
-                const templateController = new Templates('');
-                templateController.providers = {
-                    firstProvider: {
-                        repositories: [{ ...sampleRepos.codewind }],
-                        canHandle() {
-                            return true;
-                        },
-                        removeRepository(repoURLToDelete) {
-                            this.repositories.splice(this.repositories.findIndex(repo => repo.url === repoURLToDelete), 1);
-                            return this.repositories;
-                        },
-                    },
-                };
-                const { firstProvider } = templateController.providers;
-                firstProvider.repositories.should.have.length(1);
-                await templateController.removeRepositoryFromProviders(sampleRepos.codewind.url);
-                firstProvider.repositories.should.have.length(0);
+                before(() => {
+                    templateController = new Templates(testWorkspaceDir);
+                    templateController.repositoryList = [...mockRepoList];
+                    // Add a dummy entry to the templates
+                    templateController.allProjectTemplates = ['template'];
+                    originalRepositoriesLength = templateController.getRepositories().length;
+                    originalTemplatesLength = templateController.getTemplates(false).length;
+                });
+                it('adds a new provider and verifies that it does not delete the old repositories and templates', async() => {
+                    await templateController.addProvider('dummyProvider', provider);
+                    const updatedRepositoryList = templateController.getRepositories();
+                    updatedRepositoryList.length.should.equal(originalRepositoriesLength + 1);
+                    updatedRepositoryList.should.deep.equal([...mockRepoList, sampleRepos.codewind]);
+                    const updatedTemplates = templateController.getTemplates(false);
+                    updatedTemplates.length.should.be.above(originalTemplatesLength);
+                    // the dummy template will have been removed as addProvider does a fresh fetch of templates
+                    updatedTemplates.should.not.contain('template');
+                });
             });
         });
     });
@@ -864,18 +762,41 @@ describe('Templates.js', function() {
                 jsonPostChange[0].should.have.property('field', 123);
             });
         });
-        describe('getRepositoryIndex(url, repositories)', () => {
-            const getRepositoryIndex = Templates.__get__('getRepositoryIndex');
-            it('returns an index of greater than -1 as the repository exists', () => {
-                const index = getRepositoryIndex('http://goodurl.com', [ { url: 'http://goodurl.com' } ]);
-                index.should.equal(0);
+        describe('validateRepository(repoUrl, repositories)', () => {
+            const validateRepository = Templates.__get__('validateRepository');
+            it('is rejected as the URL is invalid', () => {
+                return validateRepository('invalidurl')
+                    .should.be.rejected.then(err => checkTemplateError(err, 'INVALID_URL'));
             });
-            it('returns an index of -1 as the repository does not exist', () => {
-                const index = getRepositoryIndex('http://badurl.com', [ { url: 'http://goodurl.com' } ]);
-                index.should.equal(-1);
+            it('is rejected as the repositories already contains the given url', () => {
+                return validateRepository(sampleRepos.codewind.url, [...mockRepoList, sampleRepos.codewind])
+                    .should.be.rejected.then(err => checkTemplateError(err, 'DUPLICATE_URL'));
+            });
+            it('is rejected as url does not point to a valid index.json', () => {
+                return validateRepository('https://eclipse.org', [...mockRepoList])
+                    .should.be.rejected.then(err => checkTemplateError(err, 'URL_DOES_NOT_POINT_TO_INDEX_JSON'));
+            });
+            it('returns a validated url', async() => {
+                const validatedURL = await validateRepository(sampleRepos.codewind.url, [...mockRepoList]);
+                validatedURL.should.equal(sampleRepos.codewind.url);
             });
         });
-        describe('updateRepoListWithReposFromProviders(providers, repositoryList, repositoryFile)', function() {
+        describe('constructRepositoryObject(url, description, name, isRepoProtected)', () => {
+            const constructRepositoryObject = Templates.__get__('constructRepositoryObject');
+            it('returns a repository object when all arguments are given', async() => {
+                const { url, description, name, protected } = sampleRepos.codewind;
+                const repository = await constructRepositoryObject(url, description, name, protected);
+                repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'protected', 'projectStyles');
+            });
+            it('returns a repository object only a url is given - gets the name, description from the url and does not have a protected field', async() => {
+                const { url } = sampleRepos.codewind;
+                const repository = await constructRepositoryObject(url);
+                repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'projectStyles');
+                repository.should.not.have.keys('protected');
+            });
+        });
+        describe('updateRepoListWithReposFromProviders(providers, repositoryList)', function() {
+            const updateRepoListWithReposFromProviders = Templates.__get__('updateRepoListWithReposFromProviders');
             describe('when providers do not provide valid repos', function() {
                 const tests = {
                     'invalid provider: string': {
@@ -924,12 +845,9 @@ describe('Templates.js', function() {
                         after(() => {
                             fs.removeSync(testWorkspaceDir);
                         });
-                        it(`does not update the repository_list.json`, async function() {
-                            fs.existsSync(testRepositoryFile).should.be.false;
-                            const updateRepoListWithReposFromProviders = Templates.__get__('updateRepoListWithReposFromProviders'); 
-                            await updateRepoListWithReposFromProviders([test.provider], [...mockRepoList], testRepositoryFile);
-                            // repository file should not have been created as the repo list had not been updated
-                            fs.existsSync(testRepositoryFile).should.be.false;
+                        it(`does not update the repositoryList`, async function() {
+                            const updatedRepositoryList = await updateRepoListWithReposFromProviders([test.provider], [...mockRepoList]);
+                            updatedRepositoryList.should.deep.equal([...mockRepoList]);
                         });
                     });
                 }
@@ -945,7 +863,7 @@ describe('Templates.js', function() {
                 after(() => {
                     fs.removeSync(testWorkspaceDir);
                 });
-                it(`updates the repository_list.json correctly`, async function() {
+                it(`updates the repository successfully`, async function() {
                     const expectedRepo = {
                         ...validCodewindRepo,
                         enabled: true,
@@ -953,22 +871,18 @@ describe('Templates.js', function() {
                         name: 'Default templates',
                         projectStyles: ['Codewind'],
                     };
-                    const updateRepoListWithReposFromProviders = Templates.__get__('updateRepoListWithReposFromProviders'); 
                     const provider = {
                         getRepositories() {
                             return [validCodewindRepo];
                         },
                     };
-                    await updateRepoListWithReposFromProviders([provider], [...mockRepoList], testRepositoryFile);
-                    const repoFile = await fs.readJson(testRepositoryFile);
-                    repoFile.should.deep.equal([
-                        ...mockRepoList,
-                        expectedRepo,
-                    ]);
+                    const updatedRepositoryList = await updateRepoListWithReposFromProviders([provider], [...mockRepoList], testRepositoryFile);
+                    updatedRepositoryList.length.should.equal([...mockRepoList].length + 1);
+                    updatedRepositoryList.should.deep.include(expectedRepo);
                 });
             });
         });
-        describe('fetchAllRepositoryDetails(repos)', () => {
+        describe('addCodewindSettingsToRepository(repos)', () => {
             const addCodewindSettingsToRepository = Templates.__get__('addCodewindSettingsToRepository');
             const url = 'https://raw.githubusercontent.com/kabanero-io/codewind-appsody-templates/master/devfiles/index.json';
             it('should update a repository to have the enabled and protected fields when they don\'t exist', async() => {
@@ -1045,7 +959,7 @@ describe('Templates.js', function() {
                 details.should.have.deep.property('projectStyles', ['Codewind']);
             });
         });
-        describe('getNameAndDescriptionFromRepoTemplatesJSON(repository)', function() {
+        describe('getNameAndDescriptionFromRepoTemplatesJSON(url)', function() {
             const getNameAndDescriptionFromRepoTemplatesJSON = Templates.__get__('getNameAndDescriptionFromRepoTemplatesJSON');
             it('throws an error as no url is given', () => {
                 return getNameAndDescriptionFromRepoTemplatesJSON('')
@@ -1065,6 +979,48 @@ describe('Templates.js', function() {
                 repo.should.contain.keys('name', 'description');
             });
         });
+        describe('updateTemplates(repositories, allTemplates)', function() {
+            const updateTemplates = Templates.__get__('updateTemplates');
+            it('returns a populated enabledTemplates list as the given repository is enabled', async() => {
+                const originalAllTemplates = [...defaultCodewindTemplates];
+                const repositories = [{
+                    ...sampleRepos.codewind,
+                    enabled: true,
+                }];
+                const { enabledTemplates, allTemplates } = await updateTemplates(repositories, originalAllTemplates);
+                allTemplates.should.deep.equal(originalAllTemplates);
+                enabledTemplates.should.deep.equal(allTemplates);
+            });
+            it('returns an empty enabledTemplates list as the given repository is disabled', async() => {
+                const originalAllTemplates = [...defaultCodewindTemplates];
+                const repositories = [{
+                    ...sampleRepos.codewind,
+                    enabled: false,
+                }];
+                const { enabledTemplates, allTemplates } = await updateTemplates(repositories, originalAllTemplates);
+                allTemplates.should.deep.equal(originalAllTemplates);
+                enabledTemplates.length.should.equal(0);
+            });
+        });
+        describe('fetchTemplates(repositories)', function() {
+            const fetchTemplates = Templates.__get__('fetchTemplates');
+            it('returns enabledTemplates and allTemplates as the same list as the only repository is enabled', async function() {
+                const repoList = [{ ...sampleRepos.codewind }];
+                const { enabledTemplates, allTemplates } = await fetchTemplates(repoList);
+                enabledTemplates.length.should.be.above(0);
+                allTemplates.length.should.be.above(0);
+                enabledTemplates.should.deep.equal(allTemplates);
+            });
+            it('returns enabledTemplates as empty as the only repository is disabled', async function() {
+                const repoList = [{
+                    ...sampleRepos.codewind,
+                    enabled: false,
+                }];
+                const { enabledTemplates, allTemplates } = await fetchTemplates(repoList);
+                enabledTemplates.length.should.equal(0);
+                allTemplates.length.should.be.above(0);
+            });
+        });
         describe('getTemplatesFromRepos(repositoryList)', function() {
             const getTemplatesFromRepos = Templates.__get__('getTemplatesFromRepos');
             it('throws an error as no repos are given', function() {
@@ -1081,7 +1037,7 @@ describe('Templates.js', function() {
             });
         });
         describe('getTemplatesFromRepo(repository)', function() {
-            const getTemplatesFromRepo = Templates.__get__('getTemplatesFromRepo'); 
+            const getTemplatesFromRepo = Templates.__get__('getTemplatesFromRepo');
             it('returns the correct templates from a valid repository', async function() {
                 const output = await getTemplatesFromRepo(sampleRepos.codewind);
                 output.should.have.deep.members(defaultCodewindTemplates);
@@ -1235,7 +1191,6 @@ describe('Templates.js', function() {
                 return doesURLPointToIndexJSON(url).should.eventually.be.true;
             });
             it('returns false as the URL does not point to JSON', function() {
-                this.timeout(testTimeout.short);
                 return doesURLPointToIndexJSON('http://google.com').should.eventually.be.false;
             });
             it('returns false as the file URL does not point to JSON', () => {
@@ -1283,6 +1238,426 @@ describe('Templates.js', function() {
                 template.extraField = 'string';
                 isTemplateSummary(template).should.be.true;
             });
+        });
+        describe('addRepositoryToProviders(repo, providers)', () => {
+            const addRepositoryToProviders = Templates.__get__('addRepositoryToProviders');
+            const validProvider = {
+                repositories: [],
+                canHandle() {
+                    return true;
+                },
+                addRepository(newRepo) {
+                    this.repositories.push(newRepo);
+                    return this.repositories;
+                },
+            };
+            it('adds a repository to a provider', async() => {
+                const providers = {
+                    firstProvider: { ...validProvider },
+                };
+                const { firstProvider } = providers;
+                firstProvider.repositories.should.have.length(0);
+                const updatedProviders = await addRepositoryToProviders({ ...sampleRepos.codewind }, providers);
+                const { firstProvider: updatedFirstProvider } = updatedProviders;
+                updatedFirstProvider.repositories.should.have.length(1);
+            });
+            it('throws a TemplateError if one of the providers errors while adding the repository', () => {
+                const errorFunction = () => {
+                    throw new Error();
+                };
+                const providerThrowsError = {
+                    ...validProvider,
+                    async addRepository() {
+                        await errorFunction();
+                    },
+                };
+                const providers = {
+                    badProvider: { ...providerThrowsError },
+                };
+                return addRepositoryToProviders({ ...sampleRepos.codewind }, providers)
+                    .should.be.rejected.then(err => checkTemplateError(err, 'ADD_TO_PROVIDER_FAILURE'));
+            });
+        });
+        describe('removeRepositoryFromProviders(repo)', () => {
+            const removeRepositoryFromProviders = Templates.__get__('removeRepositoryFromProviders');
+            it('removes a repository from a provider', async() => {
+                const providers = {
+                    firstProvider: {
+                        repositories: [{ ...sampleRepos.codewind }],
+                        canHandle() {
+                            return true;
+                        },
+                        removeRepository(repoURLToDelete) {
+                            this.repositories.splice(this.repositories.findIndex(repo => repo.url === repoURLToDelete), 1);
+                            return this.repositories;
+                        },
+                    },
+                };
+                const { firstProvider } = providers;
+                firstProvider.repositories.should.have.length(1);
+                const updatedProviders = await removeRepositoryFromProviders(sampleRepos.codewind.url, providers);
+                const { firstProvider: updatedFirstProvider } = updatedProviders;
+                updatedFirstProvider.repositories.should.have.length(0);
+            });
+        });
+        describe('performOperationsOnRepositoryList(requestedOperations, repositoryList)', function() {
+            const performOperationsOnRepositoryList = Templates.__get__('performOperationsOnRepositoryList');
+            describe('when the requested operations are all valid', function() {
+                const tests = {
+                    'enable 2 existing repos': {
+                        input: [
+                            {
+                                op: 'enable',
+                                url: '1',
+                                value: 'true',
+                            },
+                            {
+                                op: 'enable',
+                                url: '2',
+                                value: 'true',
+                            },
+                        ],
+                        output: [
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '1',
+                                    value: 'true',
+                                },
+                            },
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '2',
+                                    value: 'true',
+                                },
+                            },
+                        ],
+                        expectedRepoDetails: [
+                            {
+                                url: '1',
+                                description: '1',
+                                enabled: true,
+                            },
+                            {
+                                url: '2',
+                                description: '2',
+                                enabled: true,
+                            },
+                        ],
+                    },
+                    'disable 2 existing repos': {
+                        input: [
+                            {
+                                op: 'enable',
+                                url: '1',
+                                value: 'false',
+                            },
+                            {
+                                op: 'enable',
+                                url: '2',
+                                value: 'false',
+                            },
+                        ],
+                        output: [
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '1',
+                                    value: 'false',
+                                },
+                            },
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '2',
+                                    value: 'false',
+                                },
+                            },
+                        ],
+                        expectedRepoDetails: [
+                            {
+                                url: '1',
+                                description: '1',
+                                enabled: false,
+                            },
+                            {
+                                url: '2',
+                                description: '2',
+                                enabled: false,
+                            },
+                        ],
+                    },
+                    'enable an unknown repo': {
+                        input: [
+                            {
+                                op: 'enable',
+                                url: '1',
+                                value: 'false',
+                            },
+                            {
+                                op: 'enable',
+                                url: '2',
+                                value: 'false',
+                            },
+                        ],
+                        output: [
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '1',
+                                    value: 'false',
+                                },
+                            },
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '2',
+                                    value: 'false',
+                                },
+                            },
+                        ],
+                        expectedRepoDetails: [
+                            {
+                                url: '1',
+                                description: '1',
+                                enabled: false,
+                            },
+                            {
+                                url: '2',
+                                description: '2',
+                                enabled: false,
+                            },
+                        ],
+                    },
+                    'enable an unknown repo': {
+                        input: [
+                            {
+                                op: 'enable',
+                                url: 'unknownRepoUrl',
+                                value: 'true',
+                            },
+                        ],
+                        output: [
+                            {
+                                status: 404,
+                                error: 'Unknown repository URL',
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: 'unknownRepoUrl',
+                                    value: 'true',
+                                },
+                            },
+                        ],
+                    },
+                    'disable an unknown repo': {
+                        input: [
+                            {
+                                op: 'enable',
+                                url: 'unknownRepoUrl',
+                                value: 'false',
+                            },
+                        ],
+                        output: [
+                            {
+                                status: 404,
+                                error: 'Unknown repository URL',
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: 'unknownRepoUrl',
+                                    value: 'false',
+                                },
+                            },
+                        ],
+                    },
+                    'disable an existing repo and an unknown repo': {
+                        input: [
+                            {
+                                op: 'enable',
+                                url: '1',
+                                value: 'false',
+                            },
+                            {
+                                op: 'enable',
+                                url: 'unknownRepoUrl',
+                                value: 'false',
+                            },
+                        ],
+                        output: [
+                            {
+                                status: 200,
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: '1',
+                                    value: 'false',
+                                },
+                            },
+                            {
+                                status: 404,
+                                error: 'Unknown repository URL',
+                                requestedOperation: {
+                                    op: 'enable',
+                                    url: 'unknownRepoUrl',
+                                    value: 'false',
+                                },
+                            },
+                        ],
+                        expectedRepoDetails: [
+                            {
+                                url: '1',
+                                description: '1',
+                                enabled: false,
+                            },
+                        ],
+                    },
+                };
+                for (const [testName, test] of Object.entries(tests)) {
+                    // eslint-disable-next-line no-loop-func
+                    it(`${testName}`, async function() {
+                        const repoList = [...mockRepoList];
+                        const { operationResults, newRepositoryList } = await performOperationsOnRepositoryList(test.input, repoList);
+                        operationResults.should.deep.equal(test.output);
+                        if (test.expectedRepoDetails) {
+                            newRepositoryList.should.containSubset(test.expectedRepoDetails);   
+                        }
+                    });
+                }
+            });
+        });
+        describe('performOperationOnRepository(operation, repositoryList)', function() {
+            const performOperationOnRepository = Templates.__get__('performOperationOnRepository');
+            describe('when `operation.url` is an existing url', function() {
+                const tests = {
+                    'enable an existing repo': {
+                        input: {
+                            op: 'enable',
+                            url: '1',
+                            value: 'true',
+                        },
+                        output: {
+                            status: 200,
+                            requestedOperation: {
+                                op: 'enable',
+                                url: '1',
+                                value: 'true',
+                            },
+                        },
+                        expectedRepoDetails: {
+                            url: '1',
+                            description: '1',
+                            enabled: true,
+                        },
+                    },
+                    'disable an existing repo': {
+                        input: {
+                            op: 'enable',
+                            url: '1',
+                            value: 'false',
+                        },
+                        output: {
+                            status: 200,
+                            requestedOperation: {
+                                op: 'enable',
+                                url: '1',
+                                value: 'false',
+                            },
+                        },
+                        expectedRepoDetails: {
+                            url: '1',
+                            description: '1',
+                            enabled: false,
+                        },
+                    },
+                };
+                for (const [testName, test] of Object.entries(tests)) {
+                    describe(testName, function() { // eslint-disable-line no-loop-func
+                        it(`returns the expected operation info and correctly updates the repository file`, async function() {
+                            const repositoryList = [...mockRepoList];
+                            const { operationResult, updatedRepo } = await performOperationOnRepository(test.input, repositoryList);
+                            operationResult.should.deep.equal(test.output);
+                            updatedRepo.should.deep.equal(test.expectedRepoDetails);
+                        });
+                    });
+                }
+            });
+            describe('when `operation.url` is an unknown url', function() {
+                const tests = {
+                    'enable an unknown repo': {
+                        input: {
+                            op: 'enable',
+                            url: 'unknownRepoUrl',
+                            value: 'true',
+                        },
+                        output: {
+                            status: 404,
+                            error: 'Unknown repository URL',
+                            requestedOperation: {
+                                op: 'enable',
+                                url: 'unknownRepoUrl',
+                                value: 'true',
+                            },
+                        },
+                    },
+                    'disable an unknown repo': {
+                        input: {
+                            op: 'enable',
+                            url: 'unknownRepoUrl',
+                            value: 'false',
+                        },
+                        output: {
+                            status: 404,
+                            error: 'Unknown repository URL',
+                            requestedOperation: {
+                                op: 'enable',
+                                url: 'unknownRepoUrl',
+                                value: 'false',
+                            },
+                        },
+                    },
+                };
+                for (const [testName, test] of Object.entries(tests)) {
+                    describe(testName, function() { // eslint-disable-line no-loop-func
+                        it(`returns the expected operation info`, async function() {
+                            const repositoryList = [...mockRepoList];
+                            const { operationResult, updatedRepo } = await performOperationOnRepository(test.input, repositoryList);
+                            operationResult.should.deep.equal(test.output);
+                            // eslint-disable-next-line no-undefined
+                            should.equal(updatedRepo, undefined);
+                        });
+                    });
+                }
+            });
+        });
+        describe('enableOrDisableRepository({ url, value }, repo)', () => {
+            const enableOrDisableRepository = Templates.__get__('enableOrDisableRepository');
+            it('returns 404 as its status as the repository does not exist', async() => {
+                const { response: operationResponse } = await enableOrDisableRepository({ url: 'urlThatDoesNotExist' });
+                operationResponse.should.have.property('status', 404);
+                operationResponse.should.have.property('error', 'Unknown repository URL');
+            });
+            const tests = {
+                'enables a project (Boolean)': { input: true, output: true, testRepo: mockRepos.disabled },
+                'enables a project (String)': { input: 'true', output: true, testRepo: mockRepos.disabled },
+                'disables a project (Boolean)': { input: false, output: false, testRepo: mockRepos.enabled },
+                'disables a project (String)': { input: 'false', output: false, testRepo: mockRepos.enabled },
+            };
+            for (const [testName, test] of Object.entries(tests)) {
+                const { input, output, testRepo } = test;
+                // eslint-disable-next-line no-loop-func
+                it(`returns 200 and ${testName}`, async() => {
+                    const { response: operationResponse, updatedRepo } = await enableOrDisableRepository({ url: testRepo.url, value: input }, testRepo);
+                    operationResponse.should.have.property('status', 200);
+                    operationResponse.should.not.have.property('error');
+
+                    updatedRepo.should.have.property('enabled', output);
+                });
+            }
         });
     });
 });


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix - Tests
- [x] Enhancement - Lock

## What does this PR do ?
Changes the implementation of `Template.js` to update the repository list and template list in the `add repository` function rather than on a `get repositories` or `get templates` to resolve the race conditions that can appear when doing multiple `GET` requests. 
Uses a `lock` and returns `423 Locked` if the templates file is `locked`.

### Details
#### Templates
* Added `lock` to `Templates.js`
* Move the functions which fetch the templates and update the repository list into the `add`, `delete` functions rather than the `get`
  * `add` and `delete` will take longer as they do more (`POST`, `DELETE)
  * `get` should be a lot quicker (`GET`)
  * removed the `projectListNeedsUpdating` and the `templatesNeedUpdating` variables.
* Refactor functions which didn't need to be in the Class into local functions.
  * This will further lock down the use of them.
  * All functions within the class have the locking mechanism.
* Refactor `batchUpdate` to not fetch a new template list but to `enable` or `disable` based on the templates respective repository.
  * Added a `sourceURL` field to the template object due to this.


#### ExtensionList
* Changed the `addExtensionsToTemplates` function to be a `for` loop to resolve problems with the the Templates being locked when an `async` function was used. 
* As this is only called when Codewind is intialised it currently makes more sense to make this change rather than refactor much of the logic to cope with the lock -> In the future if enhance PFE to add extensions while its running (API?) then we'll need a more complex lock.



### Testing
* Added tests for new functions in Template.js
* Added `setupReposAndTemplatesForTesting` function which when included will set the `repositoryList` to only contain the testing Codewind repository.
  * The Appsody repository will be still show as it cannot be deleted.
* Enhanced the `addProvider` tests now that more logic has been added.

Takes some testing logic from https://github.com/eclipse/codewind/pull/2268/files which this PR supersedes.

#### Appsody test fix for `repository.yaml` in `.appsody` directory that does not include the `incubator` repository
* Removed the Appsody checks from the `project-types` and `templates styles` API tests.
* Added an Appsody check into the `extension` API test.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2190

## Does this PR require a documentation change ?
Only API docs -> I have made that change in the `openapi.yml`

## Any special notes for your reviewer ?
This PR supersedes the previous on on the `409-conflict` branch, diff here: https://github.com/james-wallis/codewind/compare/409-conflict...james-wallis:423-locked
This PR is a rebased, cleaned up version. 