### PR TITLE
[WIP] Enhance the ability for two Docker projects to communicate (Networking drop 2)

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1753,6 +1753,95 @@ paths:
                     example: "/Dockerfile-tools"
        500:
           description: Internal Server Error
+  /api/v1/projects/{id}/links:
+    get:
+      summary: Returns the links for a project
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      responses:
+        200:
+          description: Returns the links to a given project
+    post:
+      summary: Adds a new link to a project
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      requestBody:
+        description: JSON object containing details of the project to link this project to
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LinkRequestBody'
+      responses:
+        200:
+          description: The link has been created
+        400:
+          description: Invalid parameters given
+        409:
+          description: A link with the envName specified already exists
+    put:
+      summary: Updates a project link
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      requestBody:
+        description: JSON object containing the envName of the link to update, and an updated envName or/and an updated projectURL
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - envName
+              properties:
+                envName:
+                  type: string
+                updatedEnvName:
+                  type: string
+                targetProjectURL:
+                  type: string
+      responses:
+          204:
+            description: The link has been updated
+          404:
+            description: The link does not exists
+    delete:
+      summary: Deletes a project link
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: '#/components/schemas/ProjectID'
+          required: true
+          description: id of project
+      requestBody:
+        description: JSON object containing the envName of the link to delete
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - envName
+              properties:
+                envName:
+                  type: string
+      responses:
+        204:
+          description: The link has been deleted
+        404:
+          description: The link does not exists
 
 components:
   schemas:
@@ -2246,6 +2335,26 @@ components:
     PfeLogLevel:
       type: string
       enum: ['trace', 'debug', 'info', 'warn', 'error']
+    LinkRequestBody:
+      type: object
+      required:
+        - targetProjectID
+        - envName
+      properties:
+        targetProjectID:
+          $ref: '#/components/schemas/ProjectID'
+        envName:
+          type: string
+        targetProjectURL:
+          type: string
+          description: >
+            The target project's external URL<br>
+            Required if the project to connect to is located on a different PFE
+        targetParentPFEURL:
+          type: string
+          description: >
+            The target project's PFE URL - used to identify that it is on a different PFE<br>
+            Required if the project to connect to is located on a different PFE
 
   responses:
     400:

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1798,7 +1798,7 @@ paths:
           required: true
           description: id of project
       requestBody:
-        description: JSON object containing the envName of the link to update, and an updated envName or/and an updated projectURL
+        description: JSON object containing the envName of the link to update and an updated envName
         content:
           application/json:
             schema:
@@ -1809,8 +1809,6 @@ paths:
                 envName:
                   type: string
                 updatedEnvName:
-                  type: string
-                targetProjectURL:
                   type: string
       responses:
           204:
@@ -2345,16 +2343,6 @@ components:
           $ref: '#/components/schemas/ProjectID'
         envName:
           type: string
-        targetProjectURL:
-          type: string
-          description: >
-            The target project's external URL<br>
-            Required if the project to connect to is located on a different PFE
-        targetParentPFEURL:
-          type: string
-          description: >
-            The target project's PFE URL - used to identify that it is on a different PFE<br>
-            Required if the project to connect to is located on a different PFE
 
   responses:
     400:

--- a/src/pfe/file-watcher/idc/artifacts/start_server.sh
+++ b/src/pfe/file-watcher/idc/artifacts/start_server.sh
@@ -59,6 +59,12 @@ if [ -f $SERVER_XML ]; then
                 echo "Checking for missing runtime features for $WLP_USER_DIR/servers/defaultServer $(date)"
                 /opt/ibm/wlp/bin/installUtility install --acceptLicense $WLP_USER_DIR/servers/defaultServer/server.xml
                 echo "Starting server $WLP_USER_DIR/servers/defaultServer $(date)"
+
+                PROJECT_LINKS_ENV_FILE="$APP_DIR/.codewind-project-links.env"
+                if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+                        while read LINE; do export "$LINE"; done < $PROJECT_LINKS_ENV_FILE
+                fi
+
                 /opt/ibm/wlp/bin/server start
                 echo "Completed $(date)"
         fi

--- a/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
+++ b/src/pfe/file-watcher/scripts/nodejsScripts/noderun.sh
@@ -56,6 +56,11 @@ start() {
 
     npm install 1>> $LOG_FILE 2>> $LOG_FILE
 
+    PROJECT_LINKS_ENV_FILE="/app/.codewind-project-links.env"
+	if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+		while read LINE; do export "$LINE"; done < $PROJECT_LINKS_ENV_FILE
+	fi
+
     # One of two npm scripts will be run: 'start' or 'debug'.
     # If auto build is enabled, we wrap the script in 'nodemon'.
 

--- a/src/pfe/file-watcher/scripts/springScripts/spring-start.sh
+++ b/src/pfe/file-watcher/scripts/springScripts/spring-start.sh
@@ -7,6 +7,11 @@ echo "PROJECT_NAME=$PROJECT_NAME"
 echo "START_MODE=$START_MODE"
 echo "DEBUG_PORT=$DEBUG_PORT"
 
+PROJECT_LINKS_ENV_FILE="/root/app/.codewind-project-links.env"
+if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+    while read LINE; do export "$LINE"; done < $PROJECT_LINKS_ENV_FILE
+fi
+
 # Start the application
 echo "Starting Spring application: $PROJECT_NAME in mode: $START_MODE"
 if [ "$START_MODE" == "run" ]; then

--- a/src/pfe/file-watcher/scripts/swift-container.sh
+++ b/src/pfe/file-watcher/scripts/swift-container.sh
@@ -244,7 +244,13 @@ function dockerRun() {
 	workspace=`$util getWorkspacePathForVolumeMounting $LOCAL_WORKSPACE`
 	echo "Workspace path used for volume mounting is: "$workspace""
 
-	$IMAGE_COMMAND run --network=codewind_network --name "$project" -dt -P -w /swift-project "$project"
+	PROJECT_LINKS_ENV_FILE="$workspace/$projectName/.codewind-project-links.env"
+	PROJECT_LINKS_PARAM=""
+	if [ -f "$PROJECT_LINKS_ENV_FILE" ]; then
+			PROJECT_LINKS_PARAM="--env-file $PROJECT_LINKS_ENV_FILE"
+	fi
+
+	$IMAGE_COMMAND run $PROJECT_LINKS_PARAM --network=codewind_network --name "$project" -dt -P -w /swift-project "$project"
 	if [ $? -eq 0 ]; then
 		echo -e "Copying over source files"
 		docker cp "$workspace/$projectName"/. "$project":/swift-project

--- a/src/pfe/file-watcher/server/src/utils/dockerutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/dockerutil.ts
@@ -22,6 +22,7 @@ import { BuildRequest, ProjectInfo } from "../projects/Project";
 import { StartModes } from "../projects/constants";
 import * as logHelper from "../projects/logHelper";
 import * as workspaceSettings from "./workspaceSettings";
+import { fstat, pathExists } from "fs-extra";
 
 const docker = new dockerode();
 
@@ -458,8 +459,16 @@ export async function runContainer(buildInfo: BuildRequest, containerName: strin
       }
     }
   }
-
   const args: string[] = ["run", "--label", "builtBy=codewind", "--name", containerName, "--network=codewind_network"];
+
+   // If the network file exists, add the environment variables to the Docker container
+   const networkEnvFile = path.join(buildInfo.projectLocation, ".codewind-project-links.env");
+   const networkEnvFileExists = await pathExists(networkEnvFile);
+   if (networkEnvFileExists) {
+     args.push("--env-file");
+     args.push(networkEnvFile);
+   }
+
   args.push(...portArgs);
   args.push("-dt");
   args.push(containerName);

--- a/src/pfe/portal/middleware/checkProjectExists.js
+++ b/src/pfe/portal/middleware/checkProjectExists.js
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+function checkProjectExists(req, res, next) {
+  const id = req.sanitizeParams('id');
+  const { cw_user: { projectList } } = req;
+  const project = projectList.retrieveProject(id);
+  if (!project) {
+    res.sendStatus(404);
+    return;
+  }
+  next();
+}
+
+function getProjectFromReq(req) {
+  const id = req.sanitizeParams('id');
+  const { cw_user: { projectList } } = req;
+  return projectList.retrieveProject(id);
+}
+
+module.exports = {
+  checkProjectExists,
+  getProjectFromReq,
+};

--- a/src/pfe/portal/middleware/checkProjectExists.js
+++ b/src/pfe/portal/middleware/checkProjectExists.js
@@ -13,7 +13,7 @@ function checkProjectExists(req, res, next) {
   const { cw_user: { projectList } } = req;
   const project = projectList.retrieveProject(id);
   if (!project) {
-    res.sendStatus(404);
+    res.status(404).send(`Project with ID '${id}' does not exist on the Codewind server`);
     return;
   }
   next();

--- a/src/pfe/portal/middleware/linkProxy.js
+++ b/src/pfe/portal/middleware/linkProxy.js
@@ -21,12 +21,18 @@ const router = (req) => {
   };
 }
 
+const pathRewrite = (path, req) => {
+  const id = req.sanitizeParams('id');
+  return path.replace(`/links/proxy/${id}`, '');
+}
+
 // proxy middleware options
 const options = {
   target: 'http://codewind-pfe', // target field is required but we overwrite it with the customRouter
   changeOrigin: true, // needed for virtual hosted sites
   ws: true, // proxy websockets
   router,
+  pathRewrite,
 };
 
 const projectLinkProxy = createProxyMiddleware(options);

--- a/src/pfe/portal/middleware/linkProxy.js
+++ b/src/pfe/portal/middleware/linkProxy.js
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const { getProjectFromReq } = require('./checkProjectExists');
+
+const router = (req) => {
+  const { protocol } = req;
+  const { host, ports: { internalPort }} = getProjectFromReq(req);
+  return {
+    protocol: `${protocol}:`, // The : is required
+    host: host,
+    port: internalPort,
+  };
+}
+
+// proxy middleware options
+const options = {
+  target: 'http://codewind-pfe', // target field is required but we overwrite it with the customRouter
+  changeOrigin: true, // needed for virtual hosted sites
+  ws: true, // proxy websockets
+  router,
+};
+
+const projectLinkProxy = createProxyMiddleware(options);
+
+module.exports = {
+  projectLinkProxy,
+}

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -23,6 +23,7 @@ const ProjectMetricsError = require('./utils/errors/ProjectMetricsError');
 const Logger = require('./utils/Logger');
 const LogStream = require('./LogStream');
 const metricsService = require('./metricsService');
+const Links = require('./project/Links');
 
 const log = new Logger(__filename);
 
@@ -129,6 +130,8 @@ module.exports = class Project {
       this.injectMetrics = args.injectMetrics;
     }
     this.capabilitiesReady = false;
+    
+    this.links = new Links(this.projectPath(), args.links);
   }
 
 
@@ -783,12 +786,28 @@ module.exports = class Project {
   /**
    * Resolves the given path against the project's monitor path.
    * The path is unchanged if it is already absolute.
-   * 
+   *
    * @param {String} path
    * @returns {String} an absolute path
    */
   resolveMonitorPath(path) {
     return isAbsolute(path) ? cwUtils.convertFromWindowsDriveLetter(path) : join(this.pathToMonitor, path);
+  }
+
+  // Project Link wrappers so they can access the writeInformationFile function
+  async createLink(newLink) {
+    await this.links.add(newLink);
+    return this.writeInformationFile();
+  }
+
+  async updateLink(envName, newEnvName, newProjectURL) {
+    await this.links.update(envName, newEnvName, newProjectURL);
+    return this.writeInformationFile();
+  }
+
+  async deleteLink(envName) {
+    await this.links.delete(envName);
+    return this.writeInformationFile();
   }
 }
 

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -130,8 +130,9 @@ module.exports = class Project {
       this.injectMetrics = args.injectMetrics;
     }
     this.capabilitiesReady = false;
-    
-    this.links = new Links(this.projectPath(), args.links);
+
+    // this.links = new Links(this.projectPath(), args.links);
+    this.links = new Links(this.projectPath());
   }
 
 

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -25,7 +25,7 @@ class Links {
     this._links = (args && args._links) ? args._links : [];
     this.filePath = path.join(directory, ENV_FILE_NAME);
   }
-  
+
   getAll() {
     return this._links;
   }
@@ -97,13 +97,10 @@ const envNameExists = (links, envName) => {
 }
 
 const writeEnvironmentFile = async (filePath, envPairArray) => {
-  const fileContents = envPairArray.join('\n');
+  let fileContents = envPairArray.join('\n');
+  // Add new line to the end of string
+  fileContents += '\n';
   await fs.writeFile(filePath, fileContents);
-}
-
-Links.TYPES = {
-  LOCAL: 'LOCAL', // Target project is running on the same PFE
-  REMOTE: 'REMOTE', // Target project is running on a different PFE
 }
 
 module.exports = Links;

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -26,6 +26,14 @@ class Links {
     this.filePath = path.join(directory, ENV_FILE_NAME);
   }
 
+  getFilePath() {
+    return this.filePath;
+  }
+
+  envFileExists() {
+    return fs.pathExists(this.filePath);
+  }
+
   getAll() {
     return this._links;
   }
@@ -47,7 +55,7 @@ class Links {
     const validatedLink = validateLink(newLink, this._links);
     log.info(`Link added - envName: ${envName}, projectURL: ${projectURL}`);
     this._links.push(validatedLink);
-    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+    await updateEnvironmentFile(this.filePath, this.getEnvPairs());
   }
 
   async update(envName, newEnvName) {
@@ -62,7 +70,7 @@ class Links {
 
     this._links[linkIndex] = validateLink({ ...currentLink, envName: newEnvName }, linksWithoutOneToBeUpdated);
     log.info(`Link updated - env: ${envName} properties changed to envName: ${newEnvName}`);
-    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+    await updateEnvironmentFile(this.filePath, this.getEnvPairs());
   }
 
   async delete(envName) {
@@ -72,7 +80,7 @@ class Links {
     }
     this._links.splice(linkIndex, 1);
     log.info(`Link ${envName} deleted`);
-    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+    await updateEnvironmentFile(this.filePath, this.getEnvPairs());
   }
 }
 
@@ -96,11 +104,14 @@ const envNameExists = (links, envName) => {
   return envList.includes(envName);
 }
 
-const writeEnvironmentFile = async (filePath, envPairArray) => {
+const updateEnvironmentFile = (filePath, envPairArray) => {
+  if (envPairArray.length === 0) {
+    return fs.remove(filePath);
+  }
   let fileContents = envPairArray.join('\n');
   // Add new line to the end of string
   fileContents += '\n';
-  await fs.writeFile(filePath, fileContents);
+  return fs.writeFile(filePath, fileContents);
 }
 
 module.exports = Links;

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -50,7 +50,7 @@ class Links {
     await writeEnvironmentFile(this.filePath, this.getEnvPairs());
   }
 
-  async update(envName, newEnvName, newProjectURL) {
+  async update(envName, newEnvName) {
     const linkIndex = this._links.findIndex(link => link.envName === envName);
     if (linkIndex === -1) {
       throw new ProjectLinkError('NOT_FOUND', envName);
@@ -60,8 +60,8 @@ class Links {
     // Clone and remove the updated link so we only validate against all other links
     const linksWithoutOneToBeUpdated = this._links.filter(link => link.envName !== envName);
 
-    this._links[linkIndex] = validateLink({ ...currentLink, envName: newEnvName, projectURL: newProjectURL }, linksWithoutOneToBeUpdated);
-    log.info(`Link updated - env: ${envName} properties changed to envName: ${newEnvName} projectURL: ${newProjectURL}`);
+    this._links[linkIndex] = validateLink({ ...currentLink, envName: newEnvName }, linksWithoutOneToBeUpdated);
+    log.info(`Link updated - env: ${envName} properties changed to envName: ${newEnvName}`);
     await writeEnvironmentFile(this.filePath, this.getEnvPairs());
   }
 

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -77,10 +77,8 @@ class Links {
 }
 
 const validateLink = (newLink, links) => {
-  const { projectID, parentPFEURL, envName, projectURL, type } = newLink;
-  // Only require a parentPFEURL and projectURL if the link is remote
-  // If the link is local then the parentPFEURL is not required and the projectURL can be undefined
-  if (!projectID || !envName || !type || (type === Links.TYPES.REMOTE && (!parentPFEURL || !projectURL))) {
+  const { projectID, envName, projectURL } = newLink;
+  if (!projectID || !envName || !projectURL) {
     log.error(newLink);
     throw new ProjectLinkError(`INVALID_PARAMETERS`, newLink.envName);
   }

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -15,15 +15,13 @@ const ProjectLinkError = require('../utils/errors/ProjectLinkError');
 const Logger = require('../utils/Logger');
 const log = new Logger(__filename);
 
-const ENV_FILE_NAME = '.codewind-project-links.env'; // This will be in the users container
-
 /**
  * The Links class
  */
 class Links {
   constructor(directory, args) {
     this._links = (args && args._links) ? args._links : [];
-    this.filePath = path.join(directory, ENV_FILE_NAME);
+    this.filePath = path.join(directory, Links.ENV_FILE_NAME);
   }
 
   getFilePath() {
@@ -83,6 +81,8 @@ class Links {
     await updateEnvironmentFile(this.filePath, this.getEnvPairs());
   }
 }
+
+Links.ENV_FILE_NAME = '.codewind-project-links.env'; // This will be in the users container
 
 const validateLink = (newLink, links) => {
   const { projectID, envName, projectURL } = newLink;

--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const fs = require('fs-extra');
+const path = require('path');
+
+const ProjectLinkError = require('../utils/errors/ProjectLinkError');
+const Logger = require('../utils/Logger');
+const log = new Logger(__filename);
+
+const ENV_FILE_NAME = '.codewind-project-links.env'; // This will be in the users container
+
+/**
+ * The Links class
+ */
+class Links {
+  constructor(directory, args) {
+    this._links = (args && args._links) ? args._links : [];
+    this.filePath = path.join(directory, ENV_FILE_NAME);
+  }
+  
+  getAll() {
+    return this._links;
+  }
+
+  get(envNameToFind) {
+    const link = this._links.find(({ envName }) => envName === envNameToFind);
+    if (!link) {
+      throw new ProjectLinkError('NOT_FOUND', envNameToFind);
+    }
+    return link;
+  }
+
+  getEnvPairs() {
+    return this.getAll().map(({ envName, projectURL }) => `${envName}=${projectURL}`)
+  }
+
+  async add(newLink) {
+    const { projectURL, envName } = newLink;
+    const validatedLink = validateLink(newLink, this._links);
+    log.info(`Link added - envName: ${envName}, projectURL: ${projectURL}`);
+    this._links.push(validatedLink);
+    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+  }
+
+  async update(envName, newEnvName, newProjectURL) {
+    const linkIndex = this._links.findIndex(link => link.envName === envName);
+    if (linkIndex === -1) {
+      throw new ProjectLinkError('NOT_FOUND', envName);
+    }
+    const currentLink = this._links[linkIndex];
+
+    // Clone and remove the updated link so we only validate against all other links
+    const linksWithoutOneToBeUpdated = this._links.filter(link => link.envName !== envName);
+
+    this._links[linkIndex] = validateLink({ ...currentLink, envName: newEnvName, projectURL: newProjectURL }, linksWithoutOneToBeUpdated);
+    log.info(`Link updated - env: ${envName} properties changed to envName: ${newEnvName} projectURL: ${newProjectURL}`);
+    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+  }
+
+  async delete(envName) {
+    const linkIndex = this._links.findIndex(link => link.envName === envName);
+    if (linkIndex === -1) {
+      throw new ProjectLinkError('NOT_FOUND', envName);
+    }
+    this._links.splice(linkIndex, 1);
+    log.info(`Link ${envName} deleted`);
+    await writeEnvironmentFile(this.filePath, this.getEnvPairs());
+  }
+}
+
+const validateLink = (newLink, links) => {
+  const { projectID, parentPFEURL, envName, projectURL, type } = newLink;
+  // Only require a parentPFEURL and projectURL if the link is remote
+  // If the link is local then the parentPFEURL is not required and the projectURL can be undefined
+  if (!projectID || !envName || !type || (type === Links.TYPES.REMOTE && (!parentPFEURL || !projectURL))) {
+    log.error(newLink);
+    throw new ProjectLinkError(`INVALID_PARAMETERS`, newLink.envName);
+  }
+
+  // Check for duplicate env name
+  const duplicatedEnvName = envNameExists(links, envName);
+  if (duplicatedEnvName) {
+    throw new ProjectLinkError('EXISTS', envName);
+  }
+  return newLink;
+}
+
+const envNameExists = (links, envName) => {
+  const envList = links.map(link => link.envName);
+  return envList.includes(envName);
+}
+
+const writeEnvironmentFile = async (filePath, envPairArray) => {
+  const fileContents = envPairArray.join('\n');
+  await fs.writeFile(filePath, fileContents);
+}
+
+Links.TYPES = {
+  LOCAL: 'LOCAL', // Target project is running on the same PFE
+  REMOTE: 'REMOTE', // Target project is running on a different PFE
+}
+
+module.exports = Links;

--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -51,7 +51,7 @@ module.exports.getContainerLogStream = function getContainerLogStream(project, o
 
 module.exports.inspect = async function inspect(project) {
   if (!project || !project.containerId || project.isClosed()) {
-    log.warn(`Unable to inspect: project does not exist, has no container or is closed`);
+    log.warn(`Unable to inspect: project '${project.name}' does not exist, has no container or is closed`);
     return;
   }
   const container = await docker.getContainer(project.containerId).inspect();

--- a/src/pfe/portal/modules/utils/errors/ProjectLinkError.js
+++ b/src/pfe/portal/modules/utils/errors/ProjectLinkError.js
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+'use strict';
+const BaseError = require('./BaseError')
+
+class ProjectLinkError extends BaseError {
+  // Identifier can be either a project name or ID depending on the error message
+  constructor(code = '[Unknown error code]', identifier, message) {
+    super(code, constructMessage(code, identifier, message));
+  }
+}
+
+ProjectLinkError.CODES = {
+  NOT_FOUND: 'NOT_FOUND',
+  INVALID_PARAMETERS: 'INVALID_PARAMETERS',
+  EXISTS: 'EXISTS',
+}
+
+/**
+ * Function to construct an error message based on the given error code
+ * @param code, the error code to create the message from
+ * @param identifier, the name/path of the Project in question (based on the code being called)
+ * @param message, a message to be appended on the end of a default message
+ */
+function constructMessage(code, identifier, message) {
+  let output = '';
+  switch(code) {
+  case ProjectLinkError.CODES.NOT_FOUND:
+    output = `Unable to find link: ${identifier}`;
+    break;
+  case ProjectLinkError.CODES.INVALID_PARAMETERS:
+    output = `Invalid parameters given for link: ${identifier}`;
+    break;
+  case ProjectLinkError.CODES.EXISTS:
+    output = `The envName '${identifier}' already exists as a link`;
+    break;
+  default:
+    output = `Unknown project link error`;
+  }
+
+  // Append message to output if provided
+  return message ? `${output}\n${message}` : output;
+}
+
+module.exports = ProjectLinkError;

--- a/src/pfe/portal/package-lock.json
+++ b/src/pfe/portal/package-lock.json
@@ -361,6 +361,14 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
       "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
     },
+    "@types/http-proxy": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
+      "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/keyv": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
@@ -1967,6 +1975,11 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "execa": {
       "version": "0.7.0",
@@ -4793,6 +4806,68 @@
         "toidentifier": "1.0.0"
       }
     },
+    "http-proxy": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.3.tgz",
+      "integrity": "sha512-GHvPeBD+A357zS5tHjzj6ISrVOjjCiy0I92bdyTJz0pNmIjFxO0NX/bX+xkGgnclKQE/5hHAB9JEQ7u9Pw4olg==",
+      "requires": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -5049,8 +5124,7 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -5061,7 +5135,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -6863,6 +6936,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "3.0.0",

--- a/src/pfe/portal/package.json
+++ b/src/pfe/portal/package.json
@@ -27,6 +27,7 @@
     "follow-redirects": "^1.7.0",
     "fs-extra": "^7.0.1",
     "got": "^10.6.0",
+    "http-proxy-middleware": "^1.0.3",
     "i18next": "^15.0.9",
     "i18next-node-fs-backend": "^2.1.3",
     "js-yaml": "^3.12.0",

--- a/src/pfe/portal/pushLocal.sh
+++ b/src/pfe/portal/pushLocal.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Refresh the docs directory
+rm -r ./docs
+cp -r ../../../docs ./
+
 docker cp config/. codewind-pfe:/portal/config
 docker cp docs/. codewind-pfe:/portal/docs
 docker cp middleware/. codewind-pfe:/portal/middleware

--- a/src/pfe/portal/routes/projects/index.js
+++ b/src/pfe/portal/routes/projects/index.js
@@ -27,6 +27,7 @@ const router = express.Router();
   require('./internal.route'),
   require('./fileChanges.route'),
   require('./remoteBind.route'),
+  require('./links.route'),
 ]
   .forEach((subRouter) => router.use(subRouter));
 

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -41,7 +41,7 @@ router.post('/api/v1/projects/:id/links', validateReq, checkProjectExists, async
     const project = getProjectFromReq(req);
     // TODO add logic to check remote project exists
     verifyTargetProjectExists(user, targetProjectID);
-    const projectURL = createProxyURL(targetProjectID);
+    const projectURL = createProxyURL(targetProjectID).toString();
 
     await project.createLink({
       projectID: targetProjectID,

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -140,7 +140,16 @@ const restartOrBuildProject = async(user, project) => {
 };
 
 const restartNodeSpringLiberty = async(user, project) => {
-  const { name, startMode } = project;
+  const { name, startMode, links } = project;
+  const linksFileExists = await links.envFileExists();
+  const projectRoot = cwUtils.getProjectSourceRoot(project);
+  // TODO don't hard code '.codewind-project-links.env'
+  const envFileName = '.codewind-project-links.env';
+  if (linksFileExists) {
+    await cwUtils.copyFile(project, links.getFilePath(), projectRoot, envFileName);
+  } else {
+    await cwUtils.deleteFile(project, projectRoot, envFileName);
+  }
   log.info(`Restarting ${name} to pick up network environment variables`);
   const mode = (startMode) ? startMode : 'run';
   await user.restartProject(project, mode);

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -1,0 +1,221 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+const express = require('express');
+const router = express.Router();
+
+const Logger = require('../../modules/utils/Logger');
+const { validateReq } = require('../../middleware/reqValidator');
+const { checkProjectExists, getProjectFromReq } = require('../../middleware/checkProjectExists');
+const { inspect: dockerInspect } = require('../../modules/utils/dockerFunctions');
+const { TYPES } = require('../../modules/project/Links');
+const cwUtils = require('../../modules/utils/sharedFunctions');
+const ProjectLinkError = require('../../modules/utils/errors/ProjectLinkError');
+
+const log = new Logger(__filename);
+
+router.get('/api/v1/projects/:id/links', validateReq, checkProjectExists, (req, res) => {
+  try {
+    const { links } = getProjectFromReq(req);
+    res.status(200).send(links.getAll());
+  } catch (err) {
+    log.error(err);
+    res.status(500).send(err);
+  }
+});
+
+router.post('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
+  // The targetProject is the one we want "this" project to be able to reach
+  const targetProjectID = req.sanitizeBody('targetProjectID');
+  const envName = req.sanitizeBody('envName');
+  const targetProjectURL = req.sanitizeBody('targetProjectURL');
+  const targetProjectPFEURL = req.sanitizeBody('targetProjectPFEURL');
+
+  try {
+    const { cw_user: user } = req;
+    const project = getProjectFromReq(req);
+    const newLink = {
+      projectID: targetProjectID,
+      envName,
+      projectURL: targetProjectURL,
+      parentPFEURL: targetProjectPFEURL,
+      type: TYPES.REMOTE,
+    };
+
+    // Check to see if the project exists on this PFE instance
+    if (!targetProjectURL && !targetProjectPFEURL) {
+      // Get the url from the projectList, throw an error if the project does not exist
+      const localProjectURL = await verifyProjectExistsAndReturnInternalURL(user, targetProjectID);
+      newLink.projectURL = localProjectURL;
+      newLink.type = TYPES.LOCAL;
+    }
+
+    await project.createLink(newLink);
+    log.info(`New project link created for ${project.name}`);
+
+    // Send status and then kick off the restart/rebuild
+    const { links } = project;
+    res.status(200).send(links.getAll());
+
+    if (project.isOpen()) {
+      await restartOrBuildProject(user, project);
+    }
+  } catch (err) {
+    log.error(err);
+    if (err.code === ProjectLinkError.CODES.INVALID_PARAMETERS) {
+      res.sendStatus(400);
+    } else if (err.code === ProjectLinkError.CODES.EXISTS) {
+      res.sendStatus(409);
+    } else {
+      res.status(500).send(err);
+    }
+  }
+});
+
+router.put('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
+  const currentEnvName = req.sanitizeBody('envName');
+  const newEnvName = req.sanitizeBody('updatedEnvName');
+  let newProjectURL = req.sanitizeBody('targetProjectURL');
+  try {
+    const { cw_user: user } = req;
+    const project = getProjectFromReq(req);
+    const { links } = project;
+
+    // If the link on the same PFE (local) fetch the projectURL from the ProjectList (ignore newProjectURL)
+    const { type: linkType, projectID: targetProjectID, projectURL: currentProjectURL } = links.get(currentEnvName);
+    
+    if (linkType === TYPES.LOCAL) {
+      // Get the url from the projectList, throw an error if the project does not exist
+      const localProjectURL = await verifyProjectExistsAndReturnInternalURL(user, targetProjectID);
+      newProjectURL = localProjectURL;
+    }
+
+    // If newEnvName or newProjectURL are not given through the API, default them to their old values
+    const updatedLinkEnvName = (newEnvName) ? newEnvName : currentEnvName;
+    const updatedLinkProjectURL = (newProjectURL) ? newProjectURL : currentProjectURL;
+    await project.updateLink(currentEnvName, updatedLinkEnvName, updatedLinkProjectURL);
+
+    // Send status and then kick off the restart/rebuild
+    res.sendStatus(204);
+
+    if (project.isOpen()) {
+      await restartOrBuildProject(user, project);
+    }
+  } catch (err) {
+    log.error(err);
+    if (err.code === ProjectLinkError.CODES.NOT_FOUND) {
+      res.sendStatus(404);
+    } else {
+      res.status(500).send(err);
+    }
+  }
+});
+
+router.delete('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
+  const envNameOfLinkToDelete = req.sanitizeBody('envName');
+  try {
+    const { cw_user: user } = req;
+    const project = getProjectFromReq(req);
+    await project.deleteLink(envNameOfLinkToDelete);
+
+    // Send status and then kick off the restart/rebuild
+    res.sendStatus(204);
+
+    if (project.isOpen()) {
+      await restartOrBuildProject(user, project);
+    }
+  } catch (err) {
+    log.error(err);
+    if (err.code === ProjectLinkError.CODES.NOT_FOUND) {
+      res.sendStatus(404);
+    } else {
+      res.status(500).send(err);
+    }
+  }
+});
+
+const verifyProjectExistsAndReturnInternalURL = async(user, projectID) => {
+  const project = await user.projectList.retrieveProject(projectID);
+  if (!project) {
+    throw new Error('projectID not found on local PFE');
+  }
+  const { host: dockerNetworkIP, ports: { internalPort }, appStatus } = project;
+  // If the project has not started return undefined as the projectURL
+  if (appStatus != 'started' && !dockerNetworkIP) {
+    return undefined;
+  }
+  // Attempt to get container name fall back to docker network IP address (given to us by file-watcher)
+  const container = await dockerInspect(project);
+  const host = (container && container.Name) ? container.Name.substring(1) : dockerNetworkIP;
+  return `${host}:${internalPort}`;
+}
+
+const restartOrBuildProject = async(user, project) => {
+  const { projectType } = project;
+  const projectTypesThatPickUpEnvsThroughRestart = ['nodejs', 'liberty', 'spring'];
+  if (projectTypesThatPickUpEnvsThroughRestart.includes(projectType.toLowerCase())) {
+    await restartNodeSpringLiberty(user, project);
+  } else {
+    await restartDocker(user, project);
+  }
+};
+
+const restartNodeSpringLiberty = async(user, project) => {
+  const { name, startMode } = project;
+  log.info(`Restarting ${name} to pick up network environment variables`);
+  const mode = (startMode) ? startMode : 'run';
+  await user.restartProject(project, mode);
+};
+
+const restartDocker = async(user, project) => {
+  const { name, buildStatus, projectID } = project;
+  // As this function will be repeated until it has verified whether the envs exist in the container
+  // we need to ensure that the project has not been deleted
+  const projectExists = user.projectList.retrieveProject(projectID);
+  if (!projectExists) {
+    return;
+  }
+
+  let container;
+  try {
+    container = await dockerInspect(project);
+  } catch (err) {
+    const { statusCode } = err;
+    // If container is not found keep waiting
+    if (statusCode && statusCode === 404) {
+      container = null;
+    } else {
+      throw err;
+    }
+  }
+
+  if (buildStatus != "inProgress" && container) {
+    const { Config: { Env: containerEnvs }} = container;
+    const linksExistInContainer = await checkIfEnvsExistInArray(project, containerEnvs);
+    // Only build and run the project if the links are not in the container
+    if (!linksExistInContainer) {
+      log.info(`Rebuilding ${name} to pick up network environment variables`);
+      await user.buildAndRunProject(project);
+    }
+  } else {
+    // if a build is in progress, wait 5 seconds and try again
+    await cwUtils.timeout(5000);
+    await restartDocker(user, project);
+  }
+};
+
+const checkIfEnvsExistInArray = (project, array) => {
+  const { links } = project;
+  const envPairs = links.getEnvPairs();
+  return envPairs.every(env => array.includes(env));
+}
+
+module.exports = router;

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -247,6 +247,8 @@ function setRoutes(app, userList) {
   const routes = require('./routes');
   const { pipePerfProxyReqsToPerfContainer } = require('./controllers/performance.controller');
   const { handleErrors } = require('./middleware/errorHandler');
+  const { ENDPOINT: projectLinkProxyEndpoint, projectLinkProxy } = require('./controllers/links.controller');
+  const { checkProjectExists } = require('./middleware/checkProjectExists');
 
   // Add the user object into the request
   app.all('*', function (req, res, next) {
@@ -257,6 +259,8 @@ function setRoutes(app, userList) {
 
   /* Proxy Performance container routes */
   app.use('/performance/*', pipePerfProxyReqsToPerfContainer);
+  // Proxy Link routes
+  app.use(`${projectLinkProxyEndpoint}:id`, checkProjectExists, projectLinkProxy);
 
   app.use(bodyParser.json({ limit: '30mb' }));
   app.use(bodyParser.urlencoded({
@@ -266,10 +270,6 @@ function setRoutes(app, userList) {
   log.logAllApiCalls(app); // must be called after 'app.use(bodyParser)', and before 'app.use(router)'
 
   app.use(routes);
-
-  const { projectLinkProxy } = require('./middleware/linkProxy');
-  const { checkProjectExists } = require('./middleware/checkProjectExists');
-  app.use('/links/proxy/:id', checkProjectExists, projectLinkProxy);
 
   // Default route to send a 404 response, rather than the express default which
   // sends back the user input, and was seen as a content spoofing vulnerability

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -247,7 +247,7 @@ function setRoutes(app, userList) {
   const routes = require('./routes');
   const { pipePerfProxyReqsToPerfContainer } = require('./controllers/performance.controller');
   const { handleErrors } = require('./middleware/errorHandler');
-  const { ENDPOINT: projectLinkProxyEndpoint, projectLinkProxy } = require('./controllers/links.controller');
+  const { EXPRESS_ENDPOINT: projectLinkProxyEndpoint, projectLinkProxy } = require('./controllers/links.controller');
   const { checkProjectExists } = require('./middleware/checkProjectExists');
 
   // Add the user object into the request
@@ -260,7 +260,7 @@ function setRoutes(app, userList) {
   /* Proxy Performance container routes */
   app.use('/performance/*', pipePerfProxyReqsToPerfContainer);
   // Proxy Link routes
-  app.use(`${projectLinkProxyEndpoint}:id`, checkProjectExists, projectLinkProxy);
+  app.use(projectLinkProxyEndpoint, checkProjectExists, projectLinkProxy);
 
   app.use(bodyParser.json({ limit: '30mb' }));
   app.use(bodyParser.urlencoded({

--- a/src/pfe/portal/server.js
+++ b/src/pfe/portal/server.js
@@ -267,6 +267,10 @@ function setRoutes(app, userList) {
 
   app.use(routes);
 
+  const { projectLinkProxy } = require('./middleware/linkProxy');
+  const { checkProjectExists } = require('./middleware/checkProjectExists');
+  app.use('/links/proxy/:id', checkProjectExists, projectLinkProxy);
+
   // Default route to send a 404 response, rather than the express default which
   // sends back the user input, and was seen as a content spoofing vulnerability
   app.use(function (req, res) {

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -458,12 +458,10 @@ async function getProjectLinks(projectID) {
     return res.body;
 }
 
-async function addProjectLink(projectID, targetProjectID, envName, targetProjectURL, targetProjectPFEURL) {
+async function addProjectLink(projectID, targetProjectID, envName) {
     const reqBody = {
         targetProjectID,
         envName,
-        targetProjectURL,
-        targetProjectPFEURL,
     };
     const res = await reqService.chai
         .post(`/api/v1/projects/${projectID}/links`)

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -472,11 +472,10 @@ async function addProjectLink(projectID, targetProjectID, envName, targetProject
     return res;
 }
 
-async function updateProjectLink(projectID, envName, updatedEnvName, targetProjectURL) {
+async function updateProjectLink(projectID, envName, updatedEnvName) {
     const reqBody = {
         envName,
         updatedEnvName,
-        targetProjectURL,
     };
     const res = await reqService.chai
         .put(`/api/v1/projects/${projectID}/links`)

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -75,7 +75,7 @@ const defaultNodeProjectDirList = [
 async function createProjectFromTemplate(name, projectType, path, autoBuild = false) {
     const { url, language } = templateOptions[projectType];
 
-    const pfeProjectType = (projectType === 'openliberty')
+    const pfeProjectType = (['openliberty', 'go'].includes(projectType))
         ? 'docker'
         : projectType;
 
@@ -448,6 +448,51 @@ async function notifyPfeOfFileChangesAndAwaitMsg(array, projectID) {
     await reqService.makeReqAndAwaitSocketMsg(req, 200, expectedSocketMsg);
 }
 
+async function getProjectLinks(projectID) {
+    const res = await reqService.chai
+        .get(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE);
+    res.should.have.status(200);
+    res.should.have.ownProperty('body');
+    res.body.should.be.an('array');
+    return res.body;
+}
+
+async function addProjectLink(projectID, targetProjectID, envName, targetProjectURL, targetProjectPFEURL) {
+    const reqBody = {
+        targetProjectID,
+        envName,
+        targetProjectURL,
+        targetProjectPFEURL,
+    };
+    const res = await reqService.chai
+        .post(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send(reqBody);
+    return res;
+}
+
+async function updateProjectLink(projectID, envName, updatedEnvName, targetProjectURL) {
+    const reqBody = {
+        envName,
+        updatedEnvName,
+        targetProjectURL,
+    };
+    const res = await reqService.chai
+        .put(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send(reqBody);
+    return res;
+}
+
+async function deleteProjectLink(projectID, envName) {
+    const res = await reqService.chai
+        .delete(`/api/v1/projects/${projectID}/links`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send({ envName });
+    return res;
+}
+
 
 module.exports = {
     generateUniqueName,
@@ -483,4 +528,8 @@ module.exports = {
     buildProject,
     cloneProject,
     notifyPfeOfFileChangesAndAwaitMsg,
+    getProjectLinks,
+    addProjectLink,
+    updateProjectLink,
+    deleteProjectLink,
 };

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+
+const chai = require('chai');
+const path = require('path');
+const chaiResValidator = require('chai-openapi-response-validator');
+
+const projectService = require('../../../modules/project.service');
+const { testTimeout, TEMP_TEST_DIR, pathToApiSpec } = require('../../../config');
+
+chai.use(chaiResValidator(pathToApiSpec));
+chai.should();
+
+describe('Link tests (/api/v1/project/:id/links)', () => {
+    const nodeProjectName = `test-project-links-nodejs-${Date.now()}`;
+    const goProjectName = `test-project-links-go-${Date.now()}`;
+    const pathToNodeProject = path.join(TEMP_TEST_DIR, nodeProjectName);
+    const pathToGoProject = path.join(TEMP_TEST_DIR, goProjectName);
+    let projectIDForNodeApp;
+    let projectIDForGenericDocker;
+
+    before('create a sample Node.js and Go project and bind to Codewind, without building', async function() {
+        this.timeout(testTimeout.med);
+        projectIDForNodeApp = await projectService.createProjectFromTemplate(nodeProjectName, 'nodejs', pathToNodeProject);
+        projectIDForGenericDocker = await projectService.createProjectFromTemplate(goProjectName, 'go', pathToGoProject);
+    });
+
+    after(async function() {
+        this.timeout(testTimeout.med);
+        await projectService.removeProject(pathToNodeProject, projectIDForNodeApp);
+        await projectService.removeProject(pathToGoProject, projectIDForGenericDocker);
+    });
+
+    describe('GET', function() {
+        it('returns an empty array as the project\'s links object is empty', async function() {
+            const body = await projectService.getProjectLinks(projectIDForNodeApp);
+            body.length.should.equal(0);
+        });
+    });
+    describe('POST', function() {
+        it('adds a link to a non-local project (located on different PFEs)', async function() {
+            const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, 'ENVNAME', 'urlthatdoesntoexist', 'nonexistantpfeurl');
+            res.should.have.status(200);
+            res.should.have.ownProperty('body');
+            const { body } = res;
+            body.should.be.an('array');
+            body.length.should.equal(1);
+        });
+        it('adds a link to a local project (located on the same PFE)', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, 'ENVNAME');
+            res.should.have.status(200);
+            res.should.have.ownProperty('body');
+            const { body } = res;
+            body.should.be.an('array');
+            body.length.should.equal(1);
+        });
+        it('fails to add a link as the request does not contain the required fields', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, null);
+            res.should.have.status(400);
+        });
+        it('fails to add a link as the request envName is a blank string', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '', 'urlthatdoesntoexist', 'nonexistantpfeurl');
+            res.should.have.status(400);
+        });
+        it('fails to add a link as the targetProjectPFEURL field is populated but the targetProjectURL field is not (non-local validation test)', async function() {
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '', null, 'nonexistantpfeurl');
+            res.should.have.status(400);
+        });
+        describe('add a duplicate envName', function() {
+            const duplicateEnvName = 'DUPE_ENV_VALUE';
+            before(async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, duplicateEnvName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
+                res.should.have.status(200);
+            });
+            it('fails to add a link with an envName that already exists', async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, duplicateEnvName, 'anotherurl', 'anothernonexistantpfeurl');
+                res.should.have.status(409);
+            });
+        });
+    });
+    describe('PUT', function() {
+        it('returns 404 as the link does not exist', async function() {
+            const res = await projectService.updateProjectLink(projectIDForNodeApp, 'doesnotexist');
+            res.should.have.status(404);
+        });
+        describe('updates a link', function() {
+            const envName = 'UPDATE_LINK';
+            before(async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, envName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
+                res.should.have.status(200);
+                const { body } = res;
+                const envExistsInLinks = body.findIndex(({ envName: existingEnv }) => existingEnv === envName);
+                envExistsInLinks.should.be.gt(-1);
+            });
+            it('returns 204 as the link has been updated', async function() {
+                const res = await projectService.updateProjectLink(projectIDForGenericDocker, envName, 'NEW_ENV_NAME', 'NEW_URL_VALUE');
+                res.should.have.status(204);
+
+                const body = await projectService.getProjectLinks(projectIDForGenericDocker);
+                const oldEnvExists = body.findIndex(({ envName: existingEnv }) => existingEnv === envName);
+                oldEnvExists.should.be.equal(-1);
+
+                const updatedEnvExists = body.findIndex(({ envName: existingEnv }) => existingEnv === 'NEW_ENV_NAME');
+                updatedEnvExists.should.be.gt(-1);
+            });
+        });
+    });
+    describe('DELETE', function() {
+        it('returns 404 as the link does not exist', async function() {
+            const res = await projectService.deleteProjectLink(projectIDForNodeApp, 'doesnotexist');
+            res.should.have.status(404);
+        });
+        describe('delete a link', function() {
+            const envName = 'DELETE_LINK';
+            before(async function() {
+                const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, envName, 'urlthatdoesntoexist', 'nonexistantpfeurl');
+                res.should.have.status(200);
+            });
+            it('returns 204 as the link has been deleted', async function() {
+                const res = await projectService.deleteProjectLink(projectIDForGenericDocker, envName);
+                res.should.have.status(204);
+            });
+        });
+    });
+});

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -47,15 +47,7 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
         });
     });
     describe('POST', function() {
-        it('adds a link to a non-local project (located on different PFEs)', async function() {
-            const res = await projectService.addProjectLink(projectIDForGenericDocker, projectIDForNodeApp, 'ENVNAME', 'urlthatdoesntoexist', 'nonexistantpfeurl');
-            res.should.have.status(200);
-            res.should.have.ownProperty('body');
-            const { body } = res;
-            body.should.be.an('array');
-            body.length.should.equal(1);
-        });
-        it('adds a link to a local project (located on the same PFE)', async function() {
+        it('adds a link to a project (located on the same PFE)', async function() {
             const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, 'ENVNAME');
             res.should.have.status(200);
             res.should.have.ownProperty('body');
@@ -68,11 +60,7 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
             res.should.have.status(400);
         });
         it('fails to add a link as the request envName is a blank string', async function() {
-            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '', 'urlthatdoesntoexist', 'nonexistantpfeurl');
-            res.should.have.status(400);
-        });
-        it('fails to add a link as the targetProjectPFEURL field is populated but the targetProjectURL field is not (non-local validation test)', async function() {
-            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '', null, 'nonexistantpfeurl');
+            const res = await projectService.addProjectLink(projectIDForNodeApp, projectIDForGenericDocker, '');
             res.should.have.status(400);
         });
         describe('add a duplicate envName', function() {

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -102,7 +102,7 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
                 envExistsInLinks.should.be.gt(-1);
             });
             it('returns 204 as the link has been updated', async function() {
-                const res = await projectService.updateProjectLink(projectIDForGenericDocker, envName, 'NEW_ENV_NAME', 'NEW_URL_VALUE');
+                const res = await projectService.updateProjectLink(projectIDForGenericDocker, envName, 'NEW_ENV_NAME');
                 res.should.have.status(204);
 
                 const body = await projectService.getProjectLinks(projectIDForGenericDocker);

--- a/test/src/unit/controllers/links.controller.test.js
+++ b/test/src/unit/controllers/links.controller.test.js
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+const chai = require('chai');
+const rewire = require('rewire');
+const { mockReq, mockRes } = require('sinon-express-mock');
+
+const linksController = rewire('../../../../src/pfe/portal/controllers/links.controller');
+
+chai.should();
+
+describe('links.controller.js', () => {
+    describe('customRouter(req)', () => {
+        const customRouter = linksController.__get__('customRouter');
+        const mockedProject = {
+            host: 'host',
+            ports: {
+                internalPort: 'internalPort',
+            },
+        };
+        it('returns an object containing the protocol, host and port of the project to redirect the request to', () => {
+            const request = {
+                sanitizeParams: () => '',
+                protocol: 'http',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => mockedProject,
+                    },
+                },
+            };
+            const mockedRequest = mockReq(request);
+            const { protocol, host, port } = customRouter(mockedRequest);
+            protocol.should.equal('http:');
+            host.should.equal(mockedProject.host);
+            port.should.equal(mockedProject.ports.internalPort);
+        });
+    });
+    describe('pathRewrite(path, req)', () => {
+        const pathRewrite = linksController.__get__('pathRewrite');
+        const getFullProxyEndpoint = linksController.__get__('getFullProxyEndpoint');
+        it('removes the proxy endpoint from the request path', () => {
+            const projectID = 'mockedID';
+            const path = `${getFullProxyEndpoint(projectID)}/endpoint`;
+            const request = {
+                sanitizeParams: () => projectID,
+            };
+            const mockedRequest = mockReq(request);
+            const pathWithoutProxyEndpoint = pathRewrite(path, mockedRequest);
+            pathWithoutProxyEndpoint.should.equal('/endpoint');
+        });
+    });
+    describe('createProxyURL(targetProjectID)', () => {
+        it('removes the proxy endpoint from the request path', () => {
+            const projectID = 'mockedID';
+            process.env.HOSTNAME = 'codewind-pfe';
+            const proxyURL = linksController.createProxyURL(projectID);
+            proxyURL.toString().should.equal(`http://codewind-pfe:9090/links/proxy/${projectID}`);
+        });
+    });
+});

--- a/test/src/unit/middleware/checkProjectExists.test.js
+++ b/test/src/unit/middleware/checkProjectExists.test.js
@@ -30,12 +30,16 @@ describe('checkProjectExists.js', function() {
                     },
                 },
             };
-            const codeShouldBe404 = (code) => {
+            function codeShouldBe404(code) {
                 code.should.equal(404);
+                return this;
+            };
+            const sendShouldBe = (text) => {
+                text.should.equal(`Project with ID '' does not exist on the Codewind server`);
             };
             const spiedCodeShouldBe404 = sandbox.spy(codeShouldBe404);
             const spiedNext = sandbox.spy(next);
-            checkProjectExists(failsToRetrieveProject, { sendStatus: spiedCodeShouldBe404 }, spiedNext);
+            checkProjectExists(failsToRetrieveProject, { status: spiedCodeShouldBe404, send: sendShouldBe }, spiedNext);
             spiedCodeShouldBe404.should.be.calledOnce;
             spiedNext.should.not.be.called;
         });

--- a/test/src/unit/middleware/checkProjectExists.test.js
+++ b/test/src/unit/middleware/checkProjectExists.test.js
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const rewire = require('rewire');
+const chai = require('chai');
+const sinon = require('sinon');
+
+chai.should();
+
+const { checkProjectExists, getProjectFromReq } = rewire('../../../../src/pfe/portal/middleware/checkProjectExists');
+
+const next = () => {};
+
+describe('checkProjectExists.js', function() {
+    const sandbox = sinon.createSandbox();
+    describe('checkProjectExists(req, res, next)', function() {
+        it('reports the status as 404 as the project does not exist (is false)', function() {
+            const failsToRetrieveProject = {
+                sanitizeParams: () => '',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => false,
+                    },
+                },
+            };
+            const codeShouldBe404 = (code) => {
+                code.should.equal(404);
+            };
+            const spiedCodeShouldBe404 = sandbox.spy(codeShouldBe404);
+            const spiedNext = sandbox.spy(next);
+            checkProjectExists(failsToRetrieveProject, { sendStatus: spiedCodeShouldBe404 }, spiedNext);
+            spiedCodeShouldBe404.should.be.calledOnce;
+            spiedNext.should.not.be.called;
+        });
+        it('does nothing and calls next() as the project is found (is true)', function() {
+            const successfullyRetrievesProject = {
+                sanitizeParams: () => '',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: () => true,
+                    },
+                },
+            };
+            const spiedSendStatus = sandbox.spy(() => {});
+            const spiedNext = sandbox.spy(next);
+            checkProjectExists(successfullyRetrievesProject, { sendStatus: spiedSendStatus }, spiedNext);
+            spiedSendStatus.should.not.be.called;
+            spiedNext.should.be.calledOnce;
+        });
+    });
+    describe('getProjectFromReq(req)', function() {
+        it('returns project from the req object', () => {
+            const spiedRetrieveProject = sandbox.spy(() => true);
+            const validReq = {
+                sanitizeParams: () => '',
+                cw_user: {
+                    projectList: {
+                        retrieveProject: spiedRetrieveProject,
+                    },
+                },
+            };
+            getProjectFromReq(validReq).should.be.true;
+            spiedRetrieveProject.should.be.calledOnce;
+        });
+    });
+});
+

--- a/test/src/unit/modules/project/Links.test.js
+++ b/test/src/unit/modules/project/Links.test.js
@@ -132,23 +132,23 @@ describe('Links.js', function() {
                     .and.eventually.have.property('code', 'EXISTS');
             });
         });
-        describe('update(envName, newEnvName, newProjectURL)', () => {
+        describe('update(envName, newEnvName)', () => {
             afterDeleteEnvFile();
             it('updates a link', async() => {
                 const links = new Links(TEMP_TEST_DIR);
                 await links.add(dummyLink);
 
                 const { envName } = dummyLink;
-                await links.update(envName, 'NEW_ENV', 'NEW_URL');
+                await links.update(envName, 'NEW_ENV');
                 const linkArray = links.getAll();
-                linkArray.should.deep.includes({ ...dummyLink, envName: 'NEW_ENV', projectURL: 'NEW_URL' });
+                linkArray.should.deep.includes({ ...dummyLink, envName: 'NEW_ENV' });
             });
             it('does not error when the given fields are the same as the old ones', async() => {
                 const links = new Links(TEMP_TEST_DIR);
                 await links.add(dummyLink);
 
-                const { envName, projectURL } = dummyLink;
-                await links.update(envName, envName, projectURL);
+                const { envName } = dummyLink;
+                await links.update(envName, envName);
                 const linkArray = links.getAll();
                 linkArray.should.deep.includes(dummyLink);
             });
@@ -157,23 +157,13 @@ describe('Links.js', function() {
                 await links.add(dummyLink);
 
                 const { envName } = dummyLink;
-                return links.update(envName, '', 'NEW_URL')
-                    .should.be.eventually.rejectedWith(ProjectLinkError)
-                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
-            });
-            it('throws an error as the newProjectURL is a blank string (no update)', async() => {
-                const links = new Links(TEMP_TEST_DIR);
-                await links.add(dummyLink);
-
-                const { envName } = dummyLink;
-
-                return links.update(envName, 'notnull', null)
+                return links.update(envName, '')
                     .should.be.eventually.rejectedWith(ProjectLinkError)
                     .and.eventually.have.property('code', 'INVALID_PARAMETERS');
             });
             it('throws an error as the link does not exist', () => {
                 const links = new Links(TEMP_TEST_DIR);
-                return links.update('nonexistant', 'notnull', 'notnull')
+                return links.update('nonexistant', 'notnull')
                     .should.be.eventually.rejectedWith(ProjectLinkError)
                     .and.eventually.have.property('code', 'NOT_FOUND');
             });

--- a/test/src/unit/modules/project/Links.test.js
+++ b/test/src/unit/modules/project/Links.test.js
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+global.codewind = { RUNNING_IN_K8S: false };
+
+const rewire = require('rewire');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const fs = require('fs-extra');
+const path = require('path');
+
+const Links = rewire('../../../../../src/pfe/portal/modules/project/Links');
+const { suppressLogOutput } = require('../../../../modules/log.service');
+const { TEMP_TEST_DIR } = require('../../../../config');
+const ProjectLinkError = require('../../../../../src/pfe/portal/modules/utils/errors/ProjectLinkError');
+
+chai.should();
+chai.use(chaiAsPromised);
+
+const dummyLocalLink = {
+    projectID: 'dummyID',
+    projectURL: 'projectURL',
+    envName: 'ENV_NAME',
+    type: Links.TYPES.LOCAL,
+};
+
+const dummyRemoteLink = {
+    ...dummyLocalLink,
+    parentPFEURL: 'parentURL',
+    type: Links.TYPES.REMOTE,
+};
+
+const afterDeleteEnvFile = () => {
+    afterEach(() => {
+        const envFileLocation = path.join(TEMP_TEST_DIR, '.codewind-project-links.env');
+        fs.removeSync(envFileLocation);
+    });
+};
+
+
+describe('Links.js', function() {
+    suppressLogOutput(Links);
+    describe('Class functions', () => {
+        describe('new Links(directory, args)', () => {
+            it('initialises a new Links object', () => {
+                const links = new Links('');
+                links.should.deep.equal({ _links: [], filePath: '.codewind-project-links.env' });
+            });
+            it('initialises a new Links object using the links passed in through args', () => {
+                const args = {
+                    _links: [dummyRemoteLink],
+                };
+                const links = new Links('', args);
+                links.should.deep.equal({ ...args, filePath: '.codewind-project-links.env' });
+            });
+        });
+        describe('getAll()', () => {
+            it('returns the links array', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                const linkArray = links.getAll();
+                linkArray.length.should.equal(0);
+            });
+            it('returns a populated links array', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                await links.add({ ...dummyRemoteLink, envName: 'otherEnv' });
+                const linkArray = links.getAll();
+                linkArray.length.should.equal(2);
+            });
+        });
+        describe('get()', () => {
+            it('returns the requested link', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                const link = links.get(dummyRemoteLink.envName);
+                link.should.deep.equal(dummyRemoteLink);
+            });
+            it('throws an error as the requested link does not exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                (() => links.get('nonexistant')).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'NOT_FOUND');
+            });
+        });
+        describe('getEnvPairs()', () => {
+            it('returns an empty array as no links exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                const linkArray = links.getEnvPairs();
+                linkArray.length.should.equal(0);
+            });
+            it('returns the links as envirnonment variable pairs', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                await links.add({ ...dummyRemoteLink, envName: 'otherEnv' });
+                const envPairs = links.getEnvPairs();
+                envPairs.length.should.equal(2);
+                const { envName, projectURL } = dummyRemoteLink;
+                envPairs.should.deep.equal([`${envName}=${projectURL}`, `otherEnv=${projectURL}`]);
+            });
+        });
+        describe('add(newLink)', () => {
+            afterDeleteEnvFile();
+            it('adds a new link to the link object and writes the env file', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                links.add(dummyRemoteLink);
+                links._links.length.should.equal(1);
+                const fileContents = await fs.readFile(links.filePath, 'utf8');
+                const { envName, projectURL } = dummyRemoteLink;
+                fileContents.should.equal(`${envName}=${projectURL}`);
+            });
+            it('throws an error as the newLink object is empty', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.add({})
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newLink object has all the parameters but they are null', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.add({
+                    projectID: null,
+                    projectURL: null,
+                    parentPFEURL: null,
+                    envName: null,
+                    type: null,
+                }).should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newLink object has a type of REMOTE but does not contain a parentPFEURL', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.add({
+                    ...dummyLocalLink,
+                    type: Links.TYPES.REMOTE,
+                })
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newLink object already exists in the Links array', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                return links.add(dummyRemoteLink)
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'EXISTS');
+            });
+        });
+        describe('update(envName, newEnvName, newProjectURL)', () => {
+            afterDeleteEnvFile();
+            it('updates a link', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+                await links.update(envName, 'NEW_ENV', 'NEW_URL');
+                const linkArray = links.getAll();
+                linkArray.should.deep.includes({ ...dummyRemoteLink, envName: 'NEW_ENV', projectURL: 'NEW_URL' });
+            });
+            it('does not error when the given fields are the same as the old ones', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName, projectURL } = dummyRemoteLink;
+                await links.update(envName, envName, projectURL);
+                const linkArray = links.getAll();
+                linkArray.should.deep.includes(dummyRemoteLink);
+            });
+            it('throws an error as the newEnvName is a blank string (no update)', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+                return links.update(envName, '', 'NEW_URL')
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the newProjectURL is a blank string (no update)', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+
+                return links.update(envName, 'notnull', null)
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as the link does not exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.update('nonexistant', 'notnull', 'notnull')
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'NOT_FOUND');
+            });
+            it('throws an error as the newEnvName is the same as an existing envName', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+                await links.add({ ...dummyRemoteLink, envName: 'ENV_TO_UPDATE' });
+
+                const { envName, projectURL } = dummyRemoteLink;
+                return links.update('ENV_TO_UPDATE', envName, projectURL)
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'EXISTS');
+            });
+        });
+        describe('delete(envName)', () => {
+            afterDeleteEnvFile();
+            it('deletes a link', async() => {
+                const links = new Links(TEMP_TEST_DIR);
+                await links.add(dummyRemoteLink);
+
+                const { envName } = dummyRemoteLink;
+                await links.delete(envName);
+                const linkArray = links.getAll();
+                linkArray.should.deep.equal([]);
+            });
+            it('throws an error as the link does not exist', () => {
+                const links = new Links(TEMP_TEST_DIR);
+                return links.delete('nonexistant')
+                    .should.be.eventually.rejectedWith(ProjectLinkError)
+                    .and.eventually.have.property('code', 'NOT_FOUND');
+            });
+        });
+    });
+    describe('Local functions', () => {
+        describe('validateLink(newLink, links', () => {
+            const validateLink = Links.__get__('validateLink');
+            it('throws an error as the newLink object is missing the projectID', () => {
+                const newLink = {
+                    envName: 'env',
+                    projectURL: 'some',
+                    type: Links.TYPES.LOCAL,
+                };
+                (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as a link with TYPE=REMOTE does not have a parentPFEURL', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'env',
+                    projectURL: 'some',
+                    type: Links.TYPES.REMOTE,
+                };
+                (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as a link with TYPE=REMOTE is given a projectURL of null', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'env',
+                    projectURL: null,
+                    parentPFEURL: 'url',
+                    type: Links.TYPES.REMOTE,
+                };
+                (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'INVALID_PARAMETERS');
+            });
+            it('throws an error as newLink envName already exists in the links array', () => {
+                const links = [{ envName: 'existing' }];
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'existing',
+                    projectURL: 'some',
+                    type: Links.TYPES.LOCAL,
+                };
+                (() => validateLink(newLink, links)).should.throw(ProjectLinkError)
+                    .and.have.property('code', 'EXISTS');
+            });
+            it('returns a validated link object', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'existing',
+                    projectURL: 'some',
+                    type: Links.TYPES.LOCAL,
+                };
+                const validatedLink = validateLink(newLink, []);
+                validatedLink.should.deep.equal(newLink);
+            });
+            it('returns a validated link object when projectURL is null and TYPE=LOCAL', () => {
+                const newLink = {
+                    projectID: 'id',
+                    envName: 'existing',
+                    projectURL: null,
+                    type: Links.TYPES.LOCAL,
+                };
+                const validatedLink = validateLink(newLink, []);
+                validatedLink.should.deep.equal(newLink);
+            });
+        });
+        describe('envNameExists(links, envName)', () => {
+            const envNameExists = Links.__get__('envNameExists');
+            it('returns true as the given envName exists in the links array', () => {
+                const links = [{ envName: 'existing' }];
+                envNameExists(links, 'existing').should.be.true;
+            });
+            it('returns false as the given envName does not exist in the links array', () => {
+                envNameExists([], 'notexisting').should.be.false;
+            });
+        });
+        describe('writeEnvironmentFile(filePath, links)', () => {
+            const writeEnvironmentFile = Links.__get__('writeEnvironmentFile');
+            const filePath = path.join(TEMP_TEST_DIR, 'writeEnvironmentFileTest');
+            afterEach(() => {
+                fs.removeSync(filePath);
+            });
+            it('writes out the environment file', async() => {
+                const links = ['env1=url1', 'env2=url2'];
+                await writeEnvironmentFile(filePath, links);
+                await fs.pathExists(filePath);
+                const fileContents = await fs.readFile(filePath, 'utf8');
+                fileContents.should.equal('env1=url1\nenv2=url2');
+            });
+        });
+    });
+});

--- a/test/src/unit/modules/project/Links.test.js
+++ b/test/src/unit/modules/project/Links.test.js
@@ -220,7 +220,7 @@ describe('Links.js', function() {
             it('throws an error as the newLink object is missing the projectID', () => {
                 const newLink = {
                     envName: 'env',
-                    projectURL: 'some'
+                    projectURL: 'some',
                 };
                 (() => validateLink(newLink, [])).should.throw(ProjectLinkError)
                     .and.have.property('code', 'INVALID_PARAMETERS');

--- a/test/src/unit/routes/projects/links.route.test.js
+++ b/test/src/unit/routes/projects/links.route.test.js
@@ -1,0 +1,274 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+global.codewind = { RUNNING_IN_K8S: false };
+const rewire = require('rewire');
+const chai = require('chai');
+const sinon = require('sinon');
+
+const Links = rewire('../../../../../src/pfe/portal/routes/projects/links.route');
+const ProjectLinkError = require('../../../../../src/pfe/portal/modules/utils/errors/ProjectLinkError');
+const { suppressLogOutput } = require('../../../../modules/log.service');
+
+chai.should();
+
+describe('links.route.js', () => {
+    suppressLogOutput(Links);
+    describe('handleRequestError(res, err)', () => {
+        const handleRequestError = Links.__get__('handleRequestError');
+        [
+            { errCode: ProjectLinkError.CODES.INVALID_PARAMETERS, httpCode: 400 },
+            { errCode: ProjectLinkError.CODES.NOT_FOUND, httpCode: 404 },
+            { errCode: ProjectLinkError.CODES.EXISTS, httpCode: 409 },
+        ].forEach(({ errCode, httpCode }) => {
+            it(`reports a status of ${httpCode} as the err.code is ${errCode}`, () => {
+                const sendStatus = (code) => {
+                    code.should.equal(httpCode);
+                };
+                handleRequestError({ sendStatus }, { code: errCode });
+            });
+        });
+        it('reports a status of 500 as the err.code is unknown', () => {
+            const wantedError = {
+                code: 'UNKNOWN_ERROR',
+            };
+            function status(code) {
+                code.should.equal(500);
+                return this;
+            };
+            const send = (err) => {
+                err.should.equal(wantedError);
+            };
+            handleRequestError({ status, send }, wantedError);
+        });
+    });
+    describe('verifyTargetProjectExists(user, projectID)', () => {
+        const verifyTargetProjectExists = Links.__get__('verifyTargetProjectExists');
+        it('throws an error as the project cannot be retrieved', () => {
+            const user = {
+                projectList: {
+                    retrieveProject: () => false,
+                },
+            };
+            (() => verifyTargetProjectExists(user, 'dummyid')).should.throw(ProjectLinkError)
+                .and.have.property('code', 'NOT_FOUND');
+        });
+        it('returns the project as it can be retrieved', () => {
+            const user = {
+                projectList: {
+                    retrieveProject: () => { return { projectID: 'dummyid' }; },
+                },
+            };
+            const project = verifyTargetProjectExists(user, 'dummyid');
+            project.should.deep.equal({ projectID: 'dummyid' });
+        });
+    });
+    describe('restartOrBuildProject(user, project)', () => {
+        const restartOrBuildProject = Links.__get__('restartOrBuildProject');
+        const sandbox = sinon.createSandbox();
+        ['nodejs', 'liberty', 'spring'].forEach(projectType => {
+            it(`calls restartNodeSpringLiberty as the project type is ${projectType}`, () => {
+                const spiedRestartNodeSpringLiberty = sandbox.spy(() => {});
+                const spiedRestartDocker = sandbox.spy(() => {});
+
+                Links.__set__('restartNodeSpringLiberty', spiedRestartNodeSpringLiberty);
+                Links.__set__('restartDocker', spiedRestartDocker);
+
+                restartOrBuildProject({}, { projectType });
+
+                spiedRestartNodeSpringLiberty.should.be.calledOnce;
+                spiedRestartDocker.should.not.be.called;
+            });
+        });
+        ['swift', 'docker', 'appsody', 'anythingelse'].forEach(projectType => {
+            it(`calls restartDocker as the project type is ${projectType}`, () => {
+                const spiedRestartNodeSpringLiberty = sandbox.spy(() => {});
+                const spiedRestartDocker = sandbox.spy(() => {});
+
+                Links.__set__('restartNodeSpringLiberty', spiedRestartNodeSpringLiberty);
+                Links.__set__('restartDocker', spiedRestartDocker);
+
+                restartOrBuildProject({}, { projectType });
+
+                spiedRestartNodeSpringLiberty.should.not.be.called;
+                spiedRestartDocker.should.be.calledOnce;
+            });
+        });
+    });
+    describe('restartNodeSpringLiberty(user, project)', () => {
+        const restartNodeSpringLiberty = Links.__get__('restartNodeSpringLiberty');
+        const sandbox = sinon.createSandbox();
+
+        const mockedCwUtils = {
+            getProjectSourceRoot: () => null,
+            copyFile: () => null,
+            deleteFile: () => null,
+        };
+        const mockedUser = {
+            restartProject: () => null,
+        };
+        const mockedLinks = {
+            ENV_FILE_NAME: 'dummyFileName',
+            getFilePath: () => null,
+        };
+
+        beforeEach(() => {
+            sandbox.spy(mockedCwUtils, 'copyFile');
+            sandbox.spy(mockedCwUtils, 'deleteFile');
+            sandbox.spy(mockedUser, 'restartProject');
+            Links.__set__('cwUtils', mockedCwUtils);
+        });
+        afterEach(() => {
+            sandbox.restore();
+        });
+        it('calls copyFile as linkFileExists is true', async() => {
+            const mockedProject = { links: { ...mockedLinks, envFileExists: () => true } };
+            await restartNodeSpringLiberty(mockedUser, mockedProject);
+
+            const { copyFile, deleteFile } = mockedCwUtils;
+            copyFile.should.be.calledOnce;
+            deleteFile.should.not.be.called;
+        });
+        it('calls deleteFile as linkFileExists is false', async() => {
+            const mockedProject = { links: { ...mockedLinks, envFileExists: () => false } };
+            await restartNodeSpringLiberty(mockedUser, mockedProject);
+
+            const { copyFile, deleteFile } = mockedCwUtils;
+            copyFile.should.not.be.called;
+            deleteFile.should.be.calledOnce;
+        });
+        it('checks that mode defaults to "run" if startMode is null', async() => {
+            const mockedProject = { links: { ...mockedLinks, envFileExists: () => false } };
+            await restartNodeSpringLiberty(mockedUser, mockedProject);
+            mockedUser.restartProject.should.be.calledWith(mockedProject, 'run');
+        });
+        it('checks that mode equals "debug" when it is given as the startMode', async() => {
+            const mockedProject = { startMode: 'debug', links: { ...mockedLinks, envFileExists: () => false } };
+            await restartNodeSpringLiberty(mockedUser, mockedProject);
+            mockedUser.restartProject.should.be.calledWith(mockedProject, 'debug');
+        });
+    });
+    describe('restartDocker(user, project)', () => {
+        const restartDocker = Links.__get__('restartDocker');
+        const sandbox = sinon.createSandbox();
+        const mockedUser = {
+            restartProject: () => null,
+            projectList: {
+                retrieveProject: () => true,
+            },
+        };
+        const mockedProject = {
+            name: null,
+            buildStatus: null,
+            projectID: null,
+            links: {
+                getEnvPairs: () => ['env=val'],
+            },
+        };
+        it('does nothing and does not error as the project does not exist', () => {
+            const user = {
+                ...mockedUser,
+                projectList: {
+                    retrieveProject: () => false,
+                },
+            };
+            return restartDocker(user, mockedProject).should.not.be.rejected;
+        });
+        it('throws an error as dockerInspect throws an error that does not have a statusCode of 404', () => {
+            Links.__set__('dockerInspect', () => { throw new Error(); });
+            return restartDocker(mockedUser, mockedProject).should.be.rejected;
+        });
+        describe('buildStatus == inProgress or container is not populated', () => {
+            const project = {
+                ...mockedProject,
+                buildStatus: 'inProgress',
+            };
+            beforeEach(() => {
+                Links.__set__('cwUtils', { timeout: () => null });
+            });
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('calls restartDocker once as buildStatus == inProgress', async() => {
+                Links.__set__('dockerInspect', () => true);
+                const spiedRestartDocker = sandbox.spy(() => null);
+                Links.__set__('restartDocker', spiedRestartDocker);
+                await restartDocker(mockedUser, project);
+                spiedRestartDocker.should.be.calledOnce;
+            });
+            it('calls restartDocker once as container == null (dockerInspect throws 404 statusCode)', async() => {
+                Links.__set__('dockerInspect', () => {
+                    const err = new Error();
+                    err.statusCode = 404;
+                    throw err;
+                });
+                const spiedRestartDocker = sandbox.spy(() => null);
+                Links.__set__('restartDocker', spiedRestartDocker);
+                await restartDocker(mockedUser, project);
+                spiedRestartDocker.should.be.calledOnce;
+            });
+        });
+        describe('buildStatus != inProgress && container is a populated object', () => {
+            const user = {
+                ...mockedUser,
+                buildAndRunProject: () => true,
+            };
+            afterEach(() => {
+                sandbox.restore();
+            });
+            it('calls user.buildAndRunProject once as the linksExistInContainer is false', async() => {
+                Links.__set__('dockerInspect', () => {
+                    return {
+                        Config: {
+                            Env: [
+                                'env=notval',
+                            ],
+                        },
+                    };
+                });
+                sandbox.spy(user, 'buildAndRunProject');
+                await restartDocker(user, mockedProject);
+                const { buildAndRunProject } = user;
+                buildAndRunProject.should.be.calledOnce;
+            });
+            it('calls user.buildAndRunProject once as the linksExistInContainer is true', async() => {
+                Links.__set__('dockerInspect', () => {
+                    return {
+                        Config: {
+                            Env: [
+                                'env=val',
+                            ],
+                        },
+                    };
+                });
+                sandbox.spy(user, 'buildAndRunProject');
+                await restartDocker(user, mockedProject);
+                const { buildAndRunProject } = user;
+                buildAndRunProject.should.not.be.called;
+            });
+        });
+    });
+    describe('checkIfEnvsExistInArray(project, array)', () => {
+        const checkIfEnvsExistInArray = Links.__get__('checkIfEnvsExistInArray');
+        const arrayOfEnvs = ['env=val', 'env2=val2', 'env3=val3'];
+        it('returns true as all the project link envs exist in the given array', () => {
+            const links = {
+                getEnvPairs: () => ['env=val'],
+            };
+            checkIfEnvsExistInArray({ links }, arrayOfEnvs).should.be.true;
+        });
+        it('returns false as only some of the project link envs exist in the given array', () => {
+            const links = {
+                getEnvPairs: () => ['env=val', 'env20=val20'],
+            };
+            checkIfEnvsExistInArray({ links }, arrayOfEnvs).should.be.false;
+        });
+    });
+});


### PR DESCRIPTION
Follows https://github.com/eclipse/codewind/pull/2552
View the diff of 2552 and this PR: https://github.com/james-wallis/codewind/compare/project-link...james-wallis:project-link-proxy

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds a proxy to PFE to allow Codewind links to direct their requests to PFE which PFE can then forward on to their intended destination.
  * This solves the issue with changing ports/addresses.
  * PFE will check its ProjectList each time a request comes in to ensure that the project exists (404 otherwise) and then gets the target application's current URL rather than saving it directly into the project's file system and having to do a manual update - causing the project to restart in the process.

### Summary
* Updates the `openapi.yml` to have the correct documentation for these changes.
* Fixes bug from Networking drop 1 where the env file would not be added into the project container for Node, Spring and Liberty before a restart.
* Updates the tests

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2191

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
