### PR TITLE
test: add unit tests for Portal LoadRunner.js

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -191,8 +191,11 @@ module.exports = class LoadRunner {
 
     // If appmetrics does not support timed collections (which get auto delete when published), delete them now.
     if (!this.metricsFeatures || !this.metricsFeatures.timedMetrics) {
-      options.method = 'DELETE';
-      http.request(options, function (res) {
+      const deleteOptions = {
+        ...options,
+        method: 'DELETE',
+      };
+      http.request(deleteOptions, function (res) {
         if (res.statusCode == 204) {
           log.info('recordCollection: Metrics collection deleted');
         } else {

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -343,11 +343,11 @@ module.exports = class LoadRunner {
 
     // For Java Liberty restart the server in preparation for profiling
     if (this.project.language == 'java' && this.project.projectType == 'liberty') {
-      log.info(`beginJavaProfiling: Stopping liberty server`); 
+      log.info(`beginJavaProfiling: Stopping liberty server`);
       const stopCommand = ['bash', '-c', `source $HOME/artifacts/envvars.sh; $HOME/artifacts/server_setup.sh; cd $WLP_USER_DIR;  /opt/ibm/wlp/bin/server stop; `];
       await cwUtils.spawnContainerProcess(this.project, stopCommand);
       await this.waitForHealth(false);
-      log.info(`beginJavaProfiling: Starting liberty server`); 
+      log.info(`beginJavaProfiling: Starting liberty server`);
       const startCommand = ['bash', '-c', `source $HOME/artifacts/envvars.sh; $HOME/artifacts/server_setup.sh; cd $WLP_USER_DIR;  /opt/ibm/wlp/bin/server start; `];
       await cwUtils.spawnContainerProcess(this.project, startCommand);
       await this.waitForHealth(true);
@@ -355,7 +355,7 @@ module.exports = class LoadRunner {
 
     const mkdirCommand = `mkdir -p ${loadTestDir}`;
     const mkdirArray = ['bash', '-c', mkdirCommand];
-    
+
     await cwUtils.spawnContainerProcess(this.project, mkdirArray);
 
     const healthCentercommand = `export javapid=(\`pidof java\`); java -jar $JAVA_HOME/jre/lib/ext/healthcenter.jar ID=\${javapid[-1]} level=headless -Dcom.ibm.java.diagnostics.healthcenter.headless.run.number.of.runs=1 -Dcom.ibm.java.diagnostics.healthcenter.headless.run.duration=${durationInMins} -Dcom.ibm.java.diagnostics.healthcenter.headless.output.directory=${loadTestDir} -Dcom.ibm.diagnostics.healthcenter.data.memory=off -Dcom.ibm.diagnostics.healthcenter.data.memorycounters=off -Dcom.ibm.diagnostics.healthcenter.data.cpu=off -Dcom.ibm.diagnostics.healthcenter.data.environment=off -Dcom.ibm.diagnostics.healthcenter.data.locking=off -Dcom.ibm.diagnostics.healthcenter.data.memory=off -Dcom.ibm.diagnostics.healthcenter.data.threads=off`;
@@ -510,7 +510,7 @@ module.exports = class LoadRunner {
     */
     this.socket.on('error', (err) => {
       log.error('LoadRunner socket error');
-      this.project.loadInProgress = false; 
+      this.project.loadInProgress = false;
       log.error(err);
       // If this.up is false we're already trying to reconnect
       if (this.up) {

--- a/test/package.json
+++ b/test/package.json
@@ -29,6 +29,7 @@
     "chai-openapi-response-validator": "^0.7.0",
     "chai-subset": "^1.6.0",
     "child-process-promise": "^2.2.1",
+    "compress-tag": "^1.2.2",
     "dateformat": "^3.0.3",
     "deep-equal-in-any-order": "^1.0.21",
     "dockerode": "^2.5.2",

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -13,6 +13,7 @@ const sinon = require('sinon');
 const chai = require('chai');
 const chaiSubset = require('chai-subset');
 const deepEqualInAnyOrder = require('deep-equal-in-any-order');
+const { c } = require('compress-tag');
 
 /* eslint-disable class-methods-use-this */
 class MockLogger {
@@ -75,9 +76,9 @@ describe('LoadRunner.js', () => {
             on: () => {},
             connect: () => {},
         });
-        it('updates the UI when the project supports timed metrics,\
-        then POSTs to the project collections route\
-        and returns the header location when successful', async() => {
+        it(c`updates the UI when the project supports timed metrics,
+        then POSTs to the project collections route,
+        and returns the header location when successful`, async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns({
                 statusCode: 201,
@@ -118,9 +119,9 @@ describe('LoadRunner.js', () => {
             });
             output.should.equal('mockLocation');
         });
-        it('doesn\'t update the UI when the project doesn\'t support timed metrics,\
-        then POSTs to the project collections route\
-        and returns the header location when successful', async() => {
+        it(c`doesn\'t update the UI when the project doesn\'t support timed metrics,
+        then POSTs to the project collections route
+        and returns the header location when successful`, async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns({
                 statusCode: 201,
@@ -159,9 +160,9 @@ describe('LoadRunner.js', () => {
             });
             output.should.equal('mockLocation');
         });
-        it('doesn\'t update the UI when the project doesn\'t support timed metrics,\
-        then POSTs to the project collections route when the project is in Kubernetes\
-        and returns the header location when successful', async() => {
+        it(c`doesn\'t update the UI when the project doesn\'t support timed metrics,
+        then POSTs to the project collections route when the project is in Kubernetes
+        and returns the header location when successful`, async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns({
                 statusCode: 201,
@@ -202,8 +203,8 @@ describe('LoadRunner.js', () => {
             });
             output.should.equal('mockLocation');
         });
-        it('POSTs to the project collections route\
-        then returns null when unsuccessful (400)', async() => {
+        it(c`POSTs to the project collections route
+        then returns null when unsuccessful (400)`, async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns({
                 statusCode: 400,
@@ -240,8 +241,8 @@ describe('LoadRunner.js', () => {
             logErrorSpy.should.have.been.calledOnceWithExactly('createCollection: too many metrics collections 400');
             should.equal(output, null);
         });
-        it('POSTs to the project collections route\
-        then returns null when res.statusCode is unexpected (e.g. 499)', async() => {
+        it(c`POSTs to the project collections route
+        then returns null when res.statusCode is unexpected (e.g. 499)`, async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns({
                 statusCode: 499,
@@ -284,9 +285,9 @@ describe('LoadRunner.js', () => {
             on: () => {},
             connect: () => {},
         });
-        it('GETs from the project collections route\
-        then does nothing when the status code is unexpected\
-        then doesn\'t DELETE the collection when the project supports timed collections', async() => {
+        it(c`GETs from the project collections route
+        then does nothing when the status code is unexpected
+        then doesn\'t DELETE the collection when the project supports timed collections`, async() => {
             // arrange
             const httpRequestStub = sandbox.stub().returns({
                 statusCode: 299,

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -28,6 +28,8 @@ chai.use(chaiSubset);
 chai.use(deepEqualInAnyOrder);
 const should = chai.should();
 
+const pathToLoadRunnerJs = '../../../../src/pfe/portal/modules/LoadRunner';
+
 describe('LoadRunner.js', () => {
     let sandbox;
     before(() => {
@@ -44,10 +46,10 @@ describe('LoadRunner.js', () => {
                 on: () => {},
                 connect: ioConnectStub,
             });
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/Logger': MockLogger,
-            }); 
+            });
 
             // act
             const loadRunner = new LoadRunner('mockUser');
@@ -82,16 +84,16 @@ describe('LoadRunner.js', () => {
                 headers: { location: 'mockLocation' },
             });
             const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': cwUtilsStub,
                 './utils/Logger': MockLogger,
-            });  
-            const mockUser = { 
+            });
+            const mockUser = {
                 uiSocket: { emit: sandbox.stub() },
             };
             const loadRunner = new LoadRunner(mockUser);
-            const mockProject = { 
+            const mockProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
                 host: 'mockHost',
                 getMetricsContextRoot: () => 'mockMetricsContextRoot',
@@ -99,7 +101,7 @@ describe('LoadRunner.js', () => {
             };
             loadRunner.project = mockProject;
             loadRunner.metricsFeatures = { timedMetrics: false };
-            
+
             // act
             const output = await loadRunner.createCollection();
 
@@ -125,16 +127,16 @@ describe('LoadRunner.js', () => {
                 headers: { location: 'mockLocation' },
             });
             const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': cwUtilsStub,
                 './utils/Logger': MockLogger,
-            });  
+            });
             const mockUser = {
                 uiSocket: { emit: sandbox.stub() },
             };
             const loadRunner = new LoadRunner(mockUser);
-            const mockProject = { 
+            const mockProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
                 host: 'mockHost',
                 getMetricsContextRoot: () => 'mockMetricsContextRoot',
@@ -143,7 +145,7 @@ describe('LoadRunner.js', () => {
             loadRunner.project = mockProject;
             loadRunner.metricsFeatures = { timedMetrics: true };
             const seconds = 500;
-            
+
             // act
             const output = await loadRunner.createCollection(seconds);
 
@@ -166,16 +168,16 @@ describe('LoadRunner.js', () => {
                 headers: { location: 'mockLocation' },
             });
             const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': cwUtilsStub,
                 './utils/Logger': MockLogger,
-            });  
+            });
             const mockUser = {
                 uiSocket: { emit: sandbox.stub() },
             };
             const loadRunner = new LoadRunner(mockUser);
-            const mockProject = { 
+            const mockProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
                 host: 'mockHost',
                 getMetricsContextRoot: () => 'mockMetricsContextRoot',
@@ -186,7 +188,7 @@ describe('LoadRunner.js', () => {
             loadRunner.project = mockProject;
             loadRunner.metricsFeatures = { timedMetrics: true };
             const seconds = 500;
-            
+
             // act
             const output = await loadRunner.createCollection(seconds);
 
@@ -208,23 +210,23 @@ describe('LoadRunner.js', () => {
             });
             const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
             const logErrorSpy = sandbox.spy(MockLogger.prototype, 'error');
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': cwUtilsStub,
                 './utils/Logger': MockLogger,
-            });  
+            });
             const mockUser = {
                 uiSocket: { emit: () => {} },
             };
             const loadRunner = new LoadRunner(mockUser);
-            const mockProject = { 
+            const mockProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
                 host: 'mockHost',
                 getMetricsContextRoot: () => 'mockMetricsContextRoot',
                 getPort: () => 'mockPort',
             };
             loadRunner.project = mockProject;
-            
+
             // act
             const output = await loadRunner.createCollection();
 
@@ -239,30 +241,30 @@ describe('LoadRunner.js', () => {
             should.equal(output, null);
         });
         it('POSTs to the project collections route\
-        then returns null when res.statusCode is unexpected', async() => {
+        then returns null when res.statusCode is unexpected (e.g. 499)', async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns({
                 statusCode: 499,
             });
             const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
             const logErrorSpy = sandbox.spy(MockLogger.prototype, 'error');
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': cwUtilsStub,
                 './utils/Logger': MockLogger,
-            });  
+            });
             const mockUser = {
                 uiSocket: { emit: () => {} },
             };
             const loadRunner = new LoadRunner(mockUser);
-            const mockProject = { 
+            const mockProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
                 host: 'mockHost',
                 getMetricsContextRoot: () => 'mockMetricsContextRoot',
                 getPort: () => 'mockPort',
             };
             loadRunner.project = mockProject;
-            
+
             // act
             const output = await loadRunner.createCollection();
 
@@ -286,7 +288,12 @@ describe('LoadRunner.js', () => {
         then does nothing when the status code is unexpected\
         then doesn\'t DELETE the collection when the project supports timed collections', async() => {
             // arrange
-            const httpRequestStub = sandbox.stub().returns({ statusCode: 299, on: () => ({ end: () => {} }) });
+            const httpRequestStub = sandbox.stub().returns({
+                statusCode: 299,
+                on: () => ({
+                    end: () => {},
+                }),
+            });
             const httpStub = {
                 request: httpRequestStub,
             };
@@ -294,14 +301,14 @@ describe('LoadRunner.js', () => {
                 statusCode: 201,
                 headers: { location: 'mockLocation' },
             });
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 http: httpStub,
                 './utils/sharedFunctions': { asyncHttpRequest: asyncHttpRequestStub },
                 './utils/Logger': MockLogger,
-            });  
+            });
             const loadRunner = new LoadRunner('mockUser');
-            const mockProject = { 
+            const mockProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
                 host: 'mockHost',
                 getMetricsContextRoot: () => 'mockMetricsContextRoot',
@@ -310,7 +317,7 @@ describe('LoadRunner.js', () => {
             loadRunner.project = mockProject;
             loadRunner.collectionUri = 'mockCollectionUri';
             loadRunner.metricsFeatures = { timedMetrics: false };
-            
+
             // act
             const output = await loadRunner.recordCollection();
 
@@ -337,29 +344,29 @@ describe('LoadRunner.js', () => {
         });
         it('throws the correct error when loadRunner already has a project', async() => {
             // arrange
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/Logger': MockLogger,
-            });  
+            });
             const loadRunner = new LoadRunner('mockUser');
-            const mockProject = { 
+            const mockProject = {
                 name: 'mockName',
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
             };
             loadRunner.project = mockProject;
-            
+
             // act & assert
             await loadRunner.runLoad().should.eventually.be.rejectedWith(`Load run already in progress.\nFor project ${mockProject.name} (${mockProject.projectID})`);
         });
         it('throws the correct error when loadRunner is not up', async() => {
             // arrange
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/Logger': MockLogger,
-            });  
+            });
             const loadRunner = new LoadRunner('mockUser');
             // by default, loadRunner.up === false
-            
+
             // act & assert
             await loadRunner.runLoad().should.eventually.be.rejectedWith('Load Runner service is not available');
         });
@@ -372,24 +379,24 @@ describe('LoadRunner.js', () => {
         it('throws the correct error when loadRunner\'s request to cancel load errors', async() => {
             // arrange
             const asyncHttpRequestStub = () => { throw new Error('error cancelling load'); };
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': { asyncHttpRequest: asyncHttpRequestStub },
                 './utils/Logger': MockLogger,
-            });  
+            });
             const loadRunner = new LoadRunner('mockUser');
-            
+
             // act & assert
             await loadRunner.cancelRunLoad().should.eventually.be.rejectedWith('Load Runner service is not available');
         });
         it('returns the response to the request to cancel load when it doesn\'t error', async() => {
             // arrange
             const asyncHttpRequestStub = sandbox.stub().returns('mockCancelLoadResponse');
-            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+            const LoadRunner = proxyquire(pathToLoadRunnerJs, {
                 'socket.io-client': mockIo,
                 './utils/sharedFunctions': { asyncHttpRequest: asyncHttpRequestStub },
                 './utils/Logger': MockLogger,
-            });  
+            });
             const loadRunner = new LoadRunner('mockUser');
             const expectedOptions = {
                 host: 'codewind-performance',
@@ -400,10 +407,10 @@ describe('LoadRunner.js', () => {
                     'Content-Type': 'application/json',
                 },
             };
-            
+
             // act
             const output = await loadRunner.cancelRunLoad('mockLoadConfig');
-            
+
             // assert
             asyncHttpRequestStub.should.have.been.calledOnceWithExactly(expectedOptions, 'mockLoadConfig');
             output.should.equal('mockCancelLoadResponse');

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const chai = require('chai');
+const chaiSubset = require('chai-subset');
+const deepEqualInAnyOrder = require('deep-equal-in-any-order');
+
+/* eslint-disable class-methods-use-this */
+class MockLogger {
+    error() {}
+    warn() {}
+    info() {}
+    debug() {}
+    trace() {}
+};
+/* eslint-enable class-methods-use-this */
+
+chai.use(chaiSubset);
+chai.use(deepEqualInAnyOrder);
+const should = chai.should();
+
+describe('LoadRunner.js', () => {
+    let sandbox;
+    before(() => {
+        sandbox = sinon.createSandbox();
+    });
+    beforeEach(() => {
+        sandbox.restore();
+    });
+    describe('new LoadRunner(user)', () => {
+        it('returns a new LoadRunner and connects to the loadrunner container socket', () => {
+            // arrange
+            const ioConnectStub = sandbox.stub();
+            const mockIo = () => ({
+                on: () => {},
+                connect: ioConnectStub,
+            });
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/Logger': MockLogger,
+            }); 
+
+            // act
+            const loadRunner = new LoadRunner('mockUser');
+
+            // assert
+            loadRunner.should.containSubset({
+                user: 'mockUser',
+                hostname: 'codewind-performance',
+                port: '9095',
+                project: null,
+                runDescription: null,
+                up: false,
+                collectionUri: null,
+                profilingSocket: null,
+                metricsFeatures: {},
+            });
+            loadRunner.socket.should.not.be.null;
+            ioConnectStub.should.have.been.calledOnce;
+        });
+    });
+    describe('createCollection(seconds)', () => {
+        const mockIo = () => ({
+            on: () => {},
+            connect: () => {},
+        });
+        it('updates the UI when the project supports timed metrics,\
+        then POSTs to the project collections route\
+        and returns the header location when successful', async() => {
+            // arrange
+            const asyncHttpRequestStub = sandbox.stub().returns({
+                statusCode: 201,
+                headers: { location: 'mockLocation' },
+            });
+            const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': cwUtilsStub,
+                './utils/Logger': MockLogger,
+            });  
+            const mockUser = { 
+                uiSocket: { emit: sandbox.stub() },
+            };
+            const loadRunner = new LoadRunner(mockUser);
+            const mockProject = { 
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                host: 'mockHost',
+                getMetricsContextRoot: () => 'mockMetricsContextRoot',
+                getPort: () => 'mockPort',
+            };
+            loadRunner.project = mockProject;
+            loadRunner.metricsFeatures = { timedMetrics: false };
+            
+            // act
+            const output = await loadRunner.createCollection();
+
+            // assert
+            loadRunner.user.uiSocket.emit.should.have.been.calledOnceWithExactly('runloadStatusChanged', {
+                projectID: mockProject.projectID,
+                status: 'app-is-using-old-metrics',
+            });
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly({
+                host: 'mockHost',
+                port: 'mockPort',
+                path: '/mockMetricsContextRoot/api/v1/collections',
+                method: 'POST',
+            });
+            output.should.equal('mockLocation');
+        });
+        it('doesn\'t update the UI when the project doesn\'t support timed metrics,\
+        then POSTs to the project collections route\
+        and returns the header location when successful', async() => {
+            // arrange
+            const asyncHttpRequestStub = sandbox.stub().returns({
+                statusCode: 201,
+                headers: { location: 'mockLocation' },
+            });
+            const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': cwUtilsStub,
+                './utils/Logger': MockLogger,
+            });  
+            const mockUser = {
+                uiSocket: { emit: sandbox.stub() },
+            };
+            const loadRunner = new LoadRunner(mockUser);
+            const mockProject = { 
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                host: 'mockHost',
+                getMetricsContextRoot: () => 'mockMetricsContextRoot',
+                getPort: () => 'mockPort',
+            };
+            loadRunner.project = mockProject;
+            loadRunner.metricsFeatures = { timedMetrics: true };
+            const seconds = 500;
+            
+            // act
+            const output = await loadRunner.createCollection(seconds);
+
+            // assert
+            loadRunner.user.uiSocket.emit.should.not.have.been.called;
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly({
+                host: 'mockHost',
+                port: 'mockPort',
+                path: `/mockMetricsContextRoot/api/v1/collections/${seconds}`,
+                method: 'POST',
+            });
+            output.should.equal('mockLocation');
+        });
+        it('doesn\'t update the UI when the project doesn\'t support timed metrics,\
+        then POSTs to the project collections route when the project is in Kubernetes\
+        and returns the header location when successful', async() => {
+            // arrange
+            const asyncHttpRequestStub = sandbox.stub().returns({
+                statusCode: 201,
+                headers: { location: 'mockLocation' },
+            });
+            const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': cwUtilsStub,
+                './utils/Logger': MockLogger,
+            });  
+            const mockUser = {
+                uiSocket: { emit: sandbox.stub() },
+            };
+            const loadRunner = new LoadRunner(mockUser);
+            const mockProject = { 
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                host: 'mockHost',
+                getMetricsContextRoot: () => 'mockMetricsContextRoot',
+                getPort: () => 'mockPort',
+                kubeServiceHost: 'mockKubeServiceHost',
+                kubeServicePort: 'mockKubeServicePort',
+            };
+            loadRunner.project = mockProject;
+            loadRunner.metricsFeatures = { timedMetrics: true };
+            const seconds = 500;
+            
+            // act
+            const output = await loadRunner.createCollection(seconds);
+
+            // assert
+            loadRunner.user.uiSocket.emit.should.not.have.been.called;
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly({
+                host: 'mockKubeServiceHost',
+                port: 'mockKubeServicePort',
+                path: `/mockMetricsContextRoot/api/v1/collections/${seconds}`,
+                method: 'POST',
+            });
+            output.should.equal('mockLocation');
+        });
+        it('POSTs to the project collections route\
+        then returns null when unsuccessful (400)', async() => {
+            // arrange
+            const asyncHttpRequestStub = sandbox.stub().returns({
+                statusCode: 400,
+            });
+            const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
+            const logErrorSpy = sandbox.spy(MockLogger.prototype, 'error');
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': cwUtilsStub,
+                './utils/Logger': MockLogger,
+            });  
+            const mockUser = {
+                uiSocket: { emit: () => {} },
+            };
+            const loadRunner = new LoadRunner(mockUser);
+            const mockProject = { 
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                host: 'mockHost',
+                getMetricsContextRoot: () => 'mockMetricsContextRoot',
+                getPort: () => 'mockPort',
+            };
+            loadRunner.project = mockProject;
+            
+            // act
+            const output = await loadRunner.createCollection();
+
+            // assert
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly({
+                host: 'mockHost',
+                port: 'mockPort',
+                path: '/mockMetricsContextRoot/api/v1/collections',
+                method: 'POST',
+            });
+            logErrorSpy.should.have.been.calledOnceWithExactly('createCollection: too many metrics collections 400');
+            should.equal(output, null);
+        });
+        it('POSTs to the project collections route\
+        then returns null when res.statusCode is unexpected', async() => {
+            // arrange
+            const asyncHttpRequestStub = sandbox.stub().returns({
+                statusCode: 499,
+            });
+            const cwUtilsStub = { asyncHttpRequest: asyncHttpRequestStub };
+            const logErrorSpy = sandbox.spy(MockLogger.prototype, 'error');
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': cwUtilsStub,
+                './utils/Logger': MockLogger,
+            });  
+            const mockUser = {
+                uiSocket: { emit: () => {} },
+            };
+            const loadRunner = new LoadRunner(mockUser);
+            const mockProject = { 
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                host: 'mockHost',
+                getMetricsContextRoot: () => 'mockMetricsContextRoot',
+                getPort: () => 'mockPort',
+            };
+            loadRunner.project = mockProject;
+            
+            // act
+            const output = await loadRunner.createCollection();
+
+            // assert
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly({
+                host: 'mockHost',
+                port: 'mockPort',
+                path: '/mockMetricsContextRoot/api/v1/collections',
+                method: 'POST',
+            });
+            logErrorSpy.should.have.been.calledOnceWithExactly('createCollection: unable to create metrics collection: 499');
+            should.equal(output, null);
+        });
+    });
+    describe('recordCollection()', () => {
+        const mockIo = () => ({
+            on: () => {},
+            connect: () => {},
+        });
+        it('GETs from the project collections route\
+        then does nothing when the status code is unexpected\
+        then doesn\'t DELETE the collection when the project supports timed collections', async() => {
+            // arrange
+            const httpRequestStub = sandbox.stub().returns({ statusCode: 299, on: () => ({ end: () => {} }) });
+            const httpStub = {
+                request: httpRequestStub,
+            };
+            const asyncHttpRequestStub = sandbox.stub().returns({
+                statusCode: 201,
+                headers: { location: 'mockLocation' },
+            });
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                http: httpStub,
+                './utils/sharedFunctions': { asyncHttpRequest: asyncHttpRequestStub },
+                './utils/Logger': MockLogger,
+            });  
+            const loadRunner = new LoadRunner('mockUser');
+            const mockProject = { 
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                host: 'mockHost',
+                getMetricsContextRoot: () => 'mockMetricsContextRoot',
+                getPort: () => 'mockPort',
+            };
+            loadRunner.project = mockProject;
+            loadRunner.collectionUri = 'mockCollectionUri';
+            loadRunner.metricsFeatures = { timedMetrics: false };
+            
+            // act
+            const output = await loadRunner.recordCollection();
+
+            // assert
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly({
+                method: 'GET',
+                host: 'mockHost',
+                port: 'mockPort',
+                path: '/mockMetricsContextRoot/api/v1/mockCollectionUri',
+            });
+            httpRequestStub.should.have.been.calledWithMatch({
+                method: 'DELETE',
+                host: 'mockHost',
+                port: 'mockPort',
+                path: '/mockMetricsContextRoot/api/v1/mockCollectionUri',
+            });
+            should.equal(output, undefined); // eslint-disable-line no-undefined
+        });
+    });
+    describe('runLoad(loadConfig, targetProject, runDesc)', () => {
+        const mockIo = () => ({
+            on: () => {},
+            connect: () => {},
+        });
+        it('throws the correct error when loadRunner already has a project', async() => {
+            // arrange
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/Logger': MockLogger,
+            });  
+            const loadRunner = new LoadRunner('mockUser');
+            const mockProject = { 
+                name: 'mockName',
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+            };
+            loadRunner.project = mockProject;
+            
+            // act & assert
+            await loadRunner.runLoad().should.eventually.be.rejectedWith(`Load run already in progress.\nFor project ${mockProject.name} (${mockProject.projectID})`);
+        });
+        it('throws the correct error when loadRunner is not up', async() => {
+            // arrange
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/Logger': MockLogger,
+            });  
+            const loadRunner = new LoadRunner('mockUser');
+            // by default, loadRunner.up === false
+            
+            // act & assert
+            await loadRunner.runLoad().should.eventually.be.rejectedWith('Load Runner service is not available');
+        });
+    });
+    describe('cancelRunLoad(loadConfig)', () => {
+        const mockIo = () => ({
+            on: () => {},
+            connect: () => {},
+        });
+        it('throws the correct error when loadRunner\'s request to cancel load errors', async() => {
+            // arrange
+            const asyncHttpRequestStub = () => { throw new Error('error cancelling load'); };
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': { asyncHttpRequest: asyncHttpRequestStub },
+                './utils/Logger': MockLogger,
+            });  
+            const loadRunner = new LoadRunner('mockUser');
+            
+            // act & assert
+            await loadRunner.cancelRunLoad().should.eventually.be.rejectedWith('Load Runner service is not available');
+        });
+        it('returns the response to the request to cancel load when it doesn\'t error', async() => {
+            // arrange
+            const asyncHttpRequestStub = sandbox.stub().returns('mockCancelLoadResponse');
+            const LoadRunner = proxyquire('../../../../src/pfe/portal/modules/LoadRunner', {
+                'socket.io-client': mockIo,
+                './utils/sharedFunctions': { asyncHttpRequest: asyncHttpRequestStub },
+                './utils/Logger': MockLogger,
+            });  
+            const loadRunner = new LoadRunner('mockUser');
+            const expectedOptions = {
+                host: 'codewind-performance',
+                port: '9095',
+                path: '/api/v1/cancelLoad',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+            };
+            
+            // act
+            const output = await loadRunner.cancelRunLoad('mockLoadConfig');
+            
+            // assert
+            asyncHttpRequestStub.should.have.been.calledOnceWithExactly(expectedOptions, 'mockLoadConfig');
+            output.should.equal('mockCancelLoadResponse');
+        });
+    });
+});


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
add the first unit tests for Portal's `LoadRunner.js`. There is still plenty to do when we have time.

I made a small functional change to LoadRunner.js - copying the `options` object before editing it. This is cleaner, and without the change, editing the `options` object interfered with the tests I'm adding in this PR.

These first unit tests provide a foundation on which we can easily add more tests. For example, this is the first time in any of our test files that we are using `sinon.sandbox` (see https://glebbahmutov.com/blog/mocha-and-sinon/) and spying on our logging function.

Coverage before:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/18170169/75565025-22b8c880-5a45-11ea-8dbe-74303a3a9ed0.png">

Coverage after:
![image](https://user-images.githubusercontent.com/18170169/75767174-424c3b80-5d3a-11ea-95fb-7094deb05e61.png)


## Which issue(s) does this PR fix ?
for #2232 

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
