### PR TITLE
LoadRunner Heartbeat

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -182,17 +182,17 @@ module.exports = class User {
    */
   async cancelLoad(project) {
     log.debug("cancelLoad: project " + project.projectID + " loadInProgress=" + project.loadInProgress);
-    this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelling' });
-    
     if (project.loadInProgress) {
       log.debug("Cancelling load for config: " + JSON.stringify(project.loadConfig));
       const res = await retry((bail, number) => {
         log.info(`Attempting to cancel load run. Attempt ${number}/30`);
+        this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelling' });
         return this.callCancelRunLoad(project)
           .catch(function (err) {
             if (err.code !== "CANCEL_RUN_LOAD_ERROR") {
               bail(err); 
             } else {
+              this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelled' });
               throw err;
             }
           });
@@ -202,8 +202,10 @@ module.exports = class User {
         maxTimeout: 1000,
       });
       project.loadInProgress = false;
+      this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelled' });
       return res;
     }
+    
     this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelled' });
     throw new LoadRunError("NO_RUN_IN_PROGRESS", `For project ${project.projectID}`);
   }

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -558,6 +558,7 @@ describe('LoadRunner.js', () => {
             const writeGitHash = sandbox.stub(loadRunner, 'writeGitHash');
             const beginNodeProfiling = sandbox.stub(loadRunner, 'beginNodeProfiling');
             const beginJavaProfiling = sandbox.stub(loadRunner, 'beginJavaProfiling');
+            const heartbeat = sandbox.stub(loadRunner, 'heartbeat');
 
             // act
             const loadrunnerRes = await loadRunner.runLoad(mockLoadConfig, mockProject, 'mockRunDescription');
@@ -568,19 +569,11 @@ describe('LoadRunner.js', () => {
             loadRunner.project.getProjectKubeService.should.have.been.calledOnceWithExactly();
             fetchProjectMetricsFeatures.should.have.been.calledOnceWithExactly();
             writeGitHash.should.not.have.been.called;
-            mockUser.uiSocket.emit.should.have.been.calledWithExactly('runloadStatusChanged', {
-                projectID: mockProject.projectID,
-                status: 'preparing',
-                timestamp: loadRunner.metricsFolder,
-            });
+            heartbeat.should.have.been.calledWithExactly('preparing');
             beginNodeProfiling.should.not.have.been.called;
             beginJavaProfiling.should.not.have.been.called;
             createCollection.should.have.been.calledOnceWithExactly(mockLoadConfig.maxSeconds);
-            mockUser.uiSocket.emit.should.have.been.calledWithExactly('runloadStatusChanged', {
-                projectID: mockProject.projectID,
-                status: 'starting',
-                timestamp: loadRunner.metricsFolder,
-            });
+            heartbeat.should.have.been.calledWithExactly('starting');
             loadrunnerRes.should.deep.equal({ statusCode: 202 });
         });
     });


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Socket messages for LoadRunner state changes are now emitted at a regular heartbeat interval instead of once.

This aims to resolve issues seen when the UI socket disconnects from the performance dashboard, making the UI unresponsive as it refers to the incorrect state of loadrunner. Repeating these emits on a heartbeat should prevent this issue by updating the UI socket when it reconnects.

## Which issue(s) does this PR fix ?
#2479
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No.

## Any special notes for your reviewer ?
No.