### PR TITLE
test: stop test intermittently failing in Jenkins

### DIFF
--- a/test/src/API/projects/restart.test.js
+++ b/test/src/API/projects/restart.test.js
@@ -38,22 +38,28 @@ describe('Project Restart Tests (POST /projects/{id}/restart)', function() {
     });
 
     // Node can start in 'run' or 'debugNoInit' modes, but not 'debug'.
-    it('returns 400 when `restartMode` is `run` but project is still building', async function() {
+    it('returns 400 when `restartMode` is `run` but project has not started yet', async function() {
         this.timeout(testTimeout.short);
         const res = await projectService.restartProject(projectID, 'run');
 
         res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
-        res.body.message.should.equal(`Request error for project ${projectID}. Restart is invalid when the project is building.`);
+        res.body.message.should.be.oneOf([
+            `Request error for project ${projectID}. Restart is invalid when the project is building.`,
+            `Request error for project ${projectID}. Restart is valid only when project is starting or started.`,
+        ]);
     });
 
-    it('returns 400 when `restartMode` is `debugNoInit` but project is still building', async function() {
+    it('returns 400 when `restartMode` is `debugNoInit` but project has not started yet', async function() {
         this.timeout(testTimeout.short);
         const res = await projectService.restartProject(projectID, 'debugNoInit');
 
         res.status.should.equal(400, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
-        res.body.message.should.equal(`Request error for project ${projectID}. Restart is invalid when the project is building.`);
+        res.body.message.should.be.oneOf([
+            `Request error for project ${projectID}. Restart is invalid when the project is building.`,
+            `Request error for project ${projectID}. Restart is valid only when project is starting or started.`,
+        ]);
     });
 
     it('returns 400 when `restartMode` is `debug`', async function() {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
stops the PFE restart API test failing intermittently in Jenkins. Jenkins executes things at different speeds to local, so the error response can be one of two things on Jenkins. We were previously expecting only the first, so this PR relaxes the check to get the test passing

## Which issue(s) does this PR fix ?
None, just saw this failure on one of my PRs https://github.com/eclipse/codewind/pull/2352

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
