### PR TITLE
Fix eslint warnings on remoteBind.route.test.js

### DIFF
--- a/test/src/unit/routes/projects/remoteBind.route.test.js
+++ b/test/src/unit/routes/projects/remoteBind.route.test.js
@@ -122,31 +122,31 @@ describe('remoteBind.route.js', () => {
     });
     describe('isSubdirectory(dir1, dir2)', () => {
         const isSubdirectory = RemoteBind.__get__('isSubdirectory');
-        it('returns true as relative the file paths are equivalent (1)', async() => {
+        it('returns true as relative the file paths are equivalent (1)', () => {
             isSubdirectory('filepath/', 'filepath').should.be.true;
         });
-        it('returns true as relative the file paths are equivalent (2)', async() => {
+        it('returns true as relative the file paths are equivalent (2)', () => {
             isSubdirectory('filepath', 'filepath/').should.be.true;
         });
-        it('returns true as relative the file paths are equivalent (3)', async() => {
+        it('returns true as relative the file paths are equivalent (3)', () => {
             isSubdirectory('filepath', 'filepath').should.be.true;
         });
-        it('returns false as relative the file paths are different (1)', async() => {
+        it('returns false as relative the file paths are different (1)', () => {
             isSubdirectory('filepath', 'filepathextended').should.be.false;
         });
-        it('returns false as relative the file paths are different (2)', async() => {
+        it('returns false as relative the file paths are different (2)', () => {
             isSubdirectory('filepathextended', 'filepath').should.be.false;
         });
-        it('returns false as relative the file paths are different (3)', async() => {
+        it('returns false as relative the file paths are different (3)', () => {
             isSubdirectory('.filepath', 'filepath').should.be.false;
         });
-        it('returns false as a relative path and an absolute path are different', async() => {
+        it('returns false as a relative path and an absolute path are different', () => {
             isSubdirectory('/filepath', 'filepath').should.be.false;
         });
-        it('returns true as filepath/subdirectory is a subdirectory of filepath', async() => {
+        it('returns true as filepath/subdirectory is a subdirectory of filepath', () => {
             isSubdirectory('filepath/subdirectory', 'filepath').should.be.true;
         });
-        it('returns false as filepath is not a subdirectory of filepath/subdirectory', async() => {
+        it('returns false as filepath is not a subdirectory of filepath/subdirectory', () => {
             isSubdirectory('filepath', 'filepath/subdirectory').should.be.false;
         });
     });


### PR DESCRIPTION
Signed-off-by: Matthew Colegate <colegate@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes `eslint` warnings for the remoteBind unit test.
Before:
```
$ npm run-script eslint

> codewind-test@1.0.0 eslint C:\Users\MattColegate\Desktop\GitRepos\mattcolegate\codewind\test
> eslint src/**/*.js

C:\Users\MattColegate\Desktop\GitRepos\mattcolegate\codewind\test\src\unit\routes\projects\remoteBind.route.test.js
  125:82  warning  Async arrow function has no 'await' expression  require-await
  128:82  warning  Async arrow function has no 'await' expression  require-await
  131:82  warning  Async arrow function has no 'await' expression  require-await
  134:82  warning  Async arrow function has no 'await' expression  require-await
  137:82  warning  Async arrow function has no 'await' expression  require-await
  140:82  warning  Async arrow function has no 'await' expression  require-await
  143:91  warning  Async arrow function has no 'await' expression  require-await
  146:91  warning  Async arrow function has no 'await' expression  require-await
  149:96  warning  Async arrow function has no 'await' expression  require-await

✖ 9 problems (9 warnings)
```

After:
```
$ npm run-script eslint

> codewind-test@1.0.0 eslint C:\Users\MattColegate\Desktop\GitRepos\mattcolegate\codewind\test
> eslint src/**/*.js

```



## Which issue(s) does this PR fix ?
None - noticed during testing

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
N/A

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
None