### PR TITLE
[0.10.0] Add Blocker to perf dashboard

### DIFF
--- a/src/performance/dashboard/src/components/modals/ModalBlocker.jsx
+++ b/src/performance/dashboard/src/components/modals/ModalBlocker.jsx
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+*******************************************************************************/
+
+import React, { Component, Fragment } from 'react'
+import { Button } from 'carbon-components-react'
+import IconRefresh from '@carbon/icons-react/es/restart/16';
+import { Modal } from 'carbon-components-react';
+
+import './ModalBlocker.scss'
+
+export default class ModalBlocker extends Component {
+
+    constructor(props) {
+        super(props);
+        this.handleRefreshPage = this.handleRefreshPage.bind(this)
+    }
+
+    handleRefreshPage() {
+        window.location.reload();
+    }
+
+    render() {
+
+        if (!this.props.active)
+            return (<Fragment />)
+
+        return (
+            <div>
+                <Modal id="CodewindDisconnected"
+                    modalAriaLabel="Codewind disconnected"
+                    open={true}
+                    danger={true}
+                    passiveModal={true}
+                    shouldsubmitonenter="false"
+                    modalLabel=""
+                    modalHeading="Dashboard Offline"
+                    primaryButtonText="Refresh"
+                    selectorPrimaryFocus="[data-modal-primary-focus]"
+                    secondaryButtonText=""
+                    iconDescription="Refresh window">
+                    <p>Performance dashboard has lost connection to Codewind</p>
+                    <p>You can try reconnecting by refreshing the page</p>
+                    <br />
+                    <Button size="default" onClick={() => this.handleRefreshPage()} kind="danger" icon={IconRefresh} iconDescription="Refresh page">Refresh Page</Button>
+                </Modal>
+            </div>
+        )
+    }
+}

--- a/src/performance/dashboard/src/components/modals/ModalBlocker.scss
+++ b/src/performance/dashboard/src/components/modals/ModalBlocker.scss
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019 IBM Corporation and others.
+* Copyright (c) 2020 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v2.0
 * which accompanies this distribution, and is available at
@@ -7,14 +7,12 @@
 *
 * Contributors:
 *     IBM Corporation - initial API and implementation
-******************************************************************************/
+*******************************************************************************/
 
-
-// Sample data from the API:  /api/vi/projects/{projectID}
-
-export const projectInfo = {
-    projectID: '4a8ccb90-7887-11e9-b7bb-6fc798faec9b',
-    name: 'SampleProjectName',
-    codewindVersion: 'latest',
+#CodewindDisconnected .bx--modal-close {
+  display: none;
 }
 
+#CodewindDisconnected .bx--modal-content {
+  line-height: 30px;
+}

--- a/src/performance/dashboard/src/components/modals/__tests__/ModelBlocker.test.js
+++ b/src/performance/dashboard/src/components/modals/__tests__/ModelBlocker.test.js
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright (c) 2020 IBM Corporation and others.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v2.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     IBM Corporation - initial API and implementation
+**/
+
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+import ModalBlocker from '../ModalBlocker';
+
+// initialize component props
+const componentProps = {
+    active: true
+}
+
+
+// component to render
+const wrapper = (
+    <ModalBlocker {...componentProps}/>
+)
+
+// Mute modal dataIconPath warnings
+console.error = () => { }
+
+// dont leak state
+afterEach(cleanup);
+
+// run test
+describe('<ModalBlocker />', () => {
+    test('dialog displays without error', () => {
+        render(wrapper)
+        expect(document.querySelector('#CodewindDisconnected.bx--modal').id).toBe('CodewindDisconnected');
+    });
+
+    test('has a valid heading', () => {
+        render(wrapper)
+        expect(document.querySelector('#CodewindDisconnected .bx--modal-header__heading').innerHTML).toBe('Dashboard Offline');
+    });
+});
+
+

--- a/src/performance/dashboard/src/components/navBar/NavBar.jsx
+++ b/src/performance/dashboard/src/components/navBar/NavBar.jsx
@@ -35,17 +35,17 @@ class NavBar extends React.Component {
     }
 
     async componentDidMount() {
+        if (this.props.socket != undefined) {
+            this.props.socket.on('disconnect', (reason) => {
+                console.error("Performance Dashboard has disconnected from Codewind: ", reason);
+                this.props.dispatch(setConnectionState(false));
+            });
 
-        this.props.socket.on('disconnect', (reason) => {
-            console.error("Performance Dashboard has disconnected from Codewind: ", reason);
-            this.props.dispatch(setConnectionState(false));
-        });
-
-        this.props.socket.on('connect', () => {
-            console.log("Performance Dashboard has connected to Codewind");
-            this.props.dispatch(setConnectionState(true));
-        });
-
+            this.props.socket.on('connect', () => {
+                console.log("Performance Dashboard has connected to Codewind");
+                this.props.dispatch(setConnectionState(true));
+            });
+        }
         try {
             await this.props.dispatch(fetchProjectConfig(this.props.projectID));
         } catch (err) {

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -21,6 +21,7 @@ import { SocketEvents } from '../utils/sockets/SocketEvents';
 import { CHART_TYPE_CPU, CHART_TYPE_MEMORY } from '../AppConstants';
 import ActionRunLoad from '../components/actions/ActionRunLoad';
 import ActionModifyLoadTests from '../components/actions/ActionModifyLoadTests';
+import ModalBlocker from '../components/modals/ModalBlocker'
 import Chart from '../components/chart/Chart';
 import ChartCounterSelector from '../components/chartCounterSelector/ChartCounterSelector';
 import ErrorBoundary from '../components/utils/ErrorBoundary';
@@ -51,6 +52,7 @@ class PagePerformance extends React.Component {
 
     bindSocketHandlers() {
         const uiSocket = this.props.socket;
+        window.addEventListener("focus", () =>  uiSocket.connect());
         let thisComponent = this;
         uiSocket.on(SocketEvents.RUNLOAD_STATUS_CHANGED, data => {
             if (data.status === 'idle' && data.projectID === this.props.projectID) {
@@ -157,6 +159,7 @@ class PagePerformance extends React.Component {
         const showTip = !(this.state.chartData && this.state.chartData.CPU && this.state.chartData.CPU.columns && this.state.chartData.CPU.columns.length > 0);
         return (
             <Fragment>
+                <ModalBlocker active={!this.props.connectionStatus.socketConnected}/>
                 <div className='pageTitle' role="main" aria-label='main page'>
                     <div className='pageTitle-content'>
                         <div className='main-title'>


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Blocks the Performance dashboard until it its fully connected to Codewind. When the dashboard detects that the UI Socket has disconnected it displayed a modal message that blocks interaction and ability to run new load tests or manipulate the chart: 

<img width="715" alt="Screenshot 2020-03-26 at 12 53 35" src="https://user-images.githubusercontent.com/28102564/77651959-73004900-6f65-11ea-9c01-e1e905606c7d.png">

This PR does not stop the dashboard from constantly retrying to connect on its own,  it does however make it clear the correction is currently down, preventing the user from trying to launch a new a load run where the dashboard could miss the status changes happening over the UISocket channel. 

See https://github.com/eclipse/codewind/issues/2284

