### PR TITLE
Clean up projects stuck in deleting

### DIFF
--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -260,6 +260,11 @@ module.exports = class User {
           const project = new Project({ ...projFile, ...settFile });
           await project.setOpenLiberty();
           this.projectList.addProject(project);
+          // If deletion had begun for this project but failed to complete, clear it now
+          if (projFile.action === Project.STATES.deleting) {        
+            log.info(`Completing delete of project ${projName}`);
+            await this.deleteProjectFiles(project);
+          } 
         } catch (err) {
           // Corrupt project inf file
           if (err instanceof SyntaxError) {


### PR DESCRIPTION
Signed-off-by: Julie Stalley <julie_stalley@uk.ibm.com>

## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR will clean up any projects that are stuck in 'deleting'. This occurs when the project remove is requested by the user but something fails along the way (most likely in the unbind rest request). In this scenario, a second delete request is blocked and the user is currently unable to proceed.  This change will clean up those projects on start up of the codewind-pfe container when we initialise the user's existing projects.

## Which issue(s) does this PR fix ?
This will help with
https://github.com/eclipse/codewind/issues/2661

## Does this PR require a documentation change ?

We should probably add something to the troubleshooting guide.
## Any special notes for your reviewer ?
