### PR TITLE
[0.11.0] Make Tooltip link point to Codewind docs

### DIFF
--- a/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
+++ b/src/performance/dashboard/src/components/chartCounterSelector/ChartCounterSelector.jsx
@@ -187,7 +187,7 @@ class ChartCounterSelector extends Component {
                                     </p>
 
                                         <div className="bx--tooltip__footer">
-                                            <a href="https://microclimate.dev/appmetrics#understanding-performance-metrics-in-the-dashboard-tab" className="bx--link" target="_blank" rel="noopener noreferrer">
+                                            <a href="https://www.eclipse.org/codewind/metrics-dashboard.html" className="bx--link" target="_blank" rel="noopener noreferrer">
                                                 Learn More  <IconLaunch className='bx--btn__icon' />
                                             </a>
                                         </div>


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## Fixes issue : #2681

## What does this PR do ?

Updates the URL in the tooltip help to point to the Codewind documentation rather than the Microclimate documentation

![Screenshot 2020-04-15 at 10 46 36](https://user-images.githubusercontent.com/28102564/79323917-be739a80-7f06-11ea-9120-abe2ae77299c.png)

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?

Ran UI tests manually : 


Test Suites: 6 passed, 6 total
Tests:       41 passed, 41 total
Snapshots:   0 total
Time:        7.075s
Ran all test suites.