### PR TITLE
LoadRunner Heartbeat (0.10.0)

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -46,6 +46,7 @@ module.exports = class LoadRunner {
     this.createSocketEvents();
     this.connectIfAvailable();
     this.timerID = null;
+    this.heartbeatID = null;
   }
 
   // Fetch the supported metrics features from the project
@@ -252,7 +253,7 @@ module.exports = class LoadRunner {
         }
       }
 
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'preparing', timestamp: this.metricsFolder });
+      this.heartbeat('preparing');
 
       // start profiling if supported by current language
       if (this.project.language == 'nodejs' || this.project.language === 'javascript') {
@@ -263,7 +264,7 @@ module.exports = class LoadRunner {
 
       //  Start collection on metrics endpoint (this must be started AFTER java profiling since java profiling will restart the liberty server)
       this.collectionUri = await this.createCollection(loadConfig.maxSeconds);
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'starting', timestamp: this.metricsFolder });
+      this.heartbeat('starting');
 
       // Send the load run request to the loadrunner microservice
       let loadrunnerRes = await cwUtils.asyncHttpRequest(options, loadConfig);
@@ -436,6 +437,9 @@ module.exports = class LoadRunner {
   * Function to cancel the loadrunner
   */
   async cancelRunLoad(loadConfig) {
+    if (this.heartbeatID !== null) {
+      clearTimeout(this.heartbeatID);
+    }
     try {
       let options = {
         host: this.hostname,
@@ -519,14 +523,16 @@ module.exports = class LoadRunner {
 
     this.socket.on('started', () => {
       log.info(`Load run on project ${this.project.projectID} started`);
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'started', timestamp: this.metricsFolder });
+      clearTimeout(this.heartbeatID);
+      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'started' });
     });
 
     this.socket.on('cancelled', async () => {
       log.info(`Load run on project ${this.project.projectID} cancelled`);
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'cancelling', timestamp: this.metricsFolder });
+      this.heartbeat('cancelling');
       await this.cancelProfiling();
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'cancelled', timestamp: this.metricsFolder });
+      clearTimeout(this.heartbeatID);
+      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'cancelled' });
       this.project = null;
     });
 
@@ -536,7 +542,8 @@ module.exports = class LoadRunner {
       if (this.collectionUri !== null) {
         this.recordCollection();
       }
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' , timestamp: this.metricsFolder});
+      clearTimeout(this.heartbeatID);
+      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });
       await this.endProfiling();
       if (this.timerID === null) {
         this.project = null;
@@ -659,5 +666,15 @@ module.exports = class LoadRunner {
     }
     this.up = false;
     socket.disconnect();
+  }
+
+  /**
+   * Function to send a heartbeat of the current LoadRunner status
+   */
+  heartbeat(status) {
+    if (this.heartbeatID !== null) {
+      clearTimeout(this.heartbeatID);
+    }
+    this.heartbeatID = setInterval(() => this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: status, timestamp: this.metricsFolder }), 2000);
   }
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Socket messages for LoadRunner state changes are now emitted at a regular heartbeat interval instead of once. 

This aims to resolve issues seen when the UI socket disconnects from the performance dashboard, making the UI unresponsive as it refers to the incorrect state of loadrunner. Repeating these emits on a heartbeat should prevent this issue by updating the UI socket when it reconnects. 

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2479
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No