### PR TITLE
create load-test dir if doesn't exist [0.10.0]

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -178,13 +178,8 @@ module.exports = class LoadRunner {
           metricsJson.desc = this.runDescription;
         }
         try {
-          // eslint-disable-next-line no-sync
-          if (!fs.existsSync(this.workingDir)) {
-            // eslint-disable-next-line no-sync
-            fs.mkdirSync(this.workingDir);
-          }
-          // eslint-disable-next-line no-sync
-          fs.writeJsonSync(this.workingDir + '/metrics.json', metricsJson, { spaces: '  ' });
+          await fs.ensureDir(this.workingDir);
+          await fs.writeJson(this.workingDir + '/metrics.json', metricsJson, { spaces: '  ' });
         } catch (err) {
           log.error(err);
         }

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -178,7 +178,13 @@ module.exports = class LoadRunner {
           metricsJson.desc = this.runDescription;
         }
         try {
-          await fs.writeJson(this.workingDir + '/metrics.json', metricsJson, { spaces: '  ' });
+          // eslint-disable-next-line no-sync
+          if (!fs.existsSync(this.workingDir)) {
+            // eslint-disable-next-line no-sync
+            fs.mkdirSync(this.workingDir);
+          }
+          // eslint-disable-next-line no-sync
+          fs.writeJsonSync(this.workingDir + '/metrics.json', metricsJson, { spaces: '  ' });
         } catch (err) {
           log.error(err);
         }
@@ -541,7 +547,7 @@ module.exports = class LoadRunner {
       log.info(`Load run on project ${this.project.projectID} completed`);
       this.project.loadInProgress = false;   // Clear the flag on the project
       if (this.collectionUri !== null) {
-        this.recordCollection();
+        await this.recordCollection();
       }
       clearTimeout(this.heartbeatID);
       this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
When load test runs, the output produced (metrics.json) is sometimes failing to write to the container due the the output directory not having been created yet.  This change checks the directory exists and creates if needed.

It also contains a change to await for the creation of collection

## Which issue(s) does this PR fix ?

#2284

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
no
## Any special notes for your reviewer ?
no
