### PR TITLE
Enable two Codewind Docker projects to talk to each other (Networking drop 1)

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1782,8 +1782,10 @@ paths:
             schema:
               $ref: '#/components/schemas/LinkRequestBody'
       responses:
-        200:
-          description: The link has been created
+        202:
+          description: >
+            The link has been created.
+            A further response will be sent over WebSocket once the project has restarted (using the event 'projectLink')
         400:
           description: Invalid parameters given
         409:
@@ -1813,8 +1815,10 @@ paths:
                 targetProjectURL:
                   type: string
       responses:
-          204:
-            description: The link has been updated
+          202:
+            description: >
+              The link has been updated.
+              A further response will be sent over WebSocket once the project has restarted (using the event 'projectLink')
           404:
             description: The link does not exists
     delete:
@@ -1838,8 +1842,10 @@ paths:
                 envName:
                   type: string
       responses:
-        204:
-          description: The link has been deleted
+        202:
+          description: >
+            The link has been deleted.
+            A further response will be sent over WebSocket once the project has restarted (using the event 'projectLink')
         404:
           description: The link does not exists
 

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1753,6 +1753,95 @@ paths:
                     example: "/Dockerfile-tools"
        500:
           description: Internal Server Error
+  /api/v1/projects/{id}/links:
+    get:
+      summary: Returns the links for a project
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      responses:
+        200:
+          description: Returns the links to a given project
+    post:
+      summary: Adds a new link to a project
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      requestBody:
+        description: JSON object containing details of the project to link this project to
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LinkRequestBody'
+      responses:
+        200:
+          description: The link has been created
+        400:
+          description: Invalid parameters given
+        409:
+          description: A link with the envName specified already exists
+    put:
+      summary: Updates a project link
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      requestBody:
+        description: JSON object containing the envName of the link to update, and an updated envName or/and an updated projectURL
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - envName
+              properties:
+                envName:
+                  type: string
+                updatedEnvName:
+                  type: string
+                targetProjectURL:
+                  type: string
+      responses:
+          204:
+            description: The link has been updated
+          404:
+            description: The link does not exists
+    delete:
+      summary: Deletes a project link
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      requestBody:
+        description: JSON object containing the envName of the link to delete
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - envName
+              properties:
+                envName:
+                  type: string
+      responses:
+        204:
+          description: The link has been deleted
+        404:
+          description: The link does not exists
 
 components:
   schemas:
@@ -2246,6 +2335,26 @@ components:
     PfeLogLevel:
       type: string
       enum: ['trace', 'debug', 'info', 'warn', 'error']
+    LinkRequestBody:
+      type: object
+      required:
+        - targetProjectID
+        - envName
+      properties:
+        targetProjectID:
+          $ref: '#/components/schemas/ProjectID'
+        envName:
+          type: string
+        targetProjectURL:
+          type: string
+          description: >
+            The target project's external URL<br>
+            Required if the project to connect to is located on a different PFE
+        targetParentPFEURL:
+          type: string
+          description: >
+            The target project's PFE URL - used to identify that it is on a different PFE<br>
+            Required if the project to connect to is located on a different PFE
 
   responses:
     400:

--- a/src/pfe/file-watcher/idc/artifacts/start_server.sh
+++ b/src/pfe/file-watcher/idc/artifacts/start_server.sh
@@ -59,6 +59,12 @@ if [ -f $SERVER_XML ]; then
                 echo "Checking for missing runtime features for $WLP_USER_DIR/servers/defaultServer $(date)"
                 /opt/ibm/wlp/bin/installUtility install --acceptLicense $WLP_USER_DIR/servers/defaultServer/server.xml
                 echo "Starting server $WLP_USER_DIR/servers/defaultServer $(date)"
+
+                PROJECT_LINKS_ENV_FILE="$APP_DIR/.codewind-project-links.env"
+                if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+                        while read LINE; do export "$LINE"; done < $PROJECT_LINKS_ENV_FILE
+                fi
+
                 /opt/ibm/wlp/bin/server start
                 echo "Completed $(date)"
         fi

--- a/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
@@ -56,6 +56,11 @@ start() {
 
     npm install 1>> $LOG_FILE 2>> $LOG_FILE
 
+    PROJECT_LINKS_ENV_FILE="/app/.codewind-project-links.env"
+	if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+		while read LINE; do export "$LINE"; done < $PROJECT_LINKS_ENV_FILE
+	fi
+
     # One of two npm scripts will be run: 'start' or 'debug'.
     # If auto build is enabled, we wrap the script in 'nodemon'.
 

--- a/src/pfe/file-watcher/scripts/springScripts/spring-start.sh
+++ b/src/pfe/file-watcher/scripts/springScripts/spring-start.sh
@@ -7,6 +7,11 @@ echo "PROJECT_NAME=$PROJECT_NAME"
 echo "START_MODE=$START_MODE"
 echo "DEBUG_PORT=$DEBUG_PORT"
 
+PROJECT_LINKS_ENV_FILE="/root/app/.codewind-project-links.env"
+if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+    while read LINE; do export "$LINE"; done < $PROJECT_LINKS_ENV_FILE
+fi
+
 # Start the application
 echo "Starting Spring application: $PROJECT_NAME in mode: $START_MODE"
 if [ "$START_MODE" == "run" ]; then

--- a/src/pfe/file-watcher/scripts/swift-container.sh
+++ b/src/pfe/file-watcher/scripts/swift-container.sh
@@ -244,7 +244,13 @@ function dockerRun() {
 	workspace=`$util getWorkspacePathForVolumeMounting $LOCAL_WORKSPACE`
 	echo "Workspace path used for volume mounting is: "$workspace""
 
-	$IMAGE_COMMAND run --network=codewind_network --name "$project" -dt -P -w /swift-project "$project"
+	PROJECT_LINKS_ENV_FILE="$workspace/$projectName/.codewind-project-links.env"
+	PROJECT_LINKS_PARAM=""
+	if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+			PROJECT_LINKS_PARAM="--env-file $PROJECT_LINKS_ENV_FILE"
+	fi
+
+	$IMAGE_COMMAND run $PROJECT_LINKS_PARAM --network=codewind_network --name "$project" -dt -P -w /swift-project "$project"
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
 		docker cp "$workspace/$projectName"/. "$project":/swift-project

--- a/src/pfe/file-watcher/server/src/utils/dockerutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/dockerutil.ts
@@ -22,6 +22,7 @@ import { BuildRequest, ProjectInfo } from "../projects/Project";
 import { StartModes } from "../projects/constants";
 import * as logHelper from "../projects/logHelper";
 import * as workspaceSettings from "./workspaceSettings";
+import { fstat, pathExists } from "fs-extra";
 
 const docker = new dockerode();
 
@@ -458,8 +459,16 @@ export async function runContainer(buildInfo: BuildRequest, containerName: strin
       }
     }
   }
-
   const args: string[] = ["run", "--label", "builtBy=codewind", "--name", containerName, "--network=codewind_network"];
+
+   // If the network file exists, add the environment variables to the Docker container
+   const networkEnvFile = path.join(buildInfo.projectLocation, ".codewind-project-links.env");
+   const networkEnvFileExists = await pathExists(networkEnvFile);
+   if (networkEnvFileExists) {
+     args.push("--env-file");
+     args.push(networkEnvFile);
+   }
+
   args.push(...portArgs);
   args.push("-dt");
   args.push(containerName);

--- a/src/pfe/portal/middleware/checkProjectExists.js
+++ b/src/pfe/portal/middleware/checkProjectExists.js
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+function checkProjectExists(req, res, next) {
+  const id = req.sanitizeParams('id');
+  const { cw_user: { projectList } } = req;
+  const project = projectList.retrieveProject(id);
+  if (!project) {
+    res.sendStatus(404);
+    return;
+  }
+  next();
+}
+
+function getProjectFromReq(req) {
+  const id = req.sanitizeParams('id');
+  const { cw_user: { projectList } } = req;
+  return projectList.retrieveProject(id);
+}
+
+module.exports = {
+  checkProjectExists,
+  getProjectFromReq,
+};

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -23,6 +23,7 @@ const ProjectMetricsError = require('./utils/errors/ProjectMetricsError');
 const Logger = require('./utils/Logger');
 const LogStream = require('./LogStream');
 const metricsService = require('./metricsService');
+const Links = require('./project/Links');
 
 const log = new Logger(__filename);
 
@@ -129,6 +130,8 @@ module.exports = class Project {
       this.injectMetrics = args.injectMetrics;
     }
     this.capabilitiesReady = false;
+    
+    this.links = new Links(this.projectPath(), args.links);
   }
 
 
@@ -783,12 +786,28 @@ module.exports = class Project {
   /**
    * Resolves the given path against the project's monitor path.
    * The path is unchanged if it is already absolute.
-   * 
+   *
    * @param {String} path
    * @returns {String} an absolute path
    */
   resolveMonitorPath(path) {
     return isAbsolute(path) ? cwUtils.convertFromWindowsDriveLetter(path) : join(this.pathToMonitor, path);
+  }
+
+  // Project Link wrappers so they can access the writeInformationFile function
+  async createLink(newLink) {
+    await this.links.add(newLink);
+    return this.writeInformationFile();
+  }
+
+  async updateLink(envName, newEnvName, newProjectURL) {
+    await this.links.update(envName, newEnvName, newProjectURL);
+    return this.writeInformationFile();
+  }
+
+  async deleteLink(envName) {
+    await this.links.delete(envName);
+    return this.writeInformationFile();
   }
 }
 

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -25,7 +25,7 @@ class Links {
     this._links = (args && args._links) ? args._links : [];
     this.filePath = path.join(directory, ENV_FILE_NAME);
   }
-  
+
   getAll() {
     return this._links;
   }
@@ -76,7 +76,7 @@ class Links {
   }
 }
 
