### PR TITLE
[0.11.0] Display warning when no HTTP hits available

### DIFF
--- a/src/performance/dashboard/src/components/chart/Chart.jsx
+++ b/src/performance/dashboard/src/components/chart/Chart.jsx
@@ -269,27 +269,39 @@ class Chart extends Component {
 
     render() {
         const data = buildChartData(this.props.chartData, this.props.projectLanguage, this.props.absolutePath);
-        const testPath = `Path: ${this.props.absolutePath}`;
+        const testPath = `${this.props.absolutePath}`;
         const hasData = this.isDataAvailable(data);
 
         return (
             <div className="Chart">
                 <div className="Chart_actionbar">
-                    <div style={{ width: "300px", height: "35px" }}>
-                        {
-                            (hasData) ?
-                                <span className="testPath">{testPath}</span>
-                                : <Fragment />
-                        }
-                    </div>
+                    {
+                        (hasData) ?
+                            <Fragment>
+                            <div className="testPathLabel">Metrics for route:</div>
+                            <div className="testPathURL">
+                                <input readonly aria-required="false" className="scrollableText" value={testPath} />
+                            </div>
+                            </Fragment>
+                            : <Fragment />
+                    }
                 </div>
                 <div className="Chart_C3" style={{ padding: "20px" }} >
                     {
                         (!hasData) ?
                             <div className="nodata">
                                 <div className="nodata_message">
-                                    <div className="nodata_message_title">No metrics available</div>
-                                    <div className="nodata_message_help">Tip: Run a few load tests</div>
+                                    <div className="nodata_message_title">There are no saved metrics to display for the current load run settings</div>
+                                    <div className="nodata_message_path">
+                                        <span className="nodata_message_label">route path: </span>
+                                        {this.props.absolutePath}
+                                    </div>
+                                    <div className="nodata_message_help">
+                                        Only metrics containing HTTP hit count data can be displayed.
+                                    </div>
+                                    <div className="nodata_message_help">
+                                        Run load tests, or change the route path. To change the path, click 'Edit load run settings'.
+                                    </div>
                                 </div>
                             </div>
                             : <Fragment />

--- a/src/performance/dashboard/src/components/chart/Chart.jsx
+++ b/src/performance/dashboard/src/components/chart/Chart.jsx
@@ -297,7 +297,7 @@ class Chart extends Component {
                                         {this.props.absolutePath}
                                     </div>
                                     <div className="nodata_message_help">
-                                        Only metrics containing HTTP hit count data can be displayed.
+                                        To show metrics from the last run, the Route path must return HTTP data.
                                     </div>
                                     <div className="nodata_message_help">
                                         Run load tests, or change the route path. To change the path, click 'Edit load run settings'.

--- a/src/performance/dashboard/src/components/chart/Chart.scss
+++ b/src/performance/dashboard/src/components/chart/Chart.scss
@@ -22,6 +22,27 @@
 
 .Chart_actionbar {
   line-height: 40px;
+  width: 100%;
+  height: 35px;
+  display: flex;
+}
+
+.Chart_actionbar .testPathLabel {
+  order: 1;
+  margin-right: 5px;
+}
+
+.Chart_actionbar .testPathURL {
+  order: 2;
+  flex-grow: 1;
+}
+
+.Chart_actionbar .testPathURL .scrollableText {
+  background: none;
+  color: white;
+  border: none;
+  font-size: 1.1em;
+  width: 100%;
 }
 
 .Chart_actionbar .bx--dropdown__wrapper--inline,
@@ -153,10 +174,23 @@
   font-size: carbon--type-scale(5);
 }
 
+.nodata .nodata_message_path {
+  color: $carbon--gray-10;
+  font-size: carbon--type-scale(3);
+  font-weight: carbon--type-weight("Semibold");
+  font-family: carbon--font-family("mono");
+  padding: 30px 0 10px 0;
+}
+
 .nodata .nodata_message_help {
   color: $carbon--gray-50;
-  padding: 20px;
+  padding: 20px 20px 7px 20px;
   font-size: carbon--type-scale(3);
+}
+
+.nodata_message_label {
+  color: $carbon--gray-50;
+  font-family: carbon--font-family("sans");
 }
 
 .chartTooltip {

--- a/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
+++ b/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
@@ -142,9 +142,7 @@ class ChartCounterSelector extends Component {
                             <div className="options expanded">
                                 <div className='option'>
                                     <IconLine className='bx--btn__icon' style={{ 'fill': this.getColor('HTTP_RESPONSE') }} />
-                                    <TooltipDefinition tooltipText="HTTP Response time (ms) of this path" align="end" >
-                                        {this.props.testPath}
-                                    </TooltipDefinition>
+                                    <input readonly  aria-required="false" type="text" className="scrollableTextField" value={this.props.testPath}/>   
                                 </div>
                             </div>
                         </div>
@@ -161,9 +159,7 @@ class ChartCounterSelector extends Component {
                                 <div className='option'>
                                     <IconLine className='bx--btn__icon' style={{ 'fill': this.getColor('HTTP_HITS') }} />
                                     <span className='label'>
-                                        <TooltipDefinition tooltipText="Number of times this path was accessed" align="end" direction="top">
-                                            {this.props.testPath}
-                                        </TooltipDefinition>
+                                    <input readonly  aria-required="false" type="text" className="scrollableTextField" value={this.props.testPath}/>                      
                                     </span>
                                 </div>
                             </div>

--- a/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.scss
+++ b/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.scss
@@ -29,6 +29,14 @@
     padding-right:10px
 }
 
+.ChartCounterSelector .scrollableTextField {
+    background: none;
+    color: white;
+    border: none;
+    font-size: 1em;
+    width: 100%;
+}
+
 .ChartCounterSelector .options {
     margin: 0;
     padding-left:20px;

--- a/src/performance/dashboard/src/index.js
+++ b/src/performance/dashboard/src/index.js
@@ -45,7 +45,6 @@ async function fetchAuthInfo() {
 
 async function init() {
     let initOptions = await fetchAuthInfo();
-    console.log(initOptions)
     if (initOptions.hasError) {
         console.warn("No Auth service available")
         ReactDOM.render(

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -149,7 +149,6 @@ class PagePerformance extends React.Component {
     }
 
     render() {
-
         const { snapshot_1, snapshot_2, snapshot_3 } = this.state;
         const absolutePath = MetricsUtils.getEndpoint(this.props.loadRunnerConfig.config.path) ? MetricsUtils.getEndpoint(this.props.loadRunnerConfig.config.path) : '';
         const httpMethod = this.props.loadRunnerConfig.config.method;


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [X] Enhancement

## What does this PR do ?

- Updates text when no metrics for project route path exist
- Updates label above chart with current route path filter
- Fixes path in chart key which was breaching container bounds and not wrapping / truncating
- Fixes path labels above chart component and in chart key container making them editable / copyable

## Which issue(s) does this PR fix ?

#2008 Java Load tests

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
NO


All changes are in the dashboard UI,  ran existing PFE tests:

```
  736 passing (2m)
  21 pending
=============================== Coverage summary ===============================
Statements   : 49.32% ( 2263/4588 )
Branches     : 43.05% ( 685/1591 )
Functions    : 57.63% ( 321/557 )
Lines        : 49.17% ( 2210/4495 )
================================================================================
Tests finished at 2020-04-07_12:22:48
```

and UI tests : 
```
Test Suites: 6 passed, 6 total
Tests:       41 passed, 41 total
Snapshots:   0 total
Time:        5.671s
Ran all test suites.
```