### PR TITLE
Ensure repository enablement correctly defaults to true for new repositories.

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -280,16 +280,12 @@ async function validateRepository(repoUrl, repositories) {
 }
 
 async function constructRepositoryObject(url, description, name, isRepoProtected, isRepoEnabled) {
-  let enabled = isRepoEnabled;
-  if (enabled == undefined) {
-    enabled = true;
-  }
   let repository = {
     id: uuidv5(url, uuidv5.URL),
     name,
     url,
     description,
-    enabled: enabled,
+    enabled: isRepoEnabled,
   }
   repository = await fetchRepositoryDetails(repository);
   if (isRepoProtected !== undefined) {

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -147,7 +147,7 @@ module.exports = class Templates {
   /**
    * Add a repository to the list of template repositories.
    */
-  async addRepository(repoUrl, repoDescription, repoName, isRepoProtected, isRepoEnabled) {
+  async addRepository(repoUrl, repoDescription, repoName, isRepoProtected = false, isRepoEnabled = true) {
     this.lock();
     try {
       const repositories = cwUtils.deepClone(this.repositoryList);

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -68,7 +68,8 @@ router.post('/api/v1/templates/repositories', validateReq, async (req, res, _nex
   const repositoryUrl = req.sanitizeBody('url');
   const repositoryDescription = req.sanitizeBody('description');
   const isRepoProtected = req.sanitizeBody('protected');
-  const isRepoEnabled = req.sanitizeBody('enabled');
+  // Enabled should default to true if it isn't passed.
+  const isRepoEnabled = req.sanitizeBody('enabled') !== false;
 
   try {
     await templatesController.addRepository(

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -824,12 +824,6 @@ describe('Templates.js', function() {
                 const repository = await constructRepositoryObject(url, description, name, protected, enabled);
                 repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'protected', 'projectStyles');
             });
-            it('returns a repository object when only a url is given - gets the name, description from the url and does not have a protected field', async() => {
-                const { url } = sampleRepos.codewind;
-                const repository = await constructRepositoryObject(url);
-                repository.should.have.keys('id', 'name', 'url', 'description', 'enabled', 'projectStyles');
-                repository.should.not.have.keys('protected');
-            });
         });
         describe('updateRepoListWithReposFromProviders(providers, repositoryList)', function() {
             const updateRepoListWithReposFromProviders = Templates.__get__('updateRepoListWithReposFromProviders');


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Makes sure the enabled flag is set when a template is added when we read the input parameters from the request.

The actual bug was here:
https://github.com/eclipse/codewind/blob/e976bc63d30c1d869535e59acdff2966261b48e9/src/pfe/portal/modules/Templates.js#L167-L168

`isRepoEnabled` was `undefined` and only actually set when creating  the repo object so by default it was still undefined at that point and the new templates were not added to the enabled templates despite all being marked as enabled.

I also removed a test case that called `constructRepositoryObject` with only a url. The test case was the only thing calling `constructRepositoryObject` that way and that use case required extra checks.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2641

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2641

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No