### PR TITLE
[0.11.0] Handle POST stream for live metrics 

### DIFF
--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -165,7 +165,7 @@
     let httpSummary = new HttpSummary('#httpSummaryDiv', '#summary', localizedStrings.httpSummaryTitle);
     httpSummary.setHttpSummaryOptions({ host: hostname, filteredPath: dashboardRoot });
 
-    getEnvDataAndUpdateEnvSummary();
+    // getEnvDataAndUpdateEnvSummary();
     pollMetricsAndUpdateDash(maxPolls, updateDash);
 
     function updateDash(projectData) {

--- a/src/performance/monitor/public/java-metrics.html
+++ b/src/performance/monitor/public/java-metrics.html
@@ -165,7 +165,6 @@
     let httpSummary = new HttpSummary('#httpSummaryDiv', '#summary', localizedStrings.httpSummaryTitle);
     httpSummary.setHttpSummaryOptions({ host: hostname, filteredPath: dashboardRoot });
 
-    // getEnvDataAndUpdateEnvSummary();
     pollMetricsAndUpdateDash(maxPolls, updateDash);
 
     function updateDash(projectData) {

--- a/src/pfe/portal/controllers/performance.controller.js
+++ b/src/pfe/portal/controllers/performance.controller.js
@@ -22,7 +22,12 @@ log.info(`PerformanceHost: ${performance_host}`);
 function pipePerfProxyReqsToPerfContainer(req, res) {
   try {
     const options = getOptionsForReqToPerfContainer(req, performance_host, performance_port);
-    const reqToPerfContainer = got.stream(options);
+    let reqToPerfContainer
+    if (req.method == "POST") {
+      reqToPerfContainer = got.stream.post(options);
+    } else {
+      reqToPerfContainer = got.stream(options);
+    }
     req
       .pipe(reqToPerfContainer)
       .on('error', (err) => {


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
1. Allows live metrics to stream to browser following changes moving from `request` to `got` module.
2. Removes environment error from console logs (since java projects don't have this API)

## Which issue(s) does this PR fix ?
#2616 Missing metrics 

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
NO