### PR TITLE
Make project build endpoint return JSON

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -114,26 +114,29 @@ paths:
                   enum: [ build, enableautobuild, disableautobuild ]
       responses:
         202:
-          description: Build successful
+          description: Build / Toggle Auto Build successful
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                  projectID:
-                    $ref: '#/components/schemas/ProjectID'
-                  action:
-                    description: 'Action for build'
-                    type: string
-                    enum: [ build, enableautobuild, disableautobuild ]
+                $ref: '#/components/schemas/BuildActionResponse'
         400:
-          description: Unknown action or Project not found
+          description: Invalid action
           content:
-            text/html:
+            text/plain:
               schema:
                 type: string
+        404:
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildActionResponse'
+        409:
+          description: Action not valid for project state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildActionResponse'
         500:
           description: Internal error
 
@@ -2238,6 +2241,20 @@ components:
     PfeLogLevel:
       type: string
       enum: ['trace', 'debug', 'info', 'warn', 'error']
+    BuildActionResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        status:
+          type: string
+          enum: [ accepted, failed ]
+        projectID:
+          $ref: '#/components/schemas/ProjectID'
+        action:
+          description: 'Build action'
+          type: string
+          enum: [ build, enableautobuild, disableautobuild ]
 
   responses:
     400:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1252,7 +1252,7 @@ paths:
     put:
       summary: Overwrite the default logging level of the Portal container
       requestBody:
-        description: Location on disk
+        description: New log level to use
         content:
           application/json:
             schema:
@@ -1266,9 +1266,11 @@ paths:
         200:
           description: Successful
           content:
-            text/html:
+            application/json:
               schema:
-                type: string
+                properties:
+                  level:
+                    $ref: '#/components/schemas/PfeLogLevel'
         400:
           description: Bad request
           content:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -111,14 +111,23 @@ paths:
                 action:
                   description: 'Action for build'
                   type: string
-                  enum: [build, enableautobuild, disableautobuild]
+                  enum: [ build, enableautobuild, disableautobuild ]
       responses:
         202:
           description: Build successful
           content:
-            text/html:
+            application/json:
               schema:
-                type: string
+                type: object
+                properties:
+                  status:
+                    type: string
+                  projectID:
+                    $ref: '#/components/schemas/ProjectID'
+                  action:
+                    description: 'Action for build'
+                    type: string
+                    enum: [ build, enableautobuild, disableautobuild ]
         400:
           description: Unknown action or Project not found
           content:
@@ -932,7 +941,7 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/MessageObject'
                   - $ref: '#/components/schemas/CodewindError'
-                 
+
         500:
           description: Internal error
     delete:

