### PR TITLE
Hardcode perfDashboardPath

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -73,9 +73,9 @@ module.exports = class Project {
       const isWindowsPath = cwUtils.isWindowsAbsolutePath(this.pathToMonitor);
       if (isWindowsPath) {
         this.pathToMonitor = cwUtils.convertFromWindowsDriveLetter(this.pathToMonitor);
-      } 
+      }
     }
-    
+
     // Project status information
     this.host = args.host || '';
     this.ports = args.ports || {};
@@ -124,6 +124,8 @@ module.exports = class Project {
     this.metricsCapabilities = (args.metricsCapabilities) ? args.metricsCapabilities : {};
 
     this.links = new Links(this.projectPath(), args.links);
+
+    this.perfDashboardPath = `/performance/charts?project=${this.projectID}`;
   }
 
 
@@ -155,13 +157,6 @@ module.exports = class Project {
       }
     }
     return {}
-  }
-
-  getPerfDashPath() {
-    const isPerfDashAvailable = this.injectMetrics || this.isOpenLiberty || this.metricsAvailable;
-    return isPerfDashAvailable
-      ? `/performance/charts?project=${this.projectID}`
-      : null;
   }
 
   async setMetricsState() {

--- a/src/pfe/portal/modules/ProjectList.js
+++ b/src/pfe/portal/modules/ProjectList.js
@@ -83,14 +83,12 @@ module.exports = class ProjectList {
   retrieveProject(id) {
     const project = (this._list.hasOwnProperty(id) ? this._list[id] : undefined);
     if (!project) {
-      return;
+      return null;
     }
     project.injection = {
       injectable: project.canMetricsBeInjected,
       injected: project.injectMetrics,
     };
-    project.perfDashboardPath = project.getPerfDashPath();
-
     return project;
   }
 

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -115,35 +115,6 @@ describe('Project.js', function() {
             json.should.not.containSubset(obj);
         });
     });
-    describe('getPerfDashPath()', () => {
-        const defaultArgs = {
-            projectID: 'projectID',
-            name: 'dummy',
-            locOnDisk: '/Documents/projectDir/',
-            injectMetrics: false,
-            isOpenLiberty: false,
-            metricsAvailable: false,
-        };
-        it('returns the performance dash path for a project as project.injectMetrics is true', () => {
-            const project = createProjectAndCheckIsAnObject(defaultArgs, 'dummyworkspace');
-            project.injectMetrics = true;
-            project.getPerfDashPath().should.equal(`/performance/charts?project=${defaultArgs.projectID}`);
-        });
-        it('returns the performance dash path for a project as project.isOpenLiberty is true', () => {
-            const project = createProjectAndCheckIsAnObject(defaultArgs, 'dummyworkspace');
-            project.isOpenLiberty = true;
-            project.getPerfDashPath().should.equal(`/performance/charts?project=${defaultArgs.projectID}`);
-        });
-        it('returns the performance dash path for a project as project.metricsAvailable is true', () => {
-            const project = createProjectAndCheckIsAnObject(defaultArgs, 'dummyworkspace');
-            project.metricsAvailable = true;
-            project.getPerfDashPath().should.equal(`/performance/charts?project=${defaultArgs.projectID}`);
-        });
-        it('returns null as project.injectMetrics, project.isOpenLiberty and project.metricsAvailable are all false', () => {
-            const project = createProjectAndCheckIsAnObject(defaultArgs, 'dummyworkspace');
-            expect(project.getPerfDashPath()).to.be.null;
-        });
-    });
     describe('setMetricsState()', function() {
         this.timeout(testTimeout.short);
         it('returns all capabilities as false, correctly sets the metricsCapabilities, metricsAvailable and metricsDashboard values in project', async() => {

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -59,6 +59,7 @@ describe('Project.js', function() {
             project.name.should.equal('newdummyproject');
             project.should.have.property('workspace');
             project.workspace.should.equal('./someworkspace');
+            project.perfDashboardPath.should.equal(`/performance/charts?project=${project.projectID}`);
         });
         it('Sets directory to name', () => {
             const project = createProjectAndCheckIsAnObject({


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Removes the `getPerfDashPath` variable and replaces it with a hardcoded string as we now want to send every project type to the Performance Dashboard and tell them how they can use it (whether they need to injectMetrics for example).
Related to: https://github.com/eclipse/codewind/pull/2748

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: Fixes: https://github.com/eclipse/codewind/issues/2299

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
