### PR TITLE
Remove os.tmpdir from Registry Secret API Tests

### DIFF
--- a/test/src/API/registrySecrets.test.js
+++ b/test/src/API/registrySecrets.test.js
@@ -54,6 +54,8 @@ describe('Registry Secrets route tests', function() {
     
     before('Create a backup of the existing /root/.docker/config.json file', async function() {
         this.timeout(testTimeout.med);
+        // Create the temp directory
+        await fs.ensureDir(tempDir);
 
          // Create a backup of existing docker registry file
         if (await containerService.fileExists(docker_registry_file)) {
@@ -61,9 +63,6 @@ describe('Registry Secrets route tests', function() {
             restoreConfig = true;
             await containerService.removeDir(docker_registry_file);
         }
-
-        // Create the temp directory
-        await fs.ensureDir(tempDir);
     });
 
     after('Restore /root/.docker/config.json file', async function() {

--- a/test/src/API/registrySecrets.test.js
+++ b/test/src/API/registrySecrets.test.js
@@ -11,7 +11,6 @@
 
 const chai = require('chai');
 const fs = require('fs');
-const os = require('os');
 const path = require('path');
 const reqService = require('../../modules/request.service');
 const containerService = require('../../modules/container.service');
@@ -34,7 +33,7 @@ const removeRegistrySecret = (dockerAddress) => reqService.chai
     .send({ address: dockerAddress });
 
 describe('Registry Secrets route tests', function() {
-
+    const tempDir = path.join(__dirname, 'registrySecretsTemp');
     const docker_registry_file = '/root/.docker/config.json';
     const docker_registry_secret_garbage_json = {
         auths: {
@@ -58,7 +57,7 @@ describe('Registry Secrets route tests', function() {
 
          // Create a backup of existing docker registry file
         if (await containerService.fileExists(docker_registry_file)) {
-            await containerService.copyFrom(docker_registry_file, path.join(os.tmpdir(), 'config_bk.json'));
+            await containerService.copyFrom(docker_registry_file, path.join(tempDir, 'config_bk.json'));
             restoreConfig = true;
             await containerService.removeDir(docker_registry_file);
         }
@@ -70,7 +69,7 @@ describe('Registry Secrets route tests', function() {
 
         // Restore the docker registry file backup
         if (restoreConfig) {
-            await containerService.copyTo(path.join(os.tmpdir(), 'config_bk.json'), docker_registry_file);
+            await containerService.copyTo(path.join(tempDir, 'config_bk.json'), docker_registry_file);
         }
     });
 
@@ -88,7 +87,7 @@ describe('Registry Secrets route tests', function() {
 
             // create a docker registry with the garbage content
             const docker_registry_secret_garbage_content = JSON.stringify(docker_registry_secret_garbage_json);
-            const docker_registry_secret_garbage_file = path.join(os.tmpdir(), 'config.json');
+            const docker_registry_secret_garbage_file = path.join(tempDir, 'config.json');
             fs.writeFileSync(docker_registry_secret_garbage_file, docker_registry_secret_garbage_content, 'utf8');
             await containerService.copyTo(docker_registry_secret_garbage_file, docker_registry_file);
 
@@ -102,7 +101,7 @@ describe('Registry Secrets route tests', function() {
 
             let docker_registry_secret_bad_content = JSON.stringify(docker_registry_secret_garbage_json);
             docker_registry_secret_bad_content = docker_registry_secret_bad_content.concat('garbage');
-            const docker_registry_secret_bad_file = path.join(os.tmpdir(), 'config.json');
+            const docker_registry_secret_bad_file = path.join(tempDir, 'config.json');
             fs.writeFileSync(docker_registry_secret_bad_file, docker_registry_secret_bad_content, 'utf8');
             await containerService.copyTo(docker_registry_secret_bad_file, docker_registry_file);
 
@@ -194,7 +193,7 @@ describe('Registry Secrets route tests', function() {
 
             let docker_registry_secret_bad_content = JSON.stringify(docker_registry_secret_garbage_json);
             docker_registry_secret_bad_content = docker_registry_secret_bad_content.concat('garbage');
-            const docker_registry_secret_bad_file = path.join(os.tmpdir(), 'config.json');
+            const docker_registry_secret_bad_file = path.join(tempDir, 'config.json');
             fs.writeFileSync(docker_registry_secret_bad_file, docker_registry_secret_bad_content, 'utf8');
             await containerService.copyTo(docker_registry_secret_bad_file, docker_registry_file);
 
@@ -270,7 +269,7 @@ describe('Registry Secrets route tests', function() {
             
             let docker_registry_secret_bad_content = JSON.stringify(docker_registry_secret_garbage_json);
             docker_registry_secret_bad_content = docker_registry_secret_bad_content.concat('garbage');
-            const docker_registry_secret_bad_file = path.join(os.tmpdir(), 'config.json');
+            const docker_registry_secret_bad_file = path.join(tempDir, 'config.json');
             fs.writeFileSync(docker_registry_secret_bad_file, docker_registry_secret_bad_content, 'utf8');
             await containerService.copyTo(docker_registry_secret_bad_file, docker_registry_file);
 
@@ -285,7 +284,7 @@ describe('Registry Secrets route tests', function() {
             this.timeout(testTimeout.med);
             
             const docker_registry_secret_garbage_content = JSON.stringify(docker_registry_secret_garbage_json);
-            const docker_registry_secret_garbage_file = path.join(os.tmpdir(), 'config.json');
+            const docker_registry_secret_garbage_file = path.join(tempDir, 'config.json');
             fs.writeFileSync(docker_registry_secret_garbage_file, docker_registry_secret_garbage_content, 'utf8');
             await containerService.copyTo(docker_registry_secret_garbage_file, docker_registry_file);
 

--- a/test/src/API/registrySecrets.test.js
+++ b/test/src/API/registrySecrets.test.js
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 const chai = require('chai');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const reqService = require('../../modules/request.service');
 const containerService = require('../../modules/container.service');
@@ -61,7 +61,9 @@ describe('Registry Secrets route tests', function() {
             restoreConfig = true;
             await containerService.removeDir(docker_registry_file);
         }
-        
+
+        // Create the temp directory
+        await fs.ensureDir(tempDir);
     });
 
     after('Restore /root/.docker/config.json file', async function() {
@@ -71,6 +73,9 @@ describe('Registry Secrets route tests', function() {
         if (restoreConfig) {
             await containerService.copyTo(path.join(tempDir, 'config_bk.json'), docker_registry_file);
         }
+
+        // Remove the temp directory
+        await fs.remove(tempDir);
     });
 
     describe('GET /api/v1/registrysecrets', function() {


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Removes the use of `os.tmpDir()` from the Registry Secret API tests as they are failing on Jenkins. This we have a partial build failure as they only seem to fail on the `ub18-01` machine and not the 
`s8p2d-ubuntu1804` machine.

Failing PR builds:
https://ci.eclipse.org/codewind/job/Codewind/job/codewind/job/PR-2392/6/consoleText
https://ci.eclipse.org/codewind/job/Codewind/job/codewind/job/PR-2392/4/consoleText

https://ci.eclipse.org/codewind/job/Codewind/job/codewind/job/PR-2387/3/consoleText

https://ci.eclipse.org/codewind/job/Codewind/job/codewind/job/PR-2376/4/consoleText

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: N/A

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
