### PR TITLE
Add and handle timeout for asyncHttpRequest.

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -357,8 +357,9 @@ async function getNameAndDescriptionFromRepoTemplatesJSON(url) {
   templatesUrl.pathname = templatesPath;
 
   const options = {
-    host: templatesUrl.host,
+    host: templatesUrl.hostname,
     path: templatesUrl.pathname,
+    port: templatesUrl.port,
     method: 'GET',
   }
 
@@ -483,8 +484,9 @@ async function getTemplatesJSONFromURL(givenURL) {
     }
   } else {
     const options = {
-      host: parsedURL.host,
+      host: parsedURL.hostname,
       path: parsedURL.pathname,
+      port: parsedURL.port,
       method: 'GET',
     }
     const res = await cwUtils.asyncHttpRequest(options, undefined, parsedURL.protocol === 'https:');

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -52,6 +52,7 @@ function asyncHttpRequest(options, body, secure = false) {
     let protocol = secure ? https : http;
     let req = protocol.request(options, function(res) {
       res.body = '';
+      // Listen for response events.
       res.on('error', function(err) {
         return reject(err);
       });
@@ -61,9 +62,19 @@ function asyncHttpRequest(options, body, secure = false) {
       res.on('end', function() {
         return resolve(res);
       });
-    }).on('error', function(err) {
+    });
+
+    // Listen for request events.
+    req.on('error', function(err) {
       return reject(err);
     });
+    req.setTimeout(30 * 1000);
+    req.on('timeout', function() {
+      // Calling abort will trigger an error which will call
+      // reject above.
+      req.abort();
+    });
+
     if (body) {
       req.write(JSON.stringify(body));
     }


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds and handles a timeout for asyncHttpRequest.
Fixes handling of template repositories that include a port number in their URL.

## Which issue(s) does this PR fix ?
This PR is for https://github.com/eclipse/codewind/issues/2639
It resolves a hang on starting when we can't contact the template repository quickly - however I can't verify for certain that is the users original issue without more debug from them. (Either way this PR fixes two real problems.)

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2639

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No