### PR TITLE
Ensure async/await tests are returned, await fs.writeJson in LoadRunning

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -433,7 +433,7 @@ module.exports = class LoadRunner {
     let hashObject = { gitHash: hashValue };
     const filePath = path.join(this.workingDir, 'runinfo.json');
     try {
-      fs.writeJson(filePath, hashObject, { spaces: '  ' });
+      await fs.writeJson(filePath, hashObject, { spaces: '  ' });
     } catch (err) {
       log.error(err);
     }


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes tests that were failing locally for me.
* Removed `Fails to get a profiling file using an invalid time stamp` from `getProfilingByTime` as I couldn't find which section would return a `NOT_FOUND` error code. (previously wasn't returned so mocha didn't await it).
* Added a cwUtils mock function for `findHCDfile` as we don't want to call `docker` in the unit test.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