-const validateLink = (newLink, links) => {
+function validateLink(newLink, links) {
   const { projectID, parentPFEURL, envName, projectURL, type } = newLink;
   // Only require a parentPFEURL and projectURL if the link is remote
   // If the link is local then the parentPFEURL is not required and the projectURL can be undefined
@@ -93,12 +93,12 @@ const validateLink = (newLink, links) => {
   return newLink;
 }
 
-const envNameExists = (links, envName) => {
+function envNameExists(links, envName) {
   const envList = links.map(link => link.envName);
   return envList.includes(envName);
 }
 
-const writeEnvironmentFile = async (filePath, envPairArray) => {
+async function writeEnvironmentFile(filePath, envPairArray) {
   const fileContents = envPairArray.join('\n');
   await fs.writeFile(filePath, fileContents);
 }

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const fs = require('fs-extra');
+const path = require('path');
+
+const ProjectLinkError = require('../utils/errors/ProjectLinkError');
+const Logger = require('../utils/Logger');
+const log = new Logger(__filename);
+
+const ENV_FILE_NAME = '.codewind-project-links.env'; // This will be in the users container
+
+/**
+ * The Links class
+ */
+class Links {
+  constructor(directory, args) {
+    this._links = (args && args._links) ? args._links : [];
+    this.filePath = path.join(directory, ENV_FILE_NAME);
+  }
+  
+  getAll() {
+    return this._links;
+  }
+
+  get(envNameToFind) {
+    const link = this._links.find(({ envName }) => envName === envNameToFind);
+    if (!link) {
+      throw new ProjectLinkError('NOT_FOUND', envNameToFind);
+    }
+    return link;
+  }
+
+  getEnvPairs() {
+    return this.getAll().map(({ envName, projectURL }) => `${envName}=${projectURL}`)
+  }
+
+  async add(newLink) {
+    const { projectURL, envName } = newLink;
+    const validatedLink = validateLink(newLink, this._links);
+    log.info(`Link added - envName: ${envName}, projectURL: ${projectURL}`);
+    this._links.push(validatedLink);
+    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+  }
+
+  async update(envName, newEnvName, newProjectURL) {
+    const linkIndex = this._links.findIndex(link => link.envName === envName);
+    if (linkIndex === -1) {
+      throw new ProjectLinkError('NOT_FOUND', envName);
+    }
+    const currentLink = this._links[linkIndex];
+
+    // Clone and remove the updated link so we only validate against all other links
+    const linksWithoutOneToBeUpdated = this._links.filter(link => link.envName !== envName);
+
+    this._links[linkIndex] = validateLink({ ...currentLink, envName: newEnvName, projectURL: newProjectURL }, linksWithoutOneToBeUpdated);
+    log.info(`Link updated - env: ${envName} properties changed to envName: ${newEnvName} projectURL: ${newProjectURL}`);
+    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+  }
+
+  async delete(envName) {
+    const linkIndex = this._links.findIndex(link => link.envName === envName);
+    if (linkIndex === -1) {
+      throw new ProjectLinkError('NOT_FOUND', envName);
+    }
+    this._links.splice(linkIndex, 1);
+    log.info(`Link ${envName} deleted`);
+    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+  }
+}
+
+const validateLink = (newLink, links) => {
+  const { projectID, parentPFEURL, envName, projectURL, type } = newLink;
+  // Only require a parentPFEURL and projectURL if the link is remote
+  // If the link is local then the parentPFEURL is not required and the projectURL can be undefined
+  if (!projectID || !envName || !type || (type === Links.TYPES.REMOTE && (!parentPFEURL || !projectURL))) {
+    log.error(newLink);
+    throw new ProjectLinkError(`INVALID_PARAMETERS`, newLink.envName);
+  }
+
+  // Check for duplicate env name
+  const duplicatedEnvName = envNameExists(links, envName);
+  if (duplicatedEnvName) {
+    throw new ProjectLinkError('EXISTS', envName);
+  }
+  return newLink;
+}
+
+const envNameExists = (links, envName) => {
+  const envList = links.map(link => link.envName);
+  return envList.includes(envName);
+}
+
+const writeEnvironmentFile = async (filePath, envPairArray) => {
+  const fileContents = envPairArray.join('\n');
+  await fs.writeFile(filePath, fileContents);
+}
+
+Links.TYPES = {
+  LOCAL: 'LOCAL', // Target project is running on the same PFE
+  REMOTE: 'REMOTE', // Target project is running on a different PFE
+}
+
+module.exports = Links;

--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -51,7 +51,7 @@ module.exports.getContainerLogStream = function getContainerLogStream(project, o
 
 module.exports.inspect = async function inspect(project) {
   if (!project || !project.containerId || project.isClosed()) {
-    log.warn(`Unable to inspect: project does not exist, has no container or is closed`);
+    log.warn(`Unable to inspect: project '${project.name}' does not exist, has no container or is closed`);
     return;
   }
   const container = await docker.getContainer(project.containerId).inspect();

--- a/src/pfe/portal/modules/utils/errors/ProjectLinkError.js
+++ b/src/pfe/portal/modules/utils/errors/ProjectLinkError.js
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+'use strict';
+const BaseError = require('./BaseError')
+
+class ProjectLinkError extends BaseError {
+  // Identifier can be either a project name or ID depending on the error message
+  constructor(code = '[Unknown error code]', identifier, message) {
+    super(code, constructMessage(code, identifier, message));
+  }
+}
+
+ProjectLinkError.CODES = {
+  NOT_FOUND: 'NOT_FOUND',
+  INVALID_PARAMETERS: 'INVALID_PARAMETERS',
+  EXISTS: 'EXISTS',
+}
+
+/**
+ * Function to construct an error message based on the given error code
+ * @param code, the error code to create the message from
+ * @param identifier, the name/path of the Project in question (based on the code being called)
+ * @param message, a message to be appended on the end of a default message
+ */
+function constructMessage(code, identifier, message) {
+  let output = '';
+  switch(code) {
+  case ProjectLinkError.CODES.NOT_FOUND:
+    output = `Unable to find link: ${identifier}`;
+    break;
+  case ProjectLinkError.CODES.INVALID_PARAMETERS:
+    output = `Invalid parameters given for link: ${identifier}`;
+    break;
+  case ProjectLinkError.CODES.EXISTS:
+    output = `The envName '${identifier}' already exists as a link`;
+    break;
+  default:
+    output = `Unknown project link error`;
+  }
+
+  // Append message to output if provided
+  return message ? `${output}\n${message}` : output;
+}
+
+module.exports = ProjectLinkError;

--- a/src/pfe/portal/pushLocal.sh
+++ b/src/pfe/portal/pushLocal.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Refresh the docs directory
+rm -r ./docs
+cp -r ../../../docs ./
+
 docker cp config/. codewind-pfe:/portal/config
 docker cp docs/. codewind-pfe:/portal/docs
 docker cp middleware/. codewind-pfe:/portal/middleware

--- a/src/pfe/portal/routes/projects/index.js
+++ b/src/pfe/portal/routes/projects/index.js
@@ -27,6 +27,7 @@ const router = express.Router();
   require('./internal.route'),
   require('./fileChanges.route'),
   require('./remoteBind.route'),
+  require('./links.route'),
 ]
   .forEach((subRouter) => router.use(subRouter));
 

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -83,8 +83,7 @@ router.post('/api/v1/projects/:id/links', disableK8s, validateReq, checkProjectE
       emitStatusToUI(user, project, 'failed', err);
       return;
     }
-    console.log('ERROR HERE');
-    console.log(err);
+
     if (err.code === ProjectLinkError.CODES.NOT_FOUND) {
       res.sendStatus(404);
     } else if (err.code === ProjectLinkError.CODES.INVALID_PARAMETERS) {

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -23,7 +23,7 @@ const ProjectLinkError = require('../../modules/utils/errors/ProjectLinkError');
 const log = new Logger(__filename);
 
 const disableK8s = (req, res) => {
-  if (global.codewind.RUNNING_IN_K8S || true) {
+  if (global.codewind.RUNNING_IN_K8S) {
     res.status(405).send('Project links are disabled in a Kubernetes environment');
   }
 }

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -22,10 +22,12 @@ const ProjectLinkError = require('../../modules/utils/errors/ProjectLinkError');
 
 const log = new Logger(__filename);
 
-const disableK8s = (req, res) => {
+const disableK8s = (req, res, next) => {
   if (global.codewind.RUNNING_IN_K8S) {
     res.status(405).send('Project links are disabled in a Kubernetes environment');
+    return;
   }
+  next();
 }
 
 router.get('/api/v1/projects/:id/links', disableK8s, validateReq, checkProjectExists, (req, res) => {

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+const express = require('express');
+const router = express.Router();
+
+const Logger = require('../../modules/utils/Logger');
+const { validateReq } = require('../../middleware/reqValidator');
+const { checkProjectExists, getProjectFromReq } = require('../../middleware/checkProjectExists');
+const { inspect: dockerInspect } = require('../../modules/utils/dockerFunctions');
+const { TYPES } = require('../../modules/project/Links');
+const cwUtils = require('../../modules/utils/sharedFunctions');
+const ProjectLinkError = require('../../modules/utils/errors/ProjectLinkError');
+
+const log = new Logger(__filename);
+
+router.get('/api/v1/projects/:id/links', validateReq, checkProjectExists, (req, res) => {
+  try {
+    const { links } = getProjectFromReq(req);
+    res.status(200).send(links.getAll());
+  } catch (err) {
+    log.error(err);
+    res.status(500).send(err);
+  }
+});
+
+router.post('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
+  // The targetProject is the one we want "this" project to be able to reach
+  const targetProjectID = req.sanitizeBody('targetProjectID');
+  const envName = req.sanitizeBody('envName');
+  const targetProjectURL = req.sanitizeBody('targetProjectURL');
+  const targetProjectPFEURL = req.sanitizeBody('targetProjectPFEURL');
+
+  try {
+    const { cw_user: user } = req;
+    const project = getProjectFromReq(req);
+    const newLink = {
+      projectID: targetProjectID,
+      envName,
+      projectURL: targetProjectURL,
+      parentPFEURL: targetProjectPFEURL,
+      type: TYPES.REMOTE,
+    };
+
+    // Check to see if the project exists on this PFE instance
+    if (!targetProjectURL && !targetProjectPFEURL) {
+      // Get the url from the projectList, throw an error if the project does not exist
+      const localProjectURL = await verifyProjectExistsAndReturnInternalURL(user, targetProjectID);
+      newLink.projectURL = localProjectURL;
+      newLink.type = TYPES.LOCAL;
+    }
+
+    await project.createLink(newLink);
+    log.info(`New project link created for ${project.name}`);
+
+    // Send status and then kick off the restart/rebuild
+    const { links } = project;
+    res.status(200).send(links.getAll());
+
+    if (project.isOpen()) {
+      await restartOrBuildProject(user, project);
+    }
+  } catch (err) {
+    log.error(err);
+    if (err.code === ProjectLinkError.CODES.INVALID_PARAMETERS) {
+      res.sendStatus(400);
+    } else if (err.code === ProjectLinkError.CODES.EXISTS) {
+      res.sendStatus(409);
+    } else {
+      res.status(500).send(err);
+    }
+  }
+});
+
+router.put('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
+  const currentEnvName = req.sanitizeBody('envName');
+  const newEnvName = req.sanitizeBody('updatedEnvName');
+  let newProjectURL = req.sanitizeBody('targetProjectURL');
+  try {
+    const { cw_user: user } = req;
+    const project = getProjectFromReq(req);
+    const { links } = project;
+
+    // If the link on the same PFE (local) fetch the projectURL from the ProjectList (ignore newProjectURL)
+    const { type: linkType, projectID: targetProjectID, projectURL: currentProjectURL } = links.get(currentEnvName);
+    
+    if (linkType === TYPES.LOCAL) {
+      // Get the url from the projectList, throw an error if the project does not exist
+      const localProjectURL = await verifyProjectExistsAndReturnInternalURL(user, targetProjectID);
+      newProjectURL = localProjectURL;
+    }
+
+    // If newEnvName or newProjectURL are not given through the API, default them to their old values
+    const updatedLinkEnvName = (newEnvName) ? newEnvName : currentEnvName;
+    const updatedLinkProjectURL = (newProjectURL) ? newProjectURL : currentProjectURL;
+    await project.updateLink(currentEnvName, updatedLinkEnvName, updatedLinkProjectURL);
+
+    // Send status and then kick off the restart/rebuild
+    res.sendStatus(204);
+
+    if (project.isOpen()) {
+      await restartOrBuildProject(user, project);
+    }
+  } catch (err) {
+    log.error(err);
+    if (err.code === ProjectLinkError.CODES.NOT_FOUND) {
+      res.sendStatus(404);
+    } else {
+      res.status(500).send(err);
+    }
+  }
+});
+
+router.delete('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
+  const envNameOfLinkToDelete = req.sanitizeBody('envName');
+  try {
+    const { cw_user: user } = req;
+    const project = getProjectFromReq(req);
+    await project.deleteLink(envNameOfLinkToDelete);
+
+    // Send status and then kick off the restart/rebuild
+    res.sendStatus(204);
+
+    if (project.isOpen()) {
+      await restartOrBuildProject(user, project);
+    }
+  } catch (err) {
+    log.error(err);
+    if (err.code === ProjectLinkError.CODES.NOT_FOUND) {
+      res.sendStatus(404);
+    } else {
+      res.status(500).send(err);
+    }
+  }
+});
+
+const verifyProjectExistsAndReturnInternalURL = async(user, projectID) => {
+  const project = await user.projectList.retrieveProject(projectID);
+  if (!project) {
+    throw new Error('projectID not found on local PFE');
+  }
+  const { host: dockerNetworkIP, ports: { internalPort }, appStatus } = project;
+  // If the project has not started return undefined as the projectURL
+  if (appStatus != 'started' && !dockerNetworkIP) {
+    return undefined;
+  }
+  // Attempt to get container name fall back to docker network IP address (given to us by file-watcher)
+  const container = await dockerInspect(project);
+  const host = (container && container.Name) ? container.Name.substring(1) : dockerNetworkIP;
+  return `${host}:${internalPort}`;
+}
+
+const restartOrBuildProject = async(user, project) => {
+  const { projectType } = project;
+  const projectTypesThatPickUpEnvsThroughRestart = ['nodejs', 'liberty', 'spring'];
+  if (projectTypesThatPickUpEnvsThroughRestart.includes(projectType.toLowerCase())) {
+    await restartNodeSpringLiberty(user, project);
+  } else {
+    await restartDocker(user, project);
+  }
+};
+
+const restartNodeSpringLiberty = async(user, project) => {
+  const { name, startMode } = project;
+  log.info(`Restarting ${name} to pick up network environment variables`);
+  const mode = (startMode) ? startMode : 'run';
+  await user.restartProject(project, mode);
+};
+
+const restartDocker = async(user, project) => {
+  const { name, buildStatus, projectID } = project;
+  // As this function will be repeated until it has verified whether the envs exist in the container
+  // we need to ensure that the project has not been deleted
+  const projectExists = user.projectList.retrieveProject(projectID);
+  if (!projectExists) {
+    return;
+  }
+
+  let container;
+  try {
+    container = await dockerInspect(project);
+  } catch (err) {
+    const { statusCode } = err;
+    // If container is not found keep waiting
+    if (statusCode && statusCode === 404) {
+      container = null;
+    } else {
+      throw err;
+    }
+  }
+
+  if (buildStatus != "inProgress" && container) {
+    const { Config: { Env: containerEnvs }} = container;
+    const linksExistInContainer = await checkIfEnvsExistInArray(project, containerEnvs);
+    // Only build and run the project if the links are not in the container
+    if (!linksExistInContainer) {
+      log.info(`Rebuilding ${name} to pick up network environment variables`);
+      await user.buildAndRunProject(project);
+    }
+  } else {
+    // if a build is in progress, wait 5 seconds and try again
+    await cwUtils.timeout(5000);
+    await restartDocker(user, project);
+  }
+};
+
+const checkIfEnvsExistInArray = (project, array) => {
+  const { links } = project;
+  const envPairs = links.getEnvPairs();
+  return envPairs.every(env => array.includes(env));
+}
+
+module.exports = router;

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -75,7 +75,7 @@ const defaultNodeProjectDirList = [
 async function createProjectFromTemplate(name, projectType, path, autoBuild = false) {
     const { url, language } = templateOptions[projectType];
 
-    const pfeProjectType = (projectType === 'openliberty')
+    const pfeProjectType = (['openliberty', 'go'].includes(projectType))
         ? 'docker'
         : projectType;
 
@@ -448,6 +448,51 @@ async function notifyPfeOfFileChangesAndAwaitMsg(array, projectID) {
     await reqService.makeReqAndAwaitSocketMsg(req, 200, expectedSocketMsg);
 }
 
+async function getProjectLinks(projectID) {
+    const res = await reqService.chai
+        .get(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE);
+    res.should.have.status(200);
+    res.should.have.ownProperty('body');
+    res.body.should.be.an('array');
+    return res.body;
+}
+
+async function addProjectLink(projectID, targetProjectID, envName, targetProjectURL, targetProjectPFEURL) {
+    const reqBody = {
+        targetProjectID,
+        envName,
+        targetProjectURL,
+        targetProjectPFEURL,
+    };
+    const res = await reqService.chai
+        .post(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send(reqBody);
+    return res;
+}
+
+async function updateProjectLink(projectID, envName, updatedEnvName, targetProjectURL) {
+    const reqBody = {
+        envName,
+        updatedEnvName,
+        targetProjectURL,
+    };
+    const res = await reqService.chai
+        .put(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send(reqBody);
+    return res;
+}
+
+async function deleteProjectLink(projectID, envName) {
+    const res = await reqService.chai
+        .delete(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send({ envName });
+    return res;
+}
+
 
 module.exports = {
     generateUniqueName,
@@ -483,4 +528,8 @@ module.exports = {
     buildProject,
     cloneProject,
     notifyPfeOfFileChangesAndAwaitMsg,
+    getProjectLinks,
+    addProjectLink,
+    updateProjectLink,
+    deleteProjectLink,
 };

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+
+const chai = require('chai');
+const path = require('path');
+const chaiResValidator = require('chai-openapi-response-validator');
+
+const projectService = require('../../../modules/project.service');
+const { testTimeout, TEMP_TEST_DIR, pathToApiSpec } = require('../../../config');
+
+chai.use(chaiResValidator(pathToApiSpec));
+chai.should();
+
+describe('Link tests (/api/v1/project/:id/links)', () => {
+    const nodeProjectName = `test-project-links-nodejs-${Date.now()}`;
+    const goProjectName = `test-project-links-go-${Date.now()}`;
+    const pathToNodeProject = path.join(TEMP_TEST_DIR, nodeProjectName);
+    const pathToGoProject = path.join(TEMP_TEST_DIR, goProjectName);
+    let projectIDForNodeApp;
+    let projectIDForGenericDocker;
+
+    before('create a sample Node.js and Go project and bind to Codewind, without building', async function() {
+        this.timeout(testTimeout.med);
+        projectIDForNodeApp = await projectService.createProjectFromTemplate(nodeProjectName, 'nodejs', pathToNodeProject);
+        projectIDForGenericDocker = await projectService.createProjectFromTemplate(goProjectName, 'go', pathToGoProject);
+    });
+
+    after(async function() {
+        this.timeout(testTimeout.med);
+        await projectService.removeProject(pathToNodeProject, projectIDForNodeApp);
+        await projectService.removeProject(pathToGoProject, projectIDForGenericDocker);
+    });
+
+    describe('GET', function() {
+        it('returns an empty array as the project\'s links object is empty', async function() {
+            const body = await projectService.getProjectLinks(projectIDForNodeApp);
+            body.length.should.equal(0);
+        });
+    });
+    describe('POST', function() {
+        it('adds a link to a non-local project (located on different PFEs)', async function() {
+            const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, 'ENVNAME', 'urlthatdoesntoexist', 'nonexistantpfeurl');
+            res.should.have.status(200);
+            res.should.have.ownProperty('body');
+            const { body } = res;
+            body.should.be.an('array');
+            body.length.should.equal(1);
+        });
+        it('adds a link to a local project (located on the same PFE)', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, 'ENVNAME');
+            res.should.have.status(200);
+            res.should.have.ownProperty('body');
+            const { body } = res;
+            body.should.be.an('array');
+            body.length.should.equal(1);
+        });
+        it('fails to add a link as the request does not contain the required fields', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, null);
+            res.should.have.status(400);
+        });
+        it('fails to add a link as the request envName is a blank string', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '', 'urlthatdoesntoexist', 'nonexistantpfeurl');
+            res.should.have.status(400);
+        });
+        it('fails to add a link as the targetProjectPFEURL field is populated but the targetProjectURL field is not (non-local validation test)', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '', null, 'nonexistantpfeurl');
+            res.should.have.status(400);
+        });
+        describe('add a duplicate envName', function() {
+            const duplicateEnvName = 'DUPE_ENV_VALUE';
+            before(async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, duplicateEnvName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
+                res.should.have.status(200);
+            });
+            it('fails to add a link with an envName that already exists', async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, duplicateEnvName, 'anotherurl', 'anothernonexistantpfeurl');
+                res.should.have.status(409);
+            });
+        });
+    });
+    describe('PUT', function() {
+        it('returns 404 as the link does not exist', async function() {
+            const res = await projectService.updateProjectLink(projectIDForNodeApp, 'doesnotexist');
+            res.should.have.status(404);
+        });
+        describe('updates a link', function() {
+            const envName = 'UPDATE_LINK';
+            before(async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, envName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
+                res.should.have.status(200);
+                const { body } = res;
+                const envExistsInLinks = body.findIndex(({ envName: existingEnv }) => existingEnv === envName);
+                envExistsInLinks.should.be.gt(-1);
+            });
+            it('returns 204 as the link has been updated', async function() {
+                const res = await projectService.updateProjectLink(projectIDForGenericDocker, envName, 'NEW_ENV_NAME', 'NEW_URL_VALUE');
+                res.should.have.status(204);
+
+                const body = await projectService.getProjectLinks(projectIDForGenericDocker);
+                const oldEnvExists = body.findIndex(({ envName: existingEnv }) => existingEnv === envName);
+                oldEnvExists.should.be.equal(-1);
+
+                const updatedEnvExists = body.findIndex(({ envName: existingEnv }) => existingEnv === 'NEW_ENV_NAME');
+                updatedEnvExists.should.be.gt(-1);
+            });
+        });
+    });
+    describe('DELETE', function() {
+        it('returns 404 as the link does not exist', async function() {
+            const res = await projectService.deleteProjectLink(projectIDForNodeApp, 'doesnotexist');
+            res.should.have.status(404);
+        });
+        describe('delete a link', function() {
+            const envName = 'DELETE_LINK';
+            before(async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, envName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
+                res.should.have.status(200);
+            });
+            it('returns 204 as the link has been deleted', async function() {
+                const res = await projectService.deleteProjectLink(projectIDForGenericDocker, envName);
+                res.should.have.status(204);
+            });
+        });
+    });
+});

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -49,19 +49,11 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
     describe('POST', function() {
         it('adds a link to a non-local project (located on different PFEs)', async function() {
             const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, 'ENVNAME', 'urlthatdoesntoexist', 'nonexistantpfeurl');
-            res.should.have.status(200);
-            res.should.have.ownProperty('body');
-            const { body } = res;
-            body.should.be.an('array');
-            body.length.should.equal(1);
+            res.should.have.status(202);
         });
         it('adds a link to a local project (located on the same PFE)', async function() {
             const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, 'ENVNAME');
-            res.should.have.status(200);
-            res.should.have.ownProperty('body');
-            const { body } = res;
-            body.should.be.an('array');
-            body.length.should.equal(1);
+            res.should.have.status(202);
         });
         it('fails to add a link as the request does not contain the required fields', async function() {
             const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, null);
@@ -79,7 +71,7 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
             const duplicateEnvName = 'DUPE_ENV_VALUE';
             before(async function() {
                 const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, duplicateEnvName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
-                res.should.have.status(200);
+                res.should.have.status(202);
             });
             it('fails to add a link with an envName that already exists', async function() {
                 const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, duplicateEnvName, 'anotherurl', 'anothernonexistantpfeurl');
@@ -96,14 +88,11 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
             const envName = 'UPDATE_LINK';
             before(async function() {
                 const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, envName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
-                res.should.have.status(200);
-                const { body } = res;
-                const envExistsInLinks = body.findIndex(({ envName: existingEnv }) => existingEnv === envName);
-                envExistsInLinks.should.be.gt(-1);
+                res.should.have.status(202);
             });
-            it('returns 204 as the link has been updated', async function() {
+            it('returns 202 as the link has been updated', async function() {
                 const res = await projectService.updateProjectLink(projectIDForGenericDocker, envName, 'NEW_ENV_NAME', 'NEW_URL_VALUE');
-                res.should.have.status(204);
+                res.should.have.status(202);
 
                 const body = await projectService.getProjectLinks(projectIDForGenericDocker);
                 const oldEnvExists = body.findIndex(({ envName: existingEnv }) => existingEnv === envName);
@@ -123,11 +112,11 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
             const envName = 'DELETE_LINK';
             before(async function() {
                 const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, envName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
-                res.should.have.status(200);
+                res.should.have.status(202);
             });
-            it('returns 204 as the link has been deleted', async function() {
+            it('returns 202 as the link has been deleted', async function() {
                 const res = await projectService.deleteProjectLink(projectIDForGenericDocker, envName);
-                res.should.have.status(204);
+                res.should.have.status(202);
             });
         });
     });

--- a/test/src/unit/middleware/checkProjectExists.test.js
+++ b/test/src/unit/middleware/checkProjectExists.test.js
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const rewire = require('rewire');
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.should();
+
+const { checkProjectExists, getProjectFromReq } = rewire('../../../../src/pfe/portal/middleware/checkProjectExists');
+
+const next = () => {};
+
+describe('checkProjectExists.js', function() {
+    const sandbox = sinon.createSandbox();
+    describe('checkProjectExists(req, res, next)', function() {
+        it('reports the status as 404 as the project does not exist (is false)', function() {
+            const failsToRetrieveProject = {
+                sanitizeParams: () => '',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => false,
+                    },
+                },
+            };
+            const codeShouldBe404 = (code) => {
+                code.should.equal(404);
+            };
+            const spiedCodeShouldBe404 = sandbox.spy(codeShouldBe404);
+            const spiedNext = sandbox.spy(next);
+            checkProjectExists(failsToRetrieveProject, { sendStatus: spiedCodeShouldBe404 }, spiedNext);
+            spiedCodeShouldBe404.should.be.calledOnce;
+            spiedNext.should.not.be.called;
+        });
+        it('does nothing and calls next() as the project is found (is true)', function() {
+            const successfullyRetrievesProject = {
+                sanitizeParams: () => '',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => true,
+                    },
+                },
+            };
+            const spiedSendStatus = sandbox.spy(() => {});
+            const spiedNext = sandbox.spy(next);
+            checkProjectExists(successfullyRetrievesProject, { sendStatus: spiedSendStatus }, spiedNext);
+            spiedSendStatus.should.not.be.called;
+            spiedNext.should.be.calledOnce;
+        });
+    });
+    describe('getProjectFromReq(req)', function() {
+        it('returns project from the req object', () => {
+            const spiedRetrieveProject = sandbox.spy(() => true);
+            const validReq = {
+                sanitizeParams: () => '',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: spiedRetrieveProject,
+                    },
+                },
+            };
+            getProjectFromReq(validReq).should.be.true;
+            spiedRetrieveProject.should.be.calledOnce;
+        });
+    });
+});
+

--- a/test/src/unit/modules/project/Links.test.js
+++ b/test/src/unit/modules/project/Links.test.js
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+global.codewind = { RUNNING_IN_K8S: false };
+
+const rewire = require('rewire');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const fs = require('fs-extra');
+const path = require('path');
+
+const Links = rewire('../../../../../src/pfe/portal/modules/project/Links');
+const { suppressLogOutput } = require('../../../../modules/log.service');
+const { TEMP_TEST_DIR } = require('../../../../config');
+const ProjectLinkError = require('../../../../../src/pfe/portal/modules/utils/errors/ProjectLinkError');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const dummyLocalLink = {
+    projectID: 'dummyID',
+    projectURL: 'projectURL',
+    envName: 'ENV_NAME',
+    type: Links.TYPES.LOCAL,
+};
+
+const dummyRemoteLink = {
+    ...dummyLocalLink,
+    parentPFEURL: 'parentURL',
+    type: Links.TYPES.REMOTE,
+};
+
+const afterDeleteEnvFile = () => {
+    afterEach(() => {
+        const envFileLocation = path.join(TEMP_TEST_DIR, '.codewind-project-links.env');
+        fs.removeSync(envFileLocation);
+    });
+};
+
+
+describe('Links.js', function() {
+    suppressLogOutput(Links);
+    describe('Class functions', () => {
+        describe('new Links(directory, args)', () => {
+            it('initialises a new Links object', () => {
+                const links = new Links('');
+                links.should.deep.equal({ _links: [], filePath: '.codewind-project-links.env' });
+            });
+            it('initialises a new Links object using the links passed in through args', () => {
+                const args = {
+                    _links: [dummyRemoteLink],
+                };
+                const links = new Links('', args);
+                links.should.deep.equal({ ...args, filePath: '.codewind-project-links.env' });
+            });
+        });
+        describe('getAll()', () => {
+            it('returns the links array', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                const linkArray = links.getAll();
+                linkArray.length.should.equal(0);
+            });
+            it('returns a populated links array', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                await links.add({ ...dummyRemoteLink, envName: 'otherEnv' });
+                const linkArray = links.getAll();
+                linkArray.length.should.equal(2);
+            });
+        });
+        describe('get()', () => {
+            it('returns the requested link', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                const link = links.get(dummyRemoteLink.envName);
+                link.should.deep.equal(dummyRemoteLink);
+            });
+            it('throws an error as the requested link does not exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                (() => links.get('nonexistant')).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'NOT_FOUND');
+            });
+        });
+        describe('getEnvPairs()', () => {
+            it('returns an empty array as no links exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                const linkArray = links.getEnvPairs();
+                linkArray.length.should.equal(0);
+            });
+            it('returns the links as envirnonment variable pairs', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                await links.add({ ...dummyRemoteLink, envName: 'otherEnv' });
+                const envPairs = links.getEnvPairs();
+                envPairs.length.should.equal(2);
+                const { envName, projectURL } = dummyRemoteLink;
+                envPairs.should.deep.equal([`${envName}=${projectURL}`, `otherEnv=${projectURL}`]);
+            });
+        });
+        describe('add(newLink)', () => {
+            afterDeleteEnvFile();
+            it('adds a new link to the link object and writes the env file', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                links.add(dummyRemoteLink);
+                links._links.length.should.equal(1);
+                const fileContents = await fs.readFile(links.filePath, 'utf8');
+                const { envName, projectURL } = dummyRemoteLink;
+                fileContents.should.equal(`${envName}=${projectURL}`);
+            });
+            it('throws an error as the newLink object is empty', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.add({})
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newLink object has all the parameters but they are null', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.add({
+                    projectID: null,
+                    projectURL: null,
+                    parentPFEURL: null,
+                    envName: null,
+                    type: null,
+                }).should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newLink object has a type of REMOTE but does not contain a parentPFEURL', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.add({
+                    ...dummyLocalLink,
+                    type: Links.TYPES.REMOTE,
+                })
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newLink object already exists in the Links array', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                return links.add(dummyRemoteLink)
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'EXISTS');
+            });
+        });
+        describe('update(envName, newEnvName, newProjectURL)', () => {
+            afterDeleteEnvFile();
+            it('updates a link', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+                await links.update(envName, 'NEW_ENV', 'NEW_URL');
+                const linkArray = links.getAll();
+                linkArray.should.deep.includes({ ...dummyRemoteLink, envName: 'NEW_ENV', projectURL: 'NEW_URL' });
+            });
+            it('does not error when the given fields are the same as the old ones', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName, projectURL } = dummyRemoteLink;
+                await links.update(envName, envName, projectURL);
+                const linkArray = links.getAll();
+                linkArray.should.deep.includes(dummyRemoteLink);
+            });
+            it('throws an error as the newEnvName is a blank string (no update)', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+                return links.update(envName, '', 'NEW_URL')
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newProjectURL is a blank string (no update)', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+
+                return links.update(envName, 'notnull', null)
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the link does not exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.update('nonexistant', 'notnull', 'notnull')
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'NOT_FOUND');
+            });
+            it('throws an error as the newEnvName is the same as an existing envName', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                await links.add({ ...dummyRemoteLink, envName: 'ENV_TO_UPDATE' });
+
+                const { envName, projectURL } = dummyRemoteLink;
+                return links.update('ENV_TO_UPDATE', envName, projectURL)
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'EXISTS');
+            });
+        });
+        describe('delete(envName)', () => {
+            afterDeleteEnvFile();
+            it('deletes a link', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+                await links.delete(envName);
+                const linkArray = links.getAll();
+                linkArray.should.deep.equal([]);
+            });
+            it('throws an error as the link does not exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.delete('nonexistant')
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'NOT_FOUND');
+            });
+        });
+    });
+    describe('Local functions', () => {
+        describe('validateLink(newLink, links', () => {
+            const validateLink = Links.__get__('validateLink');
+            it('throws an error as the newLink object is missing the projectID', () => {
+                const newLink = {
+                    envName: 'env',
+                    projectURL: 'some',
+                    type: Links.TYPES.LOCAL,
+                };
+                (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as a link with TYPE=REMOTE does not have a parentPFEURL', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'env',
+                    projectURL: 'some',
+                    type: Links.TYPES.REMOTE,
+                };
+                (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as a link with TYPE=REMOTE is given a projectURL of null', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'env',
+                    projectURL: null,
+                    parentPFEURL: 'url',
+                    type: Links.TYPES.REMOTE,
+                };
+                (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as newLink envName already exists in the links array', () => {
+                const links = [{ envName: 'existing' }];
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'existing',
+                    projectURL: 'some',
+                    type: Links.TYPES.LOCAL,
+                };
+                (() => validateLink(newLink, links)).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'EXISTS');
+            });
+            it('returns a validated link object', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'existing',
+                    projectURL: 'some',
+                    type: Links.TYPES.LOCAL,
+                };
+                const validatedLink = validateLink(newLink, []);
+                validatedLink.should.deep.equal(newLink);
+            });
+            it('returns a validated link object when projectURL is null and TYPE=LOCAL', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'existing',
+                    projectURL: null,
+                    type: Links.TYPES.LOCAL,
+                };
+                const validatedLink = validateLink(newLink, []);
+                validatedLink.should.deep.equal(newLink);
+            });
+        });
+        describe('envNameExists(links, envName)', () => {
+            const envNameExists = Links.__get__('envNameExists');
+            it('returns true as the given envName exists in the links array', () => {
+                const links = [{ envName: 'existing' }];
+                envNameExists(links, 'existing').should.be.true;
+            });
+            it('returns false as the given envName does not exist in the links array', () => {
+                envNameExists([], 'notexisting').should.be.false;
+            });
+        });
+        describe('writeEnvironmentFile(filePath, links)', () => {
+            const writeEnvironmentFile = Links.__get__('writeEnvironmentFile');
+            const filePath = path.join(TEMP_TEST_DIR, 'writeEnvironmentFileTest');
+            afterEach(() => {
+                fs.removeSync(filePath);
+            });
+            it('writes out the environment file', async() => {
+                const links = ['env1=url1', 'env2=url2'];
+                await writeEnvironmentFile(filePath, links);
+                await fs.pathExists(filePath);
+                const fileContents = await fs.readFile(filePath, 'utf8');
+                fileContents.should.equal('env1=url1\nenv2=url2');
+            });
+        });
+    });
+});


### PR DESCRIPTION
A few bugs in this code are fixed and functionality changed in network drop 2 https://github.com/eclipse/codewind/pull/2571 but I've kept this to keep the code changes as small as possible (but still big)
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds support for communication between Codewind applications on from Docker to Docker, and initial implementation of Local to a Remote Codewind. -> Through environment variables:
* For *Node, Liberty and Spring* the environment variables exist only in the application process in the Docker container to take advantage of file-watchers fast restarting and to not make adding a link slower than making a code change.
* For *Swift, generic Docker types (Go, Python) and Appsody (different PR) the environment variables will be added through the `docker run --env-file` so they will be visible in the `docker inspect`.

### Summary

**Portal Changes**
* Adds support for one project to be able to communicate via environment variables to another Codewind project.
* Adds an API (/api/v1/projects/:id/links) to use get, add, remove and update the links
* Adds a `Link` class in a new `project` directory to keep the size of `Project.js` the same (ish):
    * Had to add helper functions so that the Links can write to the `Project inf` when updated.
* Each Project will have a links object that can contain references to many projects, best to see design docs.

* Other changes:
    * Added a middleware function to check whether a project exists - this can be used in the future to remove code duplicated on all endpoints that use the get project. Also added a function to easily get the project from `req`. 
    * Added a docs refresh to the `pushLocal.sh` script for API changes.

**Turbine Changes**
* Changed the start scripts for Node, Spring and Liberty to `export` all the variables in a network env file (only when the file exists).
* Changed the `docker run` for Swift to add a `--env-file` (only when the file exists)
* Changed the `docker run` command in Docker utils to add an `--env-file` command (only when the file exists)

**Testing**
* Manually tested each project type in the default templates to ensure that the environment variables are picked up.
* Added API and Unit tests for the Portal functions.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: First drop for #2191 

## Does this PR require a documentation change ?
Have updated the design docs: https://github.com/codewind-resources/design-documentation/blob/master/codewindServer/ProjectNetworking.md
Will require a docs change when the final parts of the networking are PR'd into master.

## Any special notes for your reviewer ?
