### PR TITLE
Update template providers in place.

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -154,8 +154,7 @@ module.exports = class Templates {
       const validatedUrl = await validateRepository(repoUrl, repositories);
       const newRepo = await constructRepositoryObject(validatedUrl, repoDescription, repoName, isRepoProtected);
 
-      const providers = cwUtils.deepClone(this.providers);
-      this.providers = await addRepositoryToProviders(newRepo, providers);
+      await addRepositoryToProviders(newRepo, this.providers);
 
       // Only update the repositoryList if the providers can be updated
       const currentRepoList = cwUtils.deepClone(this.repositoryList);
@@ -178,8 +177,7 @@ module.exports = class Templates {
     try {
       const repoToDelete = this.repositoryList.find(repo => repo.url === repoUrl);
       if (!repoToDelete) throw new TemplateError('REPOSITORY_DOES_NOT_EXIST', repoUrl);
-      const providers = cwUtils.deepClone(this.providers);
-      this.providers = await removeRepositoryFromProviders(repoToDelete, providers);
+      await removeRepositoryFromProviders(repoToDelete, this.providers);
       try {
         const currentRepoList = cwUtils.deepClone(this.repositoryList);
         const updatedRepoList = await updateRepoListWithReposFromProviders(this.providers, currentRepoList, this.repositoryFile);
@@ -187,8 +185,7 @@ module.exports = class Templates {
       }
       catch (err) {
         // rollback
-        const providers = cwUtils.deepClone(this.providers);
-        this.providers = await addRepositoryToProviders(repoToDelete, providers).catch(error => log.warn(error.message));
+        await addRepositoryToProviders(repoToDelete, this.providers).catch(error => log.warn(error.message));
         throw err;
       }
       // writeRepositoryList regardless of whether it has been updated with the data from providers
@@ -582,7 +579,6 @@ async function addRepositoryToProviders(repo, providers) {
   catch (err) {
     throw new TemplateError('ADD_TO_PROVIDER_FAILURE', repo.url, err.message);
   }
-  return providers;
 }
 
 async function removeRepositoryFromProviders(repo, providers) {
@@ -597,7 +593,6 @@ async function removeRepositoryFromProviders(repo, providers) {
     }
   }
   await Promise.all(promises);
-  return providers;
 }
 
 async function performOperationsOnRepositoryList(requestedOperations, repositoryList) {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -1311,8 +1311,8 @@ describe('Templates.js', function() {
                 };
                 const { firstProvider } = providers;
                 firstProvider.repositories.should.have.length(0);
-                const updatedProviders = await addRepositoryToProviders({ ...sampleRepos.codewind }, providers);
-                const { firstProvider: updatedFirstProvider } = updatedProviders;
+                await addRepositoryToProviders({ ...sampleRepos.codewind }, providers);
+                const { firstProvider: updatedFirstProvider } = providers;
                 updatedFirstProvider.repositories.should.have.length(1);
             });
             it('throws a TemplateError if one of the providers errors while adding the repository', () => {
@@ -1349,8 +1349,8 @@ describe('Templates.js', function() {
                 };
                 const { firstProvider } = providers;
                 firstProvider.repositories.should.have.length(1);
-                const updatedProviders = await removeRepositoryFromProviders(sampleRepos.codewind.url, providers);
-                const { firstProvider: updatedFirstProvider } = updatedProviders;
+                await removeRepositoryFromProviders(sampleRepos.codewind.url, providers);
+                const { firstProvider: updatedFirstProvider } = providers;
                 updatedFirstProvider.repositories.should.have.length(0);
             });
         });


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Update the existing providers list rather than cloning a new one.
The list is only updated under the lock so this is safe to do.
Previously we copied the object using `deepClone` but this didn't copy functions to the cloned object and broke providers added for extensions.

## Which issue(s) does this PR fix ?
2439

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2439

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
