### PR TITLE
[0.10.0] Export CW_CLI_BRANCH to use the right version of cwctl.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,11 +296,10 @@ pipeline {
                         export CWCTL_IMAGE_TAG=test
 
                         # If CHANGE_TARGET is set then this is a PR so use the target branch (usually master)
-                        CW_CLI_BRANCH=""
                         if [ -z "$CHANGE_TARGET" ]; then
-                             CW_CLI_BRANCH=$GIT_BRANCH
+                            export CW_CLI_BRANCH=$GIT_BRANCH
                         else
-                            CW_CLI_BRANCH=$CHANGE_TARGET
+                            export CW_CLI_BRANCH=$CHANGE_TARGET
                         fi
 
                         echo "cwctl branch to be used: $CW_CLI_BRANCH"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -295,6 +295,16 @@ pipeline {
                         # Set image tag to test
                         export CWCTL_IMAGE_TAG=test
 
+                        # If CHANGE_TARGET is set then this is a PR so use the target branch (usually master)
+                        CW_CLI_BRANCH=""
+                        if [ -z "$CHANGE_TARGET" ]; then
+                             CW_CLI_BRANCH=$GIT_BRANCH
+                        else
+                            CW_CLI_BRANCH=$CHANGE_TARGET
+                        fi
+
+                        echo "cwctl branch to be used: $CW_CLI_BRANCH"
+
                         # Start Codewind
                         sh $DIR/start.sh
                         if [ $? -ne 0 ]; then


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Uses the Jenkins $GIT_BRANCH (for branches like master or 0.10.0) or $CHANGE_TARGET (PR builds) to select the right version of cwctl to use to launch codewind.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2523
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2523

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
I have raised https://github.com/eclipse/codewind/pull/2542 against master but this PR will verify the change actually works for a branch other than master. (We should merge if 0.10.0 is going to be a long lived branch.)
