### PR TITLE
PFE needs to use identical index.docker.io url to cwctl.

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -733,7 +733,7 @@ module.exports = class User {
     
     try {
       // Handle dockerhub specifically on local since docker.io does not work
-      if (address === "docker.io" && !global.codewind.RUNNING_IN_K8S) {
+      if (address.startsWith("docker.io") && !global.codewind.RUNNING_IN_K8S) {
         // eslint-disable-next-line no-param-reassign
         address = "https://index.docker.io/v1/";
       }
@@ -936,7 +936,7 @@ module.exports = class User {
 
     try {
       // Handle dockerhub specifically on local since docker.io does not work
-      if (address === "docker.io" && !global.codewind.RUNNING_IN_K8S) {
+      if (address.startsWith("docker.io") && !global.codewind.RUNNING_IN_K8S) {
         // eslint-disable-next-line no-param-reassign
         address = "https://index.docker.io/v1/";
       }

--- a/test/src/API/registrySecrets.test.js
+++ b/test/src/API/registrySecrets.test.js
@@ -251,7 +251,7 @@ describe('Registry Secrets route tests', function() {
             this.timeout(testTimeout.med);
             
             const dockerAddress = 'docker.io';
-            const invalidDockerAddress = 'docker.io.garbage';
+            const invalidDockerAddress = 'not.docker.io';
             const dockerUsername = 'randomusername';
             const dockerPassword = 'randompassword';
             const fullyQualifiedDockerRegistryAddress = 'https://index.docker.io/v1/';


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This is one half of ensuring that cwctl and PFE convert "docker.io" and "docker.io/" to exactly the same URL, "https://index.docker.io/v1/" (including trailing '/')/

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2588

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
This will not work without the matching PR: https://github.com/eclipse/codewind-installer/pull/426