### PR TITLE
test: set cwctl to use insecure keyring in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
 
     environment {
         CODECOV_TOKEN = credentials('codecov-token-codewind-repository')
+        INSECURE_KEYRING = 'true'
     }
 
     stages {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] CI
- [ ] Enhancement

## What does this PR do ?
Set cwctl to use insecure keyring in Jenkins when we do `cwctl start` in Jenkins

## Which issue(s) does this PR fix ?
part of https://github.com/eclipse/codewind/issues/1306

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
