### PR TITLE
Handle container being unavailable during source code sync.

### DIFF
--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -348,11 +348,20 @@ async function syncToBuildContainer(project, filesToDelete, modifiedList, timeSt
       log.info(
         `Project ${project.name} syncing with build container, projectRoot is ${projectRoot}`
       );
-      await cwUtils.copyProjectContents(
-        project,
-        globalProjectPath,
-        projectRoot
-      );
+      if (project.containerId !== undefined) {
+        try {
+          await cwUtils.copyProjectContents(
+            project,
+            globalProjectPath,
+            projectRoot
+          );
+        } catch (err) {
+          // If we fail to copy into the container we still need to send the rest of the file change notifications.
+          log.warn(`Failed to copyProjectContents for ${project.name} to ${project.containerId} - container may be stopped or removed.`);
+        }
+      } else {
+        log.info(`Project ${project.name} - no container available to sync to.`);
+      }
     }
     if (filesToDelete != undefined) {
       filesToDelete.forEach((f) => {


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Handles a possible exception from `cwUtils.copyProjectContents()` if sync fails due to the container being unavailable. The exception is caught so that the rest of the operation, notifying file watcher which files changed, can continue.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2630

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2630

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No