### PR TITLE
Updates to use gcTime instead of gcTimeSummary

### DIFF
--- a/src/performance/monitor/public/graphmetrics/index.html
+++ b/src/performance/monitor/public/graphmetrics/index.html
@@ -228,7 +228,7 @@
     socket.on('gc', function(data) {
       updateGCData(data);
       let json = JSON.parse(data);
-      summary.gc.time = json.timeSummary;
+      summary.gc.time = json.time;
       summary.gc.usedHeapAfterGCMax = json.usedHeapAfterGCMax;
       updateSummaryTable();
     });

--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -225,7 +225,7 @@
         } else if (['os_cpu_used_ratio'].includes(metric.name)) { // ignored if -1 (not available)
           cpuData.system = numMetricValue;
 
-        } else if (['base:gc_global_time_seconds', 'time_in_gc_percentage'].includes(metric.name)) {
+        } else if (['base:gc_global_time_seconds', 'overall_time_in_gc_percentage'].includes(metric.name)) {
           gcData.gcTime = numMetricValue;
         } else if (['base_gc_time_seconds'].includes(metric.name)) {
           const correctMetricsObj = metric.metrics.find(obj => obj.labels.name === 'global');
@@ -283,8 +283,7 @@
       // },
       // {
       //   time: 1572617286795,
-      //   gcTime: 0, // base_gc_time_seconds (actually milliseconds) (TODO add the scavenge and global handlers together)?
-      //   gcTimeSummary: 0.00022953932836541658
+      //   gcTime: 0.2022953932836541658
       // },
       // {
       //   time: 1572617288774,
@@ -308,7 +307,7 @@
     //       break;
     //     case 'gc':
     //       updateGCData(payload);
-    //       summary.gc.time = received.payload.gcTimeSummary;
+    //       summary.gc.time = received.payload.gcTime;
     //       break;
     //     case 'env':
     //       envTable.populateTableJSON(payload);
@@ -356,9 +355,7 @@
     }
     function processGCData(data) {
       updateGCData(JSON.stringify(data));
-      // Commented out as `data` doesn't currently get a `gcTimeSummary` property.
-      // Could we calculate it using ((data.durationTotal / 1000) / data.processUptime)?
-      // summary.gc.time = data.gcTimeSummary;
+      summary.gc.time = data.gcTime;
     }
     function processMemPoolsData(data) {
       updateMemPoolsData(JSON.stringify(data));


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [X ] Bug fix
- [ ] Enhancement

## What does this PR do ?
Updates the use of the `gcTime` metric to reflect it's new status as provider of a summary metric (percentage of time spent in GC since program start).

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2056

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2056

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
# https://github.com/RuntimeTools/javametrics/pull/106 must have been merged and published to maven in a javametrics release before this PR can be merged
