### PR TITLE
Copy docker credentials from docker secret when running locally via docker-compose

### DIFF
--- a/src/pfe/file-watcher/scripts/root-watcher.sh
+++ b/src/pfe/file-watcher/scripts/root-watcher.sh
@@ -99,4 +99,10 @@ if [ "$IN_K8" == "true" ]; then
 		echo "Creating the Codewind PFE Docker Config with the secret .dockerconfigjson data"
 		kubectl get secret $SECRET_NAME -o jsonpath="{.data.\.dockerconfigjson}" | base64 --decode > /root/.docker/config.json
 	fi
+else
+   # If a docker secrets file exists copy that into the docker config file.
+   # This handles local docker container restarts.
+   if test -f "/run/secrets/dockerconfig"; then
+     cat /run/secrets/dockerconfig | base64 --decode > /root/.docker/config.json
+   fi
 fi

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -732,7 +732,7 @@ module.exports = class User {
           "auth":encodedAuth
         }
 
-        await fs.writeJson(this.dockerConfigFile, jsonObj);
+        await fs.writeJson(this.dockerConfigFile, jsonObj, {spaces: 2});
       } else {
         log.info("The Docker config file does not exist, writing the contents");
         jsonObj = {"auths":{}}
@@ -742,7 +742,7 @@ module.exports = class User {
           "auth":encodedAuth
         }
 
-        await fs.writeJson(this.dockerConfigFile, jsonObj);
+        await fs.writeJson(this.dockerConfigFile, jsonObj, {spaces: 2});
       }
       // Update the registrySecretList to send back to the caller
       const registrySecret = {
@@ -774,7 +774,7 @@ module.exports = class User {
     
     // Since patching the Service Account failed, we need to revert the update to the Docker Config and patch the Service Account again
     delete jsonObj.auths[address];
-    await fs.writeJson(this.dockerConfigFile, jsonObj);
+    await fs.writeJson(this.dockerConfigFile, jsonObj, {spaces: 2} );
     await this.updateServiceAccountWithDockerRegisrySecret();
 
     throw new RegistrySecretsError(serviceAccountPatchData, "for address " + address);
@@ -938,7 +938,7 @@ module.exports = class User {
           throw new RegistrySecretsError("SECRET_DELETE_MISSING", "for address " + address);
         }
 
-        await fs.writeJson(this.dockerConfigFile, jsonObj);
+        await fs.writeJson(this.dockerConfigFile, jsonObj, {spaces: 2});
         log.info("The Docker config file has been updated for removal of " + address);
       } else {
         // return if there is no Docker Config file, no need to create new Kubernetes Secret or patch the Service Account
@@ -967,7 +967,7 @@ module.exports = class User {
 
     // Since patching the Service Account failed, we need to revert the delete from the Docker Config and patch the Service Account again
     jsonObj.auths[address] = registrySecretToBeDeleted;
-    await fs.writeJson(this.dockerConfigFile, jsonObj);
+    await fs.writeJson(this.dockerConfigFile, jsonObj, {spaces: 2});
     await this.updateServiceAccountWithDockerRegisrySecret();
 
     throw new RegistrySecretsError(serviceAccountPatchData, "for address " + address);


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
Copies docker credentials from `/var/run/secrets/dockerconfig` secret when PFE is running in local docker. (Similarly to how docker credentials are copied from a Kubernetes secret when running in Kube.)

## Which issue(s) does this PR fix ?
This is part of https://github.com/eclipse/codewind/issues/1306

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/1306

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
This PR needs the change in codewind-installer https://github.com/eclipse/codewind-installer/pull/394 in order to be useful. (They can be merged independently but can't be tested without each other as one creates the secret and the other reads it.)