### PR TITLE
Emit completed UISocket after profiling has finished

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -374,6 +374,8 @@ module.exports = class LoadRunner {
   async getJavaHealthCenterData(counter) {
     if (counter > 20) {
       log.error("getJavaHealthCenterData: Failed to save .hcd file");
+      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });
+      this.project = null;
       return;
     }
     try {
@@ -391,6 +393,7 @@ module.exports = class LoadRunner {
     log.info("getJavaHealthCenterData: .hcd copied to PFE");
     const data = { projectID: this.project.projectID,  status: 'hcdReady', timestamp: this.metricsFolder};
     this.user.uiSocket.emit('runloadStatusChanged', data);
+    this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });
     this.project = null;
   }
 
@@ -545,9 +548,9 @@ module.exports = class LoadRunner {
         await this.recordCollection();
       }
       clearTimeout(this.heartbeatID);
-      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });
       await this.endProfiling();
-      if (this.timerID === null) {
+      if (this.timerID === null ) {
+        this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });
         this.project = null;
       }
     });
@@ -608,6 +611,7 @@ module.exports = class LoadRunner {
       this.profilingSocket.disconnect();
       this.profilingSocket = null;
       this.profilingSamples = null;
+      this.user.uiSocket.emit('runloadStatusChanged', { projectID: this.project.projectID,  status: 'completed' });
       this.project = null;
     }
   }


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Sends the load run completed status to the IDE after the healthcenter (Java) or profiling.json (node) data has finished copying to PFE. 
