### PR TITLE
[0.11.0] Determine name of profiling file before attempting copy

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -383,7 +383,6 @@ module.exports = class LoadRunner {
     try {
       await this.project.getProfilingByTime(this.metricsFolder);
     } catch (error) {
-      log.error(error);
       if (this.project !== null) {
         log.info(`getJavaHealthCenterData: .hcd file not found, trying again. Attempt ${counter}/20`);
         this.timerID = setTimeout(() => this.getJavaHealthCenterData(counter + 1), 3000);

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -526,29 +526,23 @@ module.exports = class Project {
       try {
         const projectRoot = join("home", "default", "app");
         const relativePathToFile = join("load-test", timeOfTestRun);
-        // Clear the hcdName
-//        this.hcdName = "";
-        // find the real name of the hcd file from the docker container
+        // find the actual name of the hcd file from the docker container
         cwUtils.findHCDFile(this, join(projectRoot,relativePathToFile));
-        console.log(`#### getPathToProfilingFile ${this.hcdName}`)
-    //    console.log(`#### getPathToProfilingFile got name as ${hcdFilename}`);
         if (this.hcdName == undefined  || this.hcdName == "") {
           throw new ProjectMetricsError('HCD_NOT_FOUND', this.name, `.hcd file has not been saved for load run ${timeOfTestRun}`);
         }
-        //const relativetoHC = join(relativePathToFile, this.hcdName);
-        log.info(`Copying profiling file for ${this.name} load run ${timeOfTestRun}`)
+        log.info(`Attempting to copy profiling file ${this.hcdName} for ${this.name} load run ${timeOfTestRun}`)
 
         let originHCDPath = join(projectRoot, relativePathToFile, this.hcdName);
         let destinationHCDPath = join(this.loadTestPath, timeOfTestRun, this.hcdName);
-        console.log(`####### fullHCDPath=${originHCDPath}##`);
-        console.log(`### destinationPath=${destinationHCDPath}##`);
+        log.debug(`getPathToProfilingFile=${originHCDPath}##`);
+        log.debug(`getPathToProfilingFile=${destinationHCDPath}##`);
 
-        await cwUtils.copyFileFromContainer(this, destinationHCDPath, originHCDPath);
+        await cwUtils.copyFileFromContainer(this, originHCDPath, destinationHCDPath);
       } catch (error) {
         throw new ProjectMetricsError('DOCKER_CP', this.name, error.message);
       }
-      log.info(`${this.name} hcd file from run ${timeOfTestRun} saved to pfe`)
-      
+      log.info(`${this.name} hcd file from run ${timeOfTestRun} saved to pfe`);      
     }
     return null
   }

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -526,14 +526,24 @@ module.exports = class Project {
       try {
         const projectRoot = join("home", "default", "app");
         const relativePathToFile = join("load-test", timeOfTestRun);
+        // Clear the hcdName
+//        this.hcdName = "";
         // find the real name of the hcd file from the docker container
-        const hcdFilename =  cwUtils.findHCDFile(this, join(projectRoot,relativePathToFile));
-        if (hcdFilename == undefined) {
+        cwUtils.findHCDFile(this, join(projectRoot,relativePathToFile));
+        console.log(`#### getPathToProfilingFile ${this.hcdName}`)
+    //    console.log(`#### getPathToProfilingFile got name as ${hcdFilename}`);
+        if (this.hcdName == undefined  || this.hcdName == "") {
           throw new ProjectMetricsError('HCD_NOT_FOUND', this.name, `.hcd file has not been saved for load run ${timeOfTestRun}`);
         }
-        const relativetoHC = join(relativePathToFile,hcdFilename);
+        //const relativetoHC = join(relativePathToFile, this.hcdName);
         log.info(`Copying profiling file for ${this.name} load run ${timeOfTestRun}`)
-        await cwUtils.copyFileFromContainer(this, this.loadTestPath, projectRoot, relativetoHC);
+
+        let originHCDPath = join(projectRoot, relativePathToFile, this.hcdName);
+        let destinationHCDPath = join(this.loadTestPath, timeOfTestRun, this.hcdName);
+        console.log(`####### fullHCDPath=${originHCDPath}##`);
+        console.log(`### destinationPath=${destinationHCDPath}##`);
+
+        await cwUtils.copyFileFromContainer(this, destinationHCDPath, originHCDPath);
       } catch (error) {
         throw new ProjectMetricsError('DOCKER_CP', this.name, error.message);
       }
@@ -799,7 +809,7 @@ async function isHcdSaved(pathToLoadTestDir) {
     if (extname(files[i]) == '.hcd') {
       return files[i];
     }
-  }
+  } 
   return false
 }
 

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -535,16 +535,26 @@ module.exports = class Project {
 
         let originHCDPath = join(projectRoot, relativePathToFile, this.hcdName);
         let destinationHCDPath = join(this.loadTestPath, timeOfTestRun, this.hcdName);
-        log.debug(`getPathToProfilingFile=${originHCDPath}##`);
-        log.debug(`getPathToProfilingFile=${destinationHCDPath}##`);
+        log.debug(`getPathToProfilingFile originHCDPath=${originHCDPath}.`);
+        log.debug(`getPathToProfilingFile destinationHCDPath=${destinationHCDPath}.`);
 
         await cwUtils.copyFileFromContainer(this, originHCDPath, destinationHCDPath);
       } catch (error) {
         throw new ProjectMetricsError('DOCKER_CP', this.name, error.message);
       }
-      log.info(`${this.name} hcd file from run ${timeOfTestRun} saved to pfe`);      
+      log.info(`${this.name} hcd file from run ${timeOfTestRun} saved to pfe`);   
+      return join(pathToLoadTestDir, this.hcdName);
     }
     return null
+  }
+
+  /**
+   * 
+   * @param {String|Int} timeOfTestRun in 'yyyymmddHHMMss' format
+   */
+  async removeProfilingData(timeOfTestRun) {
+    const profilingPath = join(this.loadTestPath, timeOfTestRun);
+    await rimraf.sync(profilingPath);
   }
 
   /**

--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -129,34 +129,24 @@ module.exports.copyFile = async function copyFile(project, fileToCopy, projectRo
 }
 
 module.exports.findHCDFile = function findHCDFile(project, hcdDirectory) {
-//  const command = 'ls ${hcdDirectory} | grep healthcenter';
-//  const hcdName = this.run(project.containerId, command);
-//  const hcdName = this.spawnContainerProcess(project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
-let process = this.spawnContainerProcess(project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
-let hcdName = "";
-process.stdout.on('data', (hcdNameOrNothing) => {
-  hcdName = hcdName + hcdNameOrNothing;
-//  project.hcdName = hcdName;
-  console.log(`############ ${hcdName}####`);
-  project.hcdName = hcdName.trim();
-  return project.hcdName;
-});
-
-
-//  console.log(`###### findHCDFile returned hcdName=${hcdName}`);
-
- // return hcdName;
+  const process = this.spawnContainerProcess(project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
+  let hcdName = "";
+  process.stdout.on('data', (hcdNameOrNothing) => {
+    // Convert the name to a string and trim
+    hcdName = hcdName + hcdNameOrNothing;
+    project.hcdName = hcdName.trim();
+    log.debug(`findHCDFile found ${project.hcdName}`)
+    return project.hcdName;
+  });
 }
 
-module.exports.copyFileFromContainer = async function copyFile(project, destinationPath, sourceFileName) {
- // const dockerCommand = `docker cp ${project.containerId}:${sourcePath ${destinationPath}`;
-//  log.info(`[docker cp command] ${dockerCommand}`);
-  const dockerCommand = `docker cp ${project.containerId}:${sourceFileName} ${destinationPath}`;
-  console.log(`####### dockerCommand=${dockerCommand}`);
+module.exports.copyFileFromContainer = async function copyFile(project, sourceName, destinationName) {
+  const dockerCommand = `docker cp ${project.containerId}:${sourceName} ${destinationName}`;
+  log.debug(`copyFileFromContainer dockerCommand=${dockerCommand}`);
   try {
     await exec(dockerCommand); 
   } catch (error) {
-    log.error(`copyFileFromContainer: Error copying file ${sourceFileName} from ${project.containerId}`);
+    log.warn(`copyFileFromContainer: Error copying file ${sourceName} from ${project.containerId}`);
     throw(error);
   }
 }

--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -129,18 +129,34 @@ module.exports.copyFile = async function copyFile(project, fileToCopy, projectRo
 }
 
 module.exports.findHCDFile = function findHCDFile(project, hcdDirectory) {
-  const hcdName = this.spawnContainerProcess(this.project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
+//  const command = 'ls ${hcdDirectory} | grep healthcenter';
+//  const hcdName = this.run(project.containerId, command);
+//  const hcdName = this.spawnContainerProcess(project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
+let process = this.spawnContainerProcess(project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
+let hcdName = "";
+process.stdout.on('data', (hcdNameOrNothing) => {
+  hcdName = hcdName + hcdNameOrNothing;
+//  project.hcdName = hcdName;
+  console.log(`############ ${hcdName}####`);
+  project.hcdName = hcdName.trim();
+  return project.hcdName;
+});
 
-  return hcdName;
+
+//  console.log(`###### findHCDFile returned hcdName=${hcdName}`);
+
+ // return hcdName;
 }
 
-module.exports.copyFileFromContainer = async function copyFile(project, destinationPath, projectRoot, relativePathOfFile) {
-  const dockerCommand = `docker cp ${project.containerId}:${projectRoot}/${relativePathOfFile} ${destinationPath}`;
-  log.info(`[docker cp command] ${dockerCommand}`);
+module.exports.copyFileFromContainer = async function copyFile(project, destinationPath, sourceFileName) {
+ // const dockerCommand = `docker cp ${project.containerId}:${sourcePath ${destinationPath}`;
+//  log.info(`[docker cp command] ${dockerCommand}`);
+  const dockerCommand = `docker cp ${project.containerId}:${sourceFileName} ${destinationPath}`;
+  console.log(`####### dockerCommand=${dockerCommand}`);
   try {
     await exec(dockerCommand); 
   } catch (error) {
-    log.error(`copyFileFromContainer: Error copying file ${relativePathOfFile} from ${project.containerId}`);
+    log.error(`copyFileFromContainer: Error copying file ${sourceFileName} from ${project.containerId}`);
     throw(error);
   }
 }

--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -128,6 +128,12 @@ module.exports.copyFile = async function copyFile(project, fileToCopy, projectRo
   await exec(dockerCommand);
 }
 
+module.exports.findHCDFile = function findHCDFile(project, hcdDirectory) {
+  const hcdName = this.spawnContainerProcess(this.project, ['sh', '-c', `ls ${hcdDirectory} | grep healthcenter`]);
+
+  return hcdName;
+}
+
 module.exports.copyFileFromContainer = async function copyFile(project, destinationPath, projectRoot, relativePathOfFile) {
   const dockerCommand = `docker cp ${project.containerId}:${projectRoot}/${relativePathOfFile} ${destinationPath}`;
   log.info(`[docker cp command] ${dockerCommand}`);


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR changes the way we copy profiling information from the project pod back to the docker volume. We were copying the load-test/date directory across but this would overwrite the metrics.json file.  We are now determining the name of the hcd file and copying just that.  

## Which issue(s) does this PR fix ?
This PR is part of the solution for https://github.com/eclipse/codewind/issues/2284

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
