### PR TITLE
Have the ability to enable/disable ssl on functional tests for che >=7.9.0

### DIFF
--- a/src/pfe/file-watcher/server/test/scripts/exec.sh
+++ b/src/pfe/file-watcher/server/test/scripts/exec.sh
@@ -57,7 +57,7 @@ function setupRegistrySecret() {
     ENCODED_CREDENTIALS=$( node ./scripts/utils.js encode $REGISTRY_SECRET_USERNAME $REGISTRY_SECRET_PASSWORD )
     checkExitCode $? "Test setup failed during Registry Secret's base64 credential encode."
 
-    REGISTRY_SECRET_SETUP_CURL_API="curl -d '{\"address\": \"$REGISTRY_SECRET_ADDRESS\", \"credentials\": \"$ENCODED_CREDENTIALS\"}' -H \"Content-Type: application/json\" -X POST https://localhost:9191/api/v1/registrysecrets -k"
+    REGISTRY_SECRET_SETUP_CURL_API="curl -k -d '{\"address\": \"$REGISTRY_SECRET_ADDRESS\", \"credentials\": \"$ENCODED_CREDENTIALS\"}' -H \"Content-Type: application/json\" -X POST https://localhost:9191/api/v1/registrysecrets -k"
     kubectl exec -i $CODEWIND_POD_ID -- bash -c "$REGISTRY_SECRET_SETUP_CURL_API"
 }
 

--- a/src/pfe/file-watcher/server/test/scripts/utils.sh
+++ b/src/pfe/file-watcher/server/test/scripts/utils.sh
@@ -22,10 +22,15 @@ export TEST_INFO_DIR="$HOME/.codewindtest/turbine"
 # Function to get the che and keycloak endpoint
 function getEndpoints() {
     echo -e "${BLUE}Getting che endpoints${RESET}\n"
+    if [ ! -z "$DISABLE_SSL" ]; then
+        PROTOCOL="http://"
+    else
+        PROTOCOL="https://"
+    fi
 
-    CHE_ENDPOINT=$(kubectl get routes --selector=component=che -o jsonpath="{.items[0].spec.host}" 2>&1)
-    KEYCLOAK_HOSTNAME=$(kubectl get routes --selector=component=keycloak -o jsonpath="{.items[0].spec.host}" 2>&1)
-    TOKEN_ENDPOINT="http://${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token"
+    CHE_ENDPOINT="${PROTOCOL}$(kubectl get routes --selector=component=che -o jsonpath="{.items[0].spec.host}" 2>&1)"
+    KEYCLOAK_HOSTNAME="${PROTOCOL}$(kubectl get routes --selector=component=keycloak -o jsonpath="{.items[0].spec.host}" 2>&1)"
+    TOKEN_ENDPOINT="${KEYCLOAK_HOSTNAME}/auth/realms/che/protocol/openid-connect/token"
 }
 
 # Function to generate the Che Access Token for Che User Authentication
@@ -36,7 +41,7 @@ function generateCheAccessToken {
 
     getEndpoints
 
-    CHE_ACCESS_TOKEN=$(curl -sSL --data "grant_type=password&client_id=che-public&username=${CHE_USER}&password=${CHE_PASS}" ${TOKEN_ENDPOINT} | jq -r '.access_token')
+    CHE_ACCESS_TOKEN=$(curl -k -sSL --data "grant_type=password&client_id=che-public&username=${CHE_USER}&password=${CHE_PASS}" ${TOKEN_ENDPOINT} | jq -r '.access_token')
 }
 
 function checkExitCode() {


### PR DESCRIPTION
Signed-off-by: ssh24 <sakib@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds the ability to enable/disable ssl on functional tests since moving upto che requires SSL by default. Users can disable by setting `DISABLE_SSL=true` before running test

Related to https://github.com/eclipse/codewind/issues/2416
