### PR TITLE
[0.10.0] test: use cwctl with insecure keyring in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,10 @@ pipeline {
         skipStagesAfterUnstable()
     }
 
+    environment {
+        INSECURE_KEYRING = 'true'
+    }
+
     stages {
         stage('Run Portal eslint and unit tests') {
             options {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

port https://github.com/eclipse/codewind/pull/2507 to 0.10.0
