### PR TITLE
Guard against this.project being null inside LoadRunner.js

### DIFF
--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -868,7 +868,7 @@ describe('LoadRunner.js', () => {
             loadRunner.user.uiSocket.emit.should.have.been.calledWith('runloadStatusChanged', expectedDataForPerfUI);
             should.equal(loadRunner.project, null);
         });
-        it('still notifies the UI the perf run has conmplated if profilingSocket is null', async() => {
+        it('still notifies the UI the perf run has completed if profilingSocket is null', async() => {
             // arrange
             const expectedMetricsFolder = '202003061524';
             const LoadRunner = proxyquire(pathToLoadRunnerJs, {});

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -868,17 +868,32 @@ describe('LoadRunner.js', () => {
             loadRunner.user.uiSocket.emit.should.have.been.calledWith('runloadStatusChanged', expectedDataForPerfUI);
             should.equal(loadRunner.project, null);
         });
-        it('does nothing if profilingSocket is null', async() => {
+        it('still notifies the UI the perf run has conmplated if profilingSocket is null', async() => {
             // arrange
+            const expectedMetricsFolder = '202003061524';
             const LoadRunner = proxyquire(pathToLoadRunnerJs, {});
-            const loadRunner = new LoadRunner('mockUser');
+            const mockUser = {
+                uiSocket: { emit: sandbox.stub() },
+            };
+            const loadRunner = new LoadRunner(mockUser);
             loadRunner.profilingSocket = null;
+            const mockProject = {
+                name: 'mockName',
+                projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+            };
+            loadRunner.project = mockProject;
+            loadRunner.metricsFolder = expectedMetricsFolder;
 
+            const expectedData = {
+                projectID: mockProject.projectID,
+                status: 'completed',
+            };
             // act
             await loadRunner.endProfiling();
 
             // assert
             should.equal(loadRunner.profilingSocket, null);
+            loadRunner.user.uiSocket.emit.should.have.been.calledWith('runloadStatusChanged', expectedData);
         });
     });
     describe('cancelProfiling() ', () => {


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds checks that `this.project` isn't null before we call functions that use in the socket message handlers.
The first time I ran this against a node project I also saw this execption:
```
[20/04/20 10:48:34 /portal/modules/LoadRunner.js] [INFO] profiling.json saved for project nodetoupload
(node:66) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'projectID' of null
    at LoadRunner.emitCompleted (/portal/modules/LoadRunner.js:709:81)
    at Socket.socket.on (/portal/modules/LoadRunner.js:573:14)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
which is why one call to `emitCompleted()` was moved and the other deleted so that it was always called once and once only.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2692

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2692

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
The diff is simpler with ignore whitespace set on.