### PR TITLE
Copy settings.xml for microprofile projects

### DIFF
--- a/src/pfe/file-watcher/idc/artifacts/build_server.sh
+++ b/src/pfe/file-watcher/idc/artifacts/build_server.sh
@@ -60,10 +60,18 @@ else
 fi
 echo "Maven build output directory is set to $MICROCLIMATE_OUTPUT_DIR"
 
+# copy settings.xml if present
+if [[ -f settings.xml ]]; then
+    mkdir -p $HOME/.m2/
+    mv settings.xml $HOME/.m2/
+fi
+
 if [[ $1 && $1 == "prod" ]]; then
 	echo "Start mvn package for production"
 	echo "mvn -B package -DinstallDirectory=/opt/ibm/wlp"
 	mvn -B package -DinstallDirectory=/opt/ibm/wlp
+	# remove settings.xml after build
+	rm -f $HOME/.m2/settings.xml
 	exit 0
 fi
 
@@ -89,3 +97,5 @@ else
 	echo "Finished mvn package for $LOGNAME $(date)"
 fi
 
+# remove settings.xml after build
+rm -f $HOME/.m2/settings.xml


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

If `settings.xml` exist, copy it to the appropriate place before the `mvn` so that the settings can take effect (example use case: installing packages from private registry). The file is deleted after the build.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/2469
See https://github.com/eclipse/codewind/issues/2469#issuecomment-601720449

## Does this PR require a documentation change ?

Yes, will open docs PR after

## Any special notes for your reviewer ?
