### PR TITLE
Introduce buildByExtension so appsody project won't get stuck in build queue

### DIFF
--- a/src/pfe/file-watcher/server/src/controllers/projectsController.ts
+++ b/src/pfe/file-watcher/server/src/controllers/projectsController.ts
@@ -583,7 +583,8 @@ function checkInProgressBuilds(): void {
         runningBuilds.forEach((project: BuildQueueType) => {
             const projectID = project.operation.projectInfo.projectID;
             const buildStatus = statusController.getBuildState(projectID);
-            if (buildStatus === statusController.BuildState.success || buildStatus === statusController.BuildState.failed) {
+            if (project.handler.buildByExtension ||
+                buildStatus === statusController.BuildState.success || buildStatus === statusController.BuildState.failed) {
                 logger.logProjectInfo("Build completed for " + projectID, projectID);
                 runningBuilds.delete(project);
             }

--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -87,6 +87,7 @@ export class ShellExtensionProject implements IExtensionProject {
 
     supportedType: string;
     detectChangeByExtension: boolean | string[] = true;
+    buildByExtension: boolean = true;
 
     private fullPath: string;
     private config: ShellExtensionProjectConfig;


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

For #2052 we want to stop displaying build status for appsody projects, since it is misleading as appsody projects do not go through a build phase.  To do that, appsody extension will return the default `unknown` build status to Codewind.

But on Codewind side, there's now a problem that appsody projects are not removed from the build queue because the code always expects build success or failure.  This PR fixes that.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

For #2052 

## Does this PR require a documentation change ?

https://github.com/eclipse/codewind-docs/pull/473

## Any special notes for your reviewer ?
