### PR TITLE
test: use husky to run eslint before git push

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -8,7 +8,8 @@
     "integrationtest": "scripts/mocha.sh src/integration",
     "unittest": "ENABLE_COVERAGE=true scripts/mocha.sh src/unit",
     "apitest": "scripts/mocha.sh src/API",
-    "eslint": "./node_modules/.bin/eslint ."
+    "eslint": "./node_modules/.bin/eslint .",
+    "eslint:fix": "npm run eslint --fix"
   },
   "bin": {
     "test-codewind": "scripts/mocha.sh"
@@ -66,6 +67,7 @@
     "eslint": "^5.9.0",
     "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-no-only-tests": "^2.0.1",
+    "husky": "^4.2.5",
     "sinon-chai": "^3.3.0",
     "swagger-parser": "^6.0.5"
   },
@@ -82,5 +84,10 @@
       "docs/**",
       "eslint-rules/**"
     ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run eslint:fix"
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [ ] Enhancement
- [x] Test improvement

## What does this PR do ?
Runs `eslint` whenever we do a `git push`. This means we won't have to wait for a Jenkins build only to see that it failed on its `eslint` check.

We will now know immediately whether `eslint` will pass. This will also fix any auto-fixable eslint errors (e.g. semi-colons)

If we like this, we can extend this to run the `eslint` check on every commit (ensuring that every commit is "clean" according to eslint). We can also run our unit tests whenever we do a `git push`, so we won't have to wait 30 minutes for the Jenkins build to tell us that they're failing

## Which issue(s) does this PR fix ?
a small part of https://github.com/eclipse/codewind/issues/2291

## Does this PR require a documentation change ?
Maybe, depends what reviewers think

## Any special notes for your reviewer ?
