### PR TITLE
Fix: Nulling project object for Appsody Projects (0.10.0)

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -530,14 +530,17 @@ module.exports = class LoadRunner {
       this.project = null;
     });
 
-    this.socket.on('completed', () => {
+    this.socket.on('completed', async () => {
       log.info(`Load run on project ${this.project.projectID} completed`);
       this.project.loadInProgress = false;   // Clear the flag on the project
       if (this.collectionUri !== null) {
         this.recordCollection();
       }
       this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' , timestamp: this.metricsFolder});
-      this.endProfiling();
+      await this.endProfiling();
+      if (this.timerID === null) {
+        this.project = null;
+      }
     });
   }
 


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
For Java/Node projects, the project object within Load runner is made null after the metrics/profiling data has been successfully saved and returned to the user. However, this means that the project object is not being made null for any projects that do not save profiling data for load runs.

This fix nulls the project object for non-Java and Node projects after the load test is completed, so the Load runner now considers these runs to be completed and can run again.

## Which issue(s) does this PR fix ?
#2479

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
[https://github.com/eclipse/codewind/issues/2479](https://github.com/eclipse/codewind/issues/2479)

## Does this PR require a documentation change ?
No.

## Any special notes for your reviewer ?