--- a/src/pfe/portal/routes/logging.route.js
+++ b/src/pfe/portal/routes/logging.route.js
@@ -39,7 +39,7 @@ router.put('/api/v1/logging', async function (req, res) {
     await Logger.setLoggingLevel(level);
     await user.setLoggingLevel(level);
     log.info(`logging level set to ${level}`);
-    res.sendStatus(200);
+    res.status(200).json({ level });
   } catch (err) {
     log.error(err);
     if (err instanceof LoggingError && err.code === 'INVALID_LEVEL') {

--- a/src/pfe/portal/routes/projects/build.route.js
+++ b/src/pfe/portal/routes/projects/build.route.js
@@ -35,17 +35,22 @@ async function buildProject(req, res) {
       res.status(400).send(`Unable to find project ${id}`);
       return;
     }
-    
+
     if (project.isClosed() || project.isClosing() || project.isDeleting()) {
       const msg = `Cannot perform build action ${action} on ${project.name} because it is in state ${project.state}.`;
       res.status(400).send(msg);
       log.error(msg);
       return;
     }
-    
-    res.status(202).send(`Trying to build project ${id} with action ${action}`);
+
+    res.status(202).json({
+      status: "Accepted",
+      projectID: id,
+      action,
+    });
+
     await user.buildProject(project, action);
-    
+
   } catch (err) {
     log.error(err);
     res.status(500).send(err);

--- a/test/src/API/logging.test.js
+++ b/test/src/API/logging.test.js
@@ -12,7 +12,7 @@ const chai = require('chai');
 const chaiResValidator = require('chai-openapi-response-validator');
 
 const reqService = require('../../modules/request.service');
-const { 
+const {
     ADMIN_COOKIE,
     pathToApiSpec,
 } = require('../../config');
@@ -57,16 +57,20 @@ describe('Logging API tests (these `it` blocks depend on each other passing)', f
         res.text.should.include('Invalid logging level requested');
     });
 
-    it('returns 200 when PUT /logging is called with body { level : debug }', async function() {
-        const res = await setLogLevel('warn');
+    it('returns 200 when PUT /logging is called with body { level : warn }', async function() {
+        const level = 'warn';
+        const res = await setLogLevel(level);
         res.status.should.equal(200, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
+        res.level.should.equal(level);
     });
 
-    it('returns 200 when PUT /logging is called with body { level : info }', async function() {
-        const res = await setLogLevel('debug');
+    it('returns 200 when PUT /logging is called with body { level : debug }', async function() {
+        const level = 'debug';
+        const res = await setLogLevel(level);
         res.status.should.equal(200, res.text); // print res.text if assertion fails
         res.should.satisfyApiSpec;
+        res.level.should.equal(level);
     });
 
 });

--- a/test/src/API/projects/build.test.js
+++ b/test/src/API/projects/build.test.js
@@ -13,7 +13,7 @@ const path = require('path');
 const chaiResValidator = require('chai-openapi-response-validator');
 
 const projectService = require('../../../modules/project.service');
-const { 
+const {
     testTimeout,
     TEMP_TEST_DIR,
     pathToApiSpec,
@@ -40,45 +40,51 @@ describe('Project Build Tests', function() {
     describe('POST projects/{id}/build', function() {
         it('returns 202 when `action` is `build`', async function() {
             this.timeout(testTimeout.short);
-            const res = await projectService.buildProject(projectID, 'build');
-            
+            const action = 'build';
+            const res = await projectService.buildProject(projectID, action);
+
             res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
-            res.text.should.equal(`Trying to build project ${projectID} with action build`);
+            res.body.action.should.equal(action);
+            res.body.projectID.should.equal(projectID);
         });
-        
+
         it('returns 202 when `action` is `enableautobuild`', async function() {
             this.timeout(testTimeout.short);
-            const res = await projectService.buildProject(projectID, 'enableautobuild');
-            
+            const action = 'enableautobuild';
+            const res = await projectService.buildProject(projectID, action);
+
             res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
-            res.text.should.equal(`Trying to build project ${projectID} with action enableautobuild`);
+            res.body.action.should.equal(action);
+            res.body.projectID.should.equal(projectID);
         });
-        
+
         it('returns 202 when `action` is `disableautobuild`', async function() {
             this.timeout(testTimeout.short);
-            const res = await projectService.buildProject(projectID, 'disableautobuild');
-            
+            const action = 'disableautobuild';
+            const res = await projectService.buildProject(projectID, action);
+
             res.status.should.equal(202, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
-            res.text.should.equal(`Trying to build project ${projectID} with action disableautobuild`);
+            res.body.action.should.equal(action);
+            res.body.projectID.should.equal(projectID);
         });
-        
+
         it('returns 400 when `action` is unknown', async function() {
             this.timeout(testTimeout.short);
             const res = await projectService.buildProject(projectID, 'unknown action');
-            
+
             res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal('Error while validating request: request.body.action should be equal to one of the allowed values');
         });
-        
+
         it('returns 400 when project does not exist', async function() {
             this.timeout(testTimeout.short);
             const projectID = '00000000-0000-0000-0000-000000000000';
             const res = await projectService.buildProject(projectID, 'build');
-            
+
             res.status.should.equal(400, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
             res.text.should.equal(`Unable to find project ${projectID}`);

--- a/test/src/API/projects/build.test.js
+++ b/test/src/API/projects/build.test.js
@@ -80,14 +80,17 @@ describe('Project Build Tests', function() {
             res.text.should.equal('Error while validating request: request.body.action should be equal to one of the allowed values');
         });
 
-        it('returns 400 when project does not exist', async function() {
+        it('returns 404 when project does not exist', async function() {
             this.timeout(testTimeout.short);
             const projectID = '00000000-0000-0000-0000-000000000000';
-            const res = await projectService.buildProject(projectID, 'build');
+            const action = 'build';
+            const res = await projectService.buildProject(projectID, action);
 
-            res.status.should.equal(400, res.text); // print res.text if assertion fails
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
             res.should.satisfyApiSpec;
-            res.text.should.equal(`Unable to find project ${projectID}`);
+            res.body.error.should.contain(`Unable to find project ${projectID}`);
+            res.body.action.should.equal(action);
+            res.body.projectID.should.equal(projectID);
         });
     });
 });


### PR DESCRIPTION
Now ~all~ more endpoints used by the IDEs return JSON.

Fixes https://github.com/eclipse/codewind/issues/2435

Signed-off-by: Tim Etchells <timetchells@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
The build endpoint seems to be the only one used by the IDEs which returns plain text instead of JSON. Also changed the error responses to provide a bit more info and use more descriptive status codes.

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2435

## Does this PR require a documentation change ?
I have updated the openapi.yml.

## Other notes for reviewers
I checked with Erin and John P and this change will not break Intellij or Eclipse
