### PR TITLE
Get default templates each time tests are run

### DIFF
--- a/test/modules/request.service.js
+++ b/test/modules/request.service.js
@@ -68,8 +68,13 @@ function isEmpty(obj) {
     return (Object.keys(obj).length === 0) && (obj.constructor === Object);
 }
 
+function externalChaiRequest(URL) {
+    return chai.request(URL);
+}
+
 module.exports = {
     makeReq,
     makeReqAndAwaitSocketMsg,
     chai: chai.request(CODEWIND_URL),
+    externalChaiRequest,
 };

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -13,81 +13,6 @@ const reqService = require('./request.service');
 
 const templateRepositoryURL = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/master/devfiles/index.json';
 
-const defaultCodewindTemplates = [
-    {
-        label: 'Go',
-        description: 'Eclipse Codewind Go sample application',
-        language: 'go',
-        url: 'https://github.com/codewind-resources/goTemplate',
-        projectType: 'docker',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'Lagom Java',
-        description: 'Eclipse Codewind Lagom Reactive microservice in Java',
-        language: 'java',
-        url: 'https://github.com/codewind-resources/lagomJavaTemplate',
-        projectType: 'docker',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'Node.js Express',
-        description: 'Eclipse Codewind Express sample application',
-        language: 'nodejs',
-        url: 'https://github.com/codewind-resources/nodeExpressTemplate',
-        projectType: 'nodejs',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'Open Liberty',
-        description: 'Eclipse Codewind Open Liberty sample application in Java',
-        language: 'java',
-        url: 'https://github.com/codewind-resources/openLibertyTemplate',
-        projectType: 'docker',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'Python',
-        description: 'Eclipse Codewind Python sample application',
-        language: 'python',
-        url: 'https://github.com/codewind-resources/pythonTemplate',
-        projectType: 'docker',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'Spring Boot®',
-        description: 'Eclipse Codewind Spring Boot® sample application',
-        language: 'java',
-        url: 'https://github.com/codewind-resources/springJavaTemplate',
-        projectType: 'spring',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'Swift',
-        description: 'Eclipse Codewind Swift sample application',
-        language: 'swift',
-        url: 'https://github.com/codewind-resources/swiftTemplate',
-        projectType: 'swift',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-    {
-        label: 'WebSphere Liberty MicroProfile®',
-        description: 'Eclipse MicroProfile® on Websphere Liberty',
-        language: 'java',
-        url: 'https://github.com/codewind-resources/javaMicroProfileTemplate',
-        projectType: 'liberty',
-        source: 'Default templates',
-        sourceURL: templateRepositoryURL,
-    },
-];
-
 const styledTemplates = {
     codewind: {
         label: 'Codewind template',
@@ -120,6 +45,25 @@ const sampleRepos = {
 };
 
 const validUrlNotPointingToIndexJson = 'https://support.oneskyapp.com/hc/en-us/article_attachments/202761627/example_1.json';
+
+async function getDefaultTemplatesFromGithub() {
+    const { status, text } = await reqService.externalChaiRequest(templateRepositoryURL).get('');
+    status.should.equal(200);
+    // Parse the index.json into our template format
+    const rawTemplates = JSON.parse(text);
+    const parsedTemplates = rawTemplates.map(({ displayName, description, language, projectType, location }) => {
+        return {
+            label: displayName,
+            description,
+            language,
+            url: location,
+            projectType,
+            source: 'Default templates',
+            sourceURL: templateRepositoryURL,
+        };
+    });
+    return parsedTemplates;
+}
 
 async function getTemplateRepos() {
     const res = await reqService.chai
@@ -263,7 +207,7 @@ function setupReposAndTemplatesForTesting() {
 }
 
 module.exports = {
-    defaultCodewindTemplates,
+    getDefaultTemplatesFromGithub,
     styledTemplates,
     templateRepositoryURL,
     sampleRepos,

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -15,7 +15,7 @@ const chaiSubset = require('chai-subset');
 const deepEqualInAnyOrder = require('deep-equal-in-any-order');
 
 const {
-    defaultCodewindTemplates,
+    getDefaultTemplatesFromGithub,
     validUrlNotPointingToIndexJson,
     sampleRepos,
     batchPatchTemplateRepos,
@@ -42,6 +42,10 @@ describe('Template API tests', function() {
     this.timeout(testTimeout.short);
     // Save the state of the repos before any test and restore the exact state after
     saveReposBeforeTestAndRestoreAfter();
+    let defaultCodewindTemplates;
+    before(async function() {
+        defaultCodewindTemplates = await getDefaultTemplatesFromGithub();
+    });
     describe('GET /api/v1/templates', function() {
         setupReposAndTemplatesForTesting();
         describe('?projectStyle=', function() {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -1122,10 +1122,11 @@ describe('Templates.js', function() {
         describe('getTemplatesJSONFromURL(givenURL)', () => {
             const getTemplatesJSONFromURL = Templates.__get__('getTemplatesJSONFromURL');
             it('gets templates JSON back from a valid URL', async() => {
-                const templatesJSON = await getTemplatesJSONFromURL(sampleRepos.codewind.url);
+                const staticCommitURL = 'https://raw.githubusercontent.com/codewind-resources/codewind-templates/3af4928a928a5c08b07908c54799cc1675b9f965/devfiles/index.json';
+                const templatesJSON = await getTemplatesJSONFromURL(staticCommitURL);
                 templatesJSON.should.be.an('array');
                 templatesJSON.forEach(templateObject => {
-                    templateObject.should.have.keys('displayName', 'description', 'language', 'projectType', 'location', 'links', 'icon');
+                    templateObject.should.have.keys('displayName', 'description', 'language', 'projectType', 'location', 'links');
                 });
             });
             it('should be rejected as URL does not point to JSON', () => {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -11,6 +11,7 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const chaiSubset = require('chai-subset');
+const deepEqualInAnyOrder = require('deep-equal-in-any-order');
 const fs = require('fs-extra');
 const path = require('path');
 const rewire = require('rewire');
@@ -22,16 +23,17 @@ const Templates = rewire('../../../src/pfe/portal/modules/Templates');
 const TemplateError = require('../../../src/pfe/portal/modules/utils/errors/TemplateError');
 const {
     styledTemplates,
-    defaultCodewindTemplates,
     sampleRepos,
     validUrlNotPointingToIndexJson,
     templateRepositoryURL,
+    getDefaultTemplatesFromGithub,
 } = require('../../modules/template.service');
 const { suppressLogOutput } = require('../../modules/log.service');
 const { testTimeout } = require('../../config');
 
 chai.use(chaiAsPromised);
 chai.use(chaiSubset);
+chai.use(deepEqualInAnyOrder);
 chai.should();
 const should = chai.should();
 
@@ -85,10 +87,14 @@ function getWorkspaceAndDeleteAfterEach(testFolderName) {
     return workspace;
 };
 
-describe('Templates.js', function() {
+describe.only('Templates.js', function() {
     // Set the default timeout for all tests
     this.timeout(testTimeout.short);
     suppressLogOutput(Templates);
+    let defaultCodewindTemplates;
+    before(async function() {
+        defaultCodewindTemplates = await getDefaultTemplatesFromGithub();
+    });
     describe('Class functions', function() {
         describe('initializeRepositoryList()', function() {
             const workspace = getWorkspaceAndDeleteAfterEach(this.title);
@@ -1087,7 +1093,7 @@ describe('Templates.js', function() {
             });
             it('returns the default Codewind templates', async function() {
                 const output = await getTemplatesFromRepos([sampleRepos.codewind]);
-                output.should.deep.equal(defaultCodewindTemplates);
+                output.should.deep.equalInAnyOrder(defaultCodewindTemplates);
             });
         });
         describe('getTemplatesFromRepo(repository)', function() {
@@ -1119,7 +1125,7 @@ describe('Templates.js', function() {
                 const templatesJSON = await getTemplatesJSONFromURL(sampleRepos.codewind.url);
                 templatesJSON.should.be.an('array');
                 templatesJSON.forEach(templateObject => {
-                    templateObject.should.have.keys('displayName', 'description', 'language', 'projectType', 'location', 'links');
+                    templateObject.should.have.keys('displayName', 'description', 'language', 'projectType', 'location', 'links', 'icon');
                 });
             });
             it('should be rejected as URL does not point to JSON', () => {

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -87,7 +87,7 @@ function getWorkspaceAndDeleteAfterEach(testFolderName) {
     return workspace;
 };
 
-describe.only('Templates.js', function() {
+describe('Templates.js', function() {
     // Set the default timeout for all tests
     this.timeout(testTimeout.short);
     suppressLogOutput(Templates);


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
* Stops the template tests from failing due to the changes to the `index.json`: https://github.com/codewind-resources/codewind-templates/commit/616f53cb73f39eea5f08deb4ae43047d62d4de0c
* Changes the tests to fetch the `index.json` before testing against it which should protect against future template changes.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: n/a - build failure

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
no