### PR TITLE
master: preserve only in upload end

### DIFF
--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -85,9 +85,9 @@ function updateObject(objectToUpdate, fieldsToAddToObject) {
   return objectToUpdate;
 }
 
-async function copyProject(fromProjectPath, toProjectPath, mode) {
+async function copyProject(fromProjectPath, toProjectPath, mode, preserve = false) {
   log.debug(`copyProject fromPath: ${fromProjectPath}, toPath: ${toProjectPath}`);
-  await fs.copy(fromProjectPath, toProjectPath, { preserveTimestamps: true });
+  await fs.copy(fromProjectPath, toProjectPath, { preserveTimestamps: preserve });
   if (mode) {
     await fs.chmod(toProjectPath, mode);
   }

--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -266,7 +266,7 @@ async function uploadEnd(req, res) {
       || modifiedList.length > 0;
     if (wasProjectChanged) {
       const projectPath = project.projectPath();
-      await cwUtils.copyProject(pathToTempProj, projectPath, getMode(project));
+      await cwUtils.copyProject(pathToTempProj, projectPath, getMode(project), true);
 
       if (project.injectMetrics) {
         try {


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Follow-up to PR #2695, preserve timestamp only in upload/end and not in bind/end

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

#2699 

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
