### PR TITLE
feat: 2647.2 add secure template repos to pfe

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1139,6 +1139,10 @@ paths:
                   $ref: '#/components/schemas/TemplateRepo'
         400:
           description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
         423:
           description: The templates object is currently locked to prevent incorrect data being accessed and returned. Retry later
     delete:
@@ -1989,6 +1993,13 @@ components:
           type: boolean
         protected:
           type: boolean
+        gitCredentials:
+          type: object
+          properties:
+            username:
+              type: string
+            password:
+              type: string
     TemplateRepo:
       type: object
       required:

--- a/src/pfe/portal/modules/ExtensionList.js
+++ b/src/pfe/portal/modules/ExtensionList.js
@@ -190,7 +190,10 @@ async function addExtensionsToTemplates(extensions, templates) {
     try {
       if (extension.templates) {
         log.trace(`Adding Extension ${extension.name}'s repository into the templates`);
-        await templates.addRepository(extension.templates, extension.description);
+        await templates.addRepository({
+          url: extension.templates,
+          description: extension.description,
+        });
       } else if (extension.templatesProvider) {
         log.trace(`Adding Extension ${extension.name}'s provider into the templates`);
         await templates.addProvider(extension.name, extension.templatesProvider);

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -62,7 +62,7 @@ router.get('/api/v1/templates/repositories', async (req, res, _next) => {
   }
 });
 
-router.post('/api/v1/templates/repositories', validateReq, postRepositories, sendRepositories);
+router.post('/api/v1/templates/repositories', validateReq, postRepositories);
 
 async function postRepositories(req, res, next) {
   const { templates: templatesController } = req.cw_user;
@@ -77,7 +77,7 @@ async function postRepositories(req, res, next) {
 
   try {
     await templatesController.addRepository(repoOptions);
-    next();
+    await sendRepositories(req, res, next);
   } catch (error) {
     log.error(error);
     const knownErrorCodes = ['INVALID_URL', 'DUPLICATE_URL', 'URL_DOES_NOT_POINT_TO_INDEX_JSON', 'ADD_TO_PROVIDER_FAILURE'];

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -33,6 +33,12 @@ const styledTemplates = {
     },
 };
 
+// Insert your own credentials to run relevant tests
+const gheCredentials = {
+    username: 'foo.bar@domain.com',
+    // password: 'INSERT_TO_RUN_RELEVANT_TESTS',
+};
+
 const sampleRepos = {
     codewind: {
         url: templateRepositoryURL,
@@ -49,6 +55,11 @@ const sampleRepos = {
         protected: true,
         projectStyles: ['Codewind'],
         name: 'Default disabled templates',
+    },
+    GHE: {
+        url: 'https://raw.github.ibm.com/Richard-Waller/sampleGHETemplateRepo/415ece47958250175f182c095af7da6cfe40e58a/devfiles/index.json',
+        description: 'Example GHE template repository',
+        name: 'Example GHE template repository',
     },
 };
 
@@ -80,11 +91,11 @@ async function getTemplateRepos() {
     return res;
 }
 
-async function addTemplateRepo(repo) {
+async function addTemplateRepo(repoOptions) {
     const res = await reqService.chai
         .post('/api/v1/templates/repositories')
         .set('Cookie', ADMIN_COOKIE)
-        .send(repo);
+        .send(repoOptions);
     return res;
 }
 
@@ -241,6 +252,7 @@ module.exports = {
     templateRepositoryURL,
     sampleRepos,
     validUrlNotPointingToIndexJson,
+    gheCredentials,
     getTemplateRepos,
     addTemplateRepo,
     deleteTemplateRepo,

--- a/test/modules/template.service.js
+++ b/test/modules/template.service.js
@@ -180,18 +180,22 @@ async function getNumberOfEnabledTemplates(queryParams) {
 }
 
 
+const idOfImmutableRepo = 'incubator';
 /**
  * Removes all templates repos known to PFE, and adds the supplied repos
  * @param {[JSON]} repoList
  */
 async function setTemplateReposTo(repoList) {
-    const reposToDelete = (await getTemplateRepos()).body;
-    if (reposToDelete.length > 0) {
+    const currentRepos = (await getTemplateRepos()).body;
+    if (currentRepos.length > 0) {
+        const reposToDelete = currentRepos.filter(repo => repo.id !== idOfImmutableRepo);
+        console.log(reposToDelete);
         for (const repo of reposToDelete) {
             await deleteTemplateRepo(repo.url);
         }
     }
-    for (const repo of repoList) {
+    const templatesToAdd = repoList.filter(repo => repo.id !== idOfImmutableRepo);
+    for (const repo of templatesToAdd) {
         await addTemplateRepo(repo);
     }
 }

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -18,6 +18,7 @@ const {
     getDefaultTemplatesFromGithub,
     validUrlNotPointingToIndexJson,
     sampleRepos,
+    gheCredentials,
     batchPatchTemplateRepos,
     getTemplateRepos,
     getNumberOfTemplates,
@@ -167,7 +168,6 @@ describe('Template API tests', function() {
                     originalTemplateReposLength = repos.length;
                     originalTemplatesLength = await getNumberOfTemplates();
                     originalEnabledTemplatesLength = await getNumberOfEnabledTemplates();
-                  
                 });
                 it('should add a disabled template repository giving no change to enabled templates', async function() {
                     const addTemplateRepoRes = await addTemplateRepo(sampleRepos.disabledcodewind);
@@ -180,10 +180,6 @@ describe('Template API tests', function() {
                     afterTemplatesLength.should.be.above(originalTemplatesLength);
                 });
             });
-
-
-
-
         });
     });
 
@@ -200,19 +196,15 @@ describe('Template API tests', function() {
     });
 
     describe('DELETE | GET | POST /api/v1/templates/repositories', function() {
-        // Save state for this test
         setupReposAndTemplatesForTesting();
         const repo = sampleRepos.codewind;
         let originalTemplateRepos;
         let originalTemplates;
-        let originalNumTemplates;
         before(async function() {
             const { body: repos } = await getTemplateRepos();
             originalTemplateRepos = repos;
             const { body: templates } = await getTemplates();
             originalTemplates = templates;
-            originalNumTemplates = templates.length;
-
         });
         it('DELETE /api/v1/templates should remove a template repository', async function() {
             const res = await deleteTemplateRepo(repo.url);
@@ -222,9 +214,9 @@ describe('Template API tests', function() {
         });
         it('GET /api/v1/templates should return fewer templates', async function() {
             const numberOfTemplates = await getNumberOfTemplates();
-            numberOfTemplates.should.be.below(originalNumTemplates);
+            numberOfTemplates.should.be.below(originalTemplates.length);
         });
-        it('POST /api/v1/templates should re-add the deleted template repository', async function() {
+        it('POST /api/v1/templates/repositories should re-add the deleted template repository', async function() {
             const res = await addTemplateRepo(repo);
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.containSubset([repo]);
@@ -234,9 +226,44 @@ describe('Template API tests', function() {
             const res = await getTemplates();
             res.should.have.status(200).and.satisfyApiSpec;
             res.body.should.deep.equalInAnyOrder(originalTemplates);
-            res.body.length.should.equal(originalNumTemplates);
         });
     });
+
+    describe('Add secure template repository and list templates', function() {
+        before(function() {
+            if (!gheCredentials.password) {
+                this.skip();
+            }
+        });
+
+        setupReposAndTemplatesForTesting();
+        it('POST /api/v1/templates/repositories without GitHub credentials should fail to add a GHE template repository', async function() {
+            const res = await addTemplateRepo(sampleRepos.GHE);
+            res.should.have.status(400).and.satisfyApiSpec;
+            res.text.should.include(sampleRepos.GHE.url);
+        });
+        it('POST /api/v1/templates/repositories with incorrect GHE credentials should fail to add a GHE template repository', async function() {
+            const res = await addTemplateRepo(sampleRepos.GHE);
+            res.should.have.status(400).and.satisfyApiSpec;
+            res.text.should.include(sampleRepos.GHE.url);
+        });
+        it('POST /api/v1/templates/repositories with correct GHE credentials should add a GHE template repository', async function() {
+            const { body: originalTemplates } = await getTemplates();
+
+            const res = await addTemplateRepo({
+                ...sampleRepos.GHE,
+                gitCredentials: gheCredentials,
+            });
+            res.should.have.status(200).and.satisfyApiSpec;
+            res.body.should.containSubset([sampleRepos.GHE]);
+
+            // Then GET /templates should return the templates from the repository we just added
+            const resToGetRequest = await getTemplates();
+            resToGetRequest.should.have.status(200).and.satisfyApiSpec;
+            resToGetRequest.body.should.have.length.above(originalTemplates.length);
+        });
+    });
+
     describe('PATCH /api/v1/batch/templates/repositories', function() {
         setupReposAndTemplatesForTesting();
         const { url: existingRepoUrl } = sampleRepos.codewind;

--- a/test/src/API/templates/templates.test.js
+++ b/test/src/API/templates/templates.test.js
@@ -113,17 +113,12 @@ describe('Template API tests', function() {
             });
             describe('a duplicate url', function() {
                 it('should return 400', async function() {
-                    // Arrange
-                    const res = await getTemplateRepos();
-                    const originalTemplateRepos = res.body;
-                    const duplicateRepoUrl = originalTemplateRepos[0].url;
-                    // Act
-                    const duplicateUrlRes = await addTemplateRepo({
-                        url: duplicateRepoUrl,
+                    const { body: [existingRepo] } = await getTemplateRepos();
+                    const res = await addTemplateRepo({
+                        url: existingRepo.url,
                         description: 'duplicate url',
                     });
-                    // Assert
-                    duplicateUrlRes.should.have.status(400, duplicateUrlRes.text);
+                    res.should.have.status(400, res.text);
                 });
             });
             describe('a valid url that does not point to an index.json', function() {


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Extends PFE's `POST /templates/repositories` to accept GHE repos if we provide `gitCredentials` (username & password) in the request body. See the `openapi.yaml` and the API tests for more details.

Currently if we successfully add a secure template, then subsequent calls to `GET /templates/repositories` and `GET /templates` will show the secure repo and its templates respectively. i.e. we do not check whether the credentials are still valid

We also do not currently encrypt the credentials in the request body, meaning they get logged on `trace` log level. We will need a solution for that in future

I had to do some refactoring to get my changes in but the tests should cover my changes ~100%

## Which issue(s) does this PR fix ?
part 2 of #2647 

## Does this PR require a documentation change ?
2647 will require documentation changes

## Any special notes for your reviewer ?
To run the tests you will need to input your own GHE credentials