### PR TITLE
[0.11.0] Return true from Project.isMetricsAvailable() for appsody JavaScript projects.

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -201,7 +201,7 @@ module.exports = class Project {
   async isMetricsAvailable() {
     // hardcoding a return of true for appsody projects until we have a better
     // way of detecting appsody has the dashboard dependency
-    if (this.projectType === "appsodyExtension" && (this.language === 'nodejs' || this.language === 'java' || this.language === 'swift')) {
+    if (this.projectType === "appsodyExtension" && ['nodejs', 'javascript', 'java', 'swift'].includes(this.language)) {
       return true;
     } 
     const isMetricsAvailable = await metricsStatusChecker.isMetricsAvailable(this.projectPath(), this.language);

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -166,6 +166,12 @@ describe('Project.js', () => {
                 const areMetricsAvailable = await project.isMetricsAvailable();
                 areMetricsAvailable.should.be.true;
             });
+            it('Checks metrics for Appsody: JavaScript', async() => {
+                const projectObj = { name: 'dummy', projectType: 'appsodyExtension', language: 'javascript', locOnDisk: '/Documents/projectDir/' };
+                const project = createProjectAndCheckIsAnObject(projectObj, global.codewind.CODEWIND_WORKSPACE);
+                const areMetricsAvailable = await project.isMetricsAvailable();
+                areMetricsAvailable.should.be.true;
+            });
             it('Checks metrics for Appsody: Java', async() => {
                 const projectObj = { name: 'dummy', projectType: 'appsodyExtension', language: 'java', locOnDisk: '/Documents/projectDir/' };
                 const project = createProjectAndCheckIsAnObject(projectObj, global.codewind.CODEWIND_WORKSPACE);


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes `Project.isMetricsAvailable()` to return true for appsody 'javascript' projects as well as appsody 'nodejs' projects.
It also adds an extra test case to make sure we don't break this behaviour in the future.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2548 for the 0.11.0 stream.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No