### PR TITLE
2465- remove container/pod if docker projects build failed

### DIFF
--- a/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
+++ b/src/pfe/file-watcher/server/src/utils/locales/en/translation.json
@@ -11,7 +11,7 @@
       "buildBuildImage": "Creating image for build",
       "compileApplication": "Compiling application",
       "compileFail": "Application failed to compile",
-      "buildFail": "Creating image for build failed",
+      "buildFail": "Failed to create image",
       "containerBuildSuccess": "Container image has been built successfully",
       "buildcontainerCreateSuccess": "Build container image has been created successfully",
       "buildMaven": "Running maven build",


### PR DESCRIPTION
Signed-off-by: Stephanie <stephanie.cao@ibm.com>

## What type of PR is this ? 

- [x] Bug fix


## What does this PR do ?
remove container/pod if docker projects build failed. So the project will be stopped and inaccessible. 

## Which issue(s) does this PR fix ?
Fixes the issue that for updating a docker project, the `appState` is still running even it has dockerfile build/compilation failure.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
#2465 

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
