### PR TITLE
Use npm pack for nodemon

### DIFF
--- a/src/pfe/Dockerfile_ppc64le
+++ b/src/pfe/Dockerfile_ppc64le
@@ -145,7 +145,8 @@ RUN npm ci \
     && rm -rf node_modules \
     && npm ci --production \
     && mkdir /file-watcher/fwdata \
-    && npm cache clean -f
+    && npm cache clean -f \
+    && npm pack nodemon
 
 # Copy translation files to the distribution directory
 RUN cp -r src/utils/locales dist/utils/locales

--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -90,6 +90,7 @@ RUN npm ci \
     && npm ci --production \
     && mkdir /file-watcher/fwdata \
     && npm cache clean -f \
+    && npm pack nodemon \
     && cp -r src/utils/locales dist/utils/locales 
 
 ######### Portal setup

--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -321,6 +321,7 @@ function deployLocal() {
 		fi
 	fi
 
+	$IMAGE_COMMAND cp /file-watcher/server/nodemon-*.tgz $project:/tmp
 	$IMAGE_COMMAND cp /file-watcher/scripts/nodejsScripts $project:/scripts
 	$IMAGE_COMMAND exec $project /scripts/noderun.sh start $AUTO_BUILD_ENABLED $START_MODE $HOST_OS
 	if [ $? -eq 0 ]; then

--- a/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
@@ -61,7 +61,12 @@ start() {
 
     prefix=""
     if [ "$AUTO_BUILD_ENABLED" = "true" ]; then
-        npm install -g nodemon >> $LOG_FILE 2>> $LOG_FILE
+        ls /tmp/nodemon-*.tgz >> $LOG_FILE 2>> $LOG_FILE
+        if [ $? -eq 0 ]; then
+            npm install -g /tmp/nodemon-*.tgz >> $LOG_FILE 2>> $LOG_FILE
+        else
+            npm install -g nodemon >> $LOG_FILE 2>> $LOG_FILE
+        fi
         # Wrap the npm script in nodemon
         # If os passed in is windows, use the legacy watch option
         if [ "$OS" = "windows" ]; then


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

- Use `npm pack nodemon` to pre-download the `nodemon` tarball
- Use `docker cp` to copy tarball into node app container and install from it, rather than from remote site
- This applies for local scenario only

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

#2356 

## Does this PR require a documentation change ?

Only to add nodejs projects to the list of projects that work ok offline

## Any special notes for your reviewer ?
