### PR TITLE
[0.11.0] Emit event when collecting hcd data

### DIFF
--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -79,6 +79,10 @@ class ActionRunLoad extends React.Component {
                         this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Running...' });
                         break;
                     }
+                    case 'collecting': {
+                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Collecting...' });
+                        break;
+                    }
                     case 'completed': {
                         // after receiving a loadrun completion message,  wait a bit,  then reset the button back to ready
                         this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Completed...' });
@@ -207,7 +211,7 @@ class ActionRunLoad extends React.Component {
         const { showNotificationRunTestFail, loadRunStatus, inlineTextLabel, timeRemaining } = this.state;
 
         let loadRunCompleted = loadRunStatus.status === 'completed';
-        const options = ['preparing', 'connecting', 'starting', 'started', 'running',  'completed', 'requesting', 'requested', 'cancelling', 'cancelled']
+        const options = ['preparing', 'connecting', 'starting', 'started', 'running',  'collecting', 'completed', 'requesting', 'requested', 'cancelling', 'cancelled']
         const showBusy = options.includes(loadRunStatus.status)
 
         let inlineTextLabelFormatted = (timeRemaining !== 0) ? `${inlineTextLabel}${timeRemaining}` : `${inlineTextLabel}`

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -377,6 +377,7 @@ module.exports = class LoadRunner {
   }
 
   async getJavaHealthCenterData(counter) {
+    clearTimeout(this.heartbeatID);
     if (counter > 20) {
       log.error("getJavaHealthCenterData: Failed to save .hcd file");
       this.collectingHCD = false;
@@ -389,9 +390,8 @@ module.exports = class LoadRunner {
       await this.project.getProfilingByTime(this.metricsFolder);
     } catch (error) {
       if (this.project !== null) {
-        const data = { projectID: this.project.projectID,  status: 'running' , timestamp: this.metricsFolder }
+        const data = { projectID: this.project.projectID,  status: 'collecting' , timestamp: this.metricsFolder }
         this.user.uiSocket.emit('runloadStatusChanged', data);
-      
         log.info(`getJavaHealthCenterData: .hcd file not found, trying again. Attempt ${counter}/20`);
         this.timerID = setTimeout(() => this.getJavaHealthCenterData(counter + 1), 3000);
       } else {


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?

Emits a "collecting" event when PFE is collecting HCD data.  This is then displayed on the performance dashboard to let the user know the test has entered the final phase. 

## Which issue(s) does this PR fix ?
#2284 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
NO