### PR TITLE
Update AppMetrics version message

### DIFF
--- a/src/performance/dashboard/src/components/status/StatusPanel.jsx
+++ b/src/performance/dashboard/src/components/status/StatusPanel.jsx
@@ -43,7 +43,7 @@ class StatusPanel extends React.Component {
         const { showOutOfDateMetrics } = this.state;
         return (
             <Fragment>
-                {showOutOfDateMetrics ? <div className="StatusPanelWarning">An old version of Appmetrics has been detected. Results may be inaccurate until you update Appmetrics within your project.</div> : <Fragment />}
+                {showOutOfDateMetrics ? <div className="StatusPanelWarning">The latest Appmetrics package is missing from your project. Open the properties for this project in your IDE and select the Inject Appmetrics option.</div> : <Fragment />}
             </Fragment>
         )
     }


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Changes warning message to read : "The latest Appmetrics package is missing from your project. Open the properties for this project in your IDE and select the Inject Appmetrics option.."


<img width="1184" alt="Screenshot 2020-04-22 at 08 47 05" src="https://user-images.githubusercontent.com/28102564/79954869-dfdc0580-8475-11ea-9c77-90d15469355c.png">

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2631

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
Label change only - other capabilities changes will be handled under issue 2687