### PR TITLE
test: automatically eslint staged files before we git commit them

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-no-only-tests": "^2.0.1",
     "husky": "^4.2.5",
+    "lint-staged": "^10.1.7",
     "sinon-chai": "^3.3.0",
     "swagger-parser": "^6.0.5"
   },
@@ -87,7 +88,12 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npm run eslint:fix"
+      "pre-commit": "lint-staged"
     }
+  },
+  "lint-staged": {
+    "**/*.js": [
+      "npm run eslint:fix"
+    ]
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -93,7 +93,7 @@
   },
   "lint-staged": {
     "**/*.js": [
-      "npm run eslint:fix"
+      "npm run eslint"
     ]
   }
 }


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 
- [ ] Bug fix
- [ ] Enhancement
- [x] Test

## What does this PR do ?
this is an improvement on https://github.com/eclipse/codewind/pull/2707. 

https://github.com/eclipse/codewind/pull/2707 introduced a dev tool called Husky to our codebase. Husky runs `eslint` for us whenever we do a `git push`. This means we won't have to wait for a Jenkins build only to see that it failed on its `eslint` check.

That is great, but suppose you commit good code, then put `.only` on a test to check something. In this case, `eslint` will fail against your `.only`, and prevent you from pushing your good commits.

This PR makes us run eslint on only on files we stage for commit. And instead of running `eslint` on every `git push`, we run it on every `git commit`. So we can only commit code that passes eslint, yet still try things out locally that we don't want to commit.

## Which issue(s) does this PR fix ?
None, I just saw this opportunity to improve our development process

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
