### PR TITLE
Fix problem with adding a new template repository

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1881,6 +1881,21 @@ components:
           example: "Default Codewind Templates"
         sourceId:
           type: string
+    TemplateRepoCreate:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+        protected:
+          type: boolean          
     TemplateRepo:
       type: object
       required:
@@ -1900,6 +1915,8 @@ components:
             type: string
           example: ['Codewind', 'Appsody']
         enabled:
+          type: boolean
+        protected:
           type: boolean
     TemplateRepoSetting:
       type: object

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1127,7 +1127,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TemplateRepo'
+              $ref: '#/components/schemas/TemplateRepoCreate'
       responses:
         200:
           description: Returns all the templates repositories that Codewind will use to find templates

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -418,14 +418,9 @@ function updateTemplates(repositories, allTemplates) {
 async function fetchTemplates(repositories) {
   const enabledRepositories = repositories.filter(repo => repo.enabled);
   const disabledRepositories = repositories.filter(repo => !repo.enabled);
-  log.info(`enabledRepos=${enabledRepositories}`);
-  log.info(`disabledRepos=${disabledRepositories}`);
   const enabledTemplates = await getTemplatesFromRepos(enabledRepositories);
-  log.info(`enabledTemplates=${enabledTemplates.length}`);
   const disabledTemplates = await getTemplatesFromRepos(disabledRepositories);
-  log.info(`disabledTemplates=${disabledTemplates.length}`);
   const allTemplates = enabledTemplates.concat(disabledTemplates);
-  log.info(`allTemplates=${allTemplates.length}`);
   return { enabledTemplates, allTemplates }
 }
 

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -147,12 +147,12 @@ module.exports = class Templates {
   /**
    * Add a repository to the list of template repositories.
    */
-  async addRepository(repoUrl, repoDescription, repoName, isRepoProtected) {
+  async addRepository(repoUrl, repoDescription, repoName, isRepoProtected, isRepoEnabled) {
     this.lock();
     try {
       const repositories = cwUtils.deepClone(this.repositoryList);
       const validatedUrl = await validateRepository(repoUrl, repositories);
-      const newRepo = await constructRepositoryObject(validatedUrl, repoDescription, repoName, isRepoProtected);
+      const newRepo = await constructRepositoryObject(validatedUrl, repoDescription, repoName, isRepoProtected, isRepoEnabled);
 
       await addRepositoryToProviders(newRepo, this.providers);
 
@@ -161,11 +161,12 @@ module.exports = class Templates {
       const newRepositoryList = [...currentRepoList, newRepo];
       this.repositoryList = await updateRepoListWithReposFromProviders(this.providers, newRepositoryList, this.repositoryFile);
 
-      // Fetch templates from the new repository and add them
+      // Fetch the repository templates and add them appropriately
       const newTemplates = await getTemplatesFromRepo(newRepo)
-      this.enabledProjectTemplates = this.allProjectTemplates.concat(newTemplates);
       this.allProjectTemplates = this.allProjectTemplates.concat(newTemplates);
-
+      if (isRepoEnabled) {
+        this.enabledProjectTemplates = this.enabledProjectTemplates.concat(newTemplates);
+      }
       await writeRepositoryList(this.repositoryFile, this.repositoryList);
     } finally {
       this.unlock();
@@ -278,13 +279,17 @@ async function validateRepository(repoUrl, repositories) {
   return url;
 }
 
-async function constructRepositoryObject(url, description, name, isRepoProtected) {
+async function constructRepositoryObject(url, description, name, isRepoProtected, isRepoEnabled) {
+  let enabled = isRepoEnabled;
+  if (enabled == undefined) {
+    enabled = true;
+  }
   let repository = {
     id: uuidv5(url, uuidv5.URL),
     name,
     url,
     description,
-    enabled: true,
+    enabled: enabled,
   }
   repository = await fetchRepositoryDetails(repository);
   if (isRepoProtected !== undefined) {
@@ -413,9 +418,14 @@ function updateTemplates(repositories, allTemplates) {
 async function fetchTemplates(repositories) {
   const enabledRepositories = repositories.filter(repo => repo.enabled);
   const disabledRepositories = repositories.filter(repo => !repo.enabled);
+  log.info(`enabledRepos=${enabledRepositories}`);
+  log.info(`disabledRepos=${disabledRepositories}`);
   const enabledTemplates = await getTemplatesFromRepos(enabledRepositories);
+  log.info(`enabledTemplates=${enabledTemplates.length}`);
   const disabledTemplates = await getTemplatesFromRepos(disabledRepositories);
+  log.info(`disabledTemplates=${disabledTemplates.length}`);
   const allTemplates = enabledTemplates.concat(disabledTemplates);
+  log.info(`allTemplates=${allTemplates.length}`);
   return { enabledTemplates, allTemplates }
 }
 

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -68,13 +68,15 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
   const repositoryUrl = req.sanitizeBody('url');
   const repositoryDescription = req.sanitizeBody('description');
   const isRepoProtected = req.sanitizeBody('protected');
+  const isRepoEnabled = req.sanitizeBody('enabled');
 
   try {
     await templatesController.addRepository(
       repositoryUrl,
       repositoryDescription,
       repositoryName,
-      isRepoProtected
+      isRepoProtected,
+      isRepoEnabled
     );
     await sendRepositories(req, res, _next);
   } catch (error) {

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -42,6 +42,14 @@ const sampleRepos = {
         projectStyles: ['Codewind'],
         name: 'Default templates',
     },
+    disabledcodewind: {
+        url: templateRepositoryURL,
+        description: 'The disabled default set of templates for new projects in Codewind.',
+        enabled: false,
+        protected: true,
+        projectStyles: ['Codewind'],
+        name: 'Default disabled templates',
+    },
 };
 
 const validUrlNotPointingToIndexJson = 'https://support.oneskyapp.com/hc/en-us/article_attachments/202761627/example_1.json';
@@ -128,6 +136,14 @@ async function getTemplates(queryParams) {
     return res;
 }
 
+async function getEnabledTemplates(queryParams) {
+    const res = await reqService.chai
+        .get('/api/v1/templates/?showEnabledOnly=true')
+        .query(queryParams)
+        .set('Cookie', ADMIN_COOKIE);
+    return res;
+}
+
 async function getNumberOfTemplates(queryParams) {
     const { statusCode, body: templates } = await getTemplates(queryParams);
     // If we get a 204 HTTP Code the templates list is empty
@@ -139,6 +155,19 @@ async function getNumberOfTemplates(queryParams) {
     // If we haven't got a 204 or 200 we cannot report the number of templates
     throw new Error(`getNumberOfTemplates - Unknown status code received: ${statusCode}`);
 }
+
+async function getNumberOfEnabledTemplates(queryParams) {
+    const { statusCode, body: templates } = await getEnabledTemplates(queryParams);
+    // If we get a 204 HTTP Code the templates list is empty
+    if (statusCode === 204) {
+        return 0;
+    } else if (statusCode === 200) {
+        return templates.length;
+    }
+    // If we haven't got a 204 or 200 we cannot report the number of templates
+    throw new Error(`getNumberOfTemplates - Unknown status code received: ${statusCode}`);
+}
+
 
 /**
  * Removes all templates repos known to PFE, and adds the supplied repos
@@ -219,6 +248,7 @@ module.exports = {
     enableTemplateRepos,
     disableTemplateRepos,
     getTemplates,
+    getNumberOfEnabledTemplates,
     getNumberOfTemplates,
     setTemplateReposTo,
     getTemplateStyles,

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -584,7 +584,7 @@ describe('Templates.js', function() {
                 }
             });
         });
-        describe('addRepository(repoUrl, repoDescription, repoName, isRepoProtected)', function() {
+        describe('addRepository(repoUrl, repoDescription, repoName, isRepoProtected, isRepoEnabled)', function() {
             const mockRepoList = [{ id: 'notanid', url: 'https://made.up/url' }];
             let templateController;
             beforeEach(() => {
@@ -817,11 +817,11 @@ describe('Templates.js', function() {
                 validatedURL.should.equal(sampleRepos.codewind.url);
             });
         });
-        describe('constructRepositoryObject(url, description, name, isRepoProtected)', () => {
+        describe('constructRepositoryObject(url, description, name, isRepoProtected, isRepoEnabled)', () => {
             const constructRepositoryObject = Templates.__get__('constructRepositoryObject');
             it('returns a repository object when all arguments are given', async() => {
-                const { url, description, name, protected } = sampleRepos.codewind;
-                const repository = await constructRepositoryObject(url, description, name, protected);
+                const { url, description, name, protected, enabled } = sampleRepos.codewind;
+                const repository = await constructRepositoryObject(url, description, name, protected, enabled);
                 repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'protected', 'projectStyles');
             });
             it('returns a repository object when only a url is given - gets the name, description from the url and does not have a protected field', async() => {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

## What type of PR is this ? 

- [ X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR fixes a problem with adding a new repository. We were incorrectly updating our cache of enabled templates with the cache of all templates so subsequent requests to get templates would give an incorrect list. I also discovered a discrepancy between our api docs and the route as we were not accepting a value for "repoEnabled" so it was not possible to add a repository in a disabled state. This may not be a user requirement (would be weird to add and not enable) but was necessary for the tests. 

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2472

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
API docs have been updated, no external doc change required.

## Any special notes for your reviewer ?
