### PR TITLE
Metrics Status - Add timed metrics availability check

### DIFF
--- a/test/src/API/projects/metricsStatus.test.js
+++ b/test/src/API/projects/metricsStatus.test.js
@@ -59,6 +59,9 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 projectType: 'nodejs',
                 creationTime: Date.now(),
             });
+            // save projectID for cleanup
+            projectID = project.projectID;
+
             project.metricsAvailable.should.be.false;
             project.metricsDashboard.should.deep.equal({ hosting: null, path: null });
 
@@ -72,10 +75,8 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 appmetricsPackageFoundInBuildFile: true,
                 canMetricsBeInjected: true, // As is a Node.js project
                 projectRunning: false,
+                hasTimedMetrics: false,
             });
-
-            // save projectID for cleanup
-            projectID = project.projectID;
         });
     });
 
@@ -117,6 +118,9 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 projectType: 'nodejs',
                 creationTime: Date.now(),
             });
+            // save projectID for cleanup
+            projectID = project.projectID;
+
             project.metricsAvailable.should.be.false;
             project.metricsDashboard.should.deep.equal({ hosting: null, path: null });
 
@@ -130,10 +134,8 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 appmetricsPackageFoundInBuildFile: false,
                 canMetricsBeInjected: true, // As is a Node.js project
                 projectRunning: false,
+                hasTimedMetrics: false,
             });
-
-            // save projectID for cleanup
-            projectID = project.projectID;
         });
     });
 
@@ -165,6 +167,9 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 projectType: 'liberty',
                 creationTime: Date.now(),
             });
+            // save projectID for cleanup
+            projectID = project.projectID;
+
             project.metricsAvailable.should.be.false;
             project.metricsDashboard.should.deep.equal({ hosting: null, path: null });
 
@@ -178,10 +183,8 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 appmetricsPackageFoundInBuildFile: true,
                 canMetricsBeInjected: true, // As is a Java project
                 projectRunning: false,
+                hasTimedMetrics: false,
             });
-
-            // save projectID for cleanup
-            projectID = project.projectID;
         });
     });
 
@@ -213,6 +216,9 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 projectType: 'docker',
                 creationTime: Date.now(),
             });
+            // save projectID for cleanup
+            projectID = project.projectID;
+
             project.metricsAvailable.should.be.false;
             project.metricsDashboard.should.deep.equal({ hosting: null, path: null });
 
@@ -226,10 +232,8 @@ describe('Metrics Status tests (/projects/{id}/metrics/status)', function() {
                 appmetricsPackageFoundInBuildFile: false,
                 canMetricsBeInjected: true, // As is an Open Liberty project
                 projectRunning: false,
+                hasTimedMetrics: false,
             });
-
-            // save projectID for cleanup
-            projectID = project.projectID;
         });
     });
 });

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -153,6 +153,7 @@ describe('Project.js', function() {
                 appmetricsEndpoint: false,
                 microprofilePackageFoundInBuildFile: false,
                 appmetricsPackageFoundInBuildFile: false,
+                hasTimedMetrics: false,
             };
             const project = createDefaultProjectAndCheckIsAnObject();
 
@@ -184,6 +185,7 @@ describe('Project.js', function() {
                     appmetricsEndpoint: '/appmetrics-dash',
                     microprofilePackageFoundInBuildFile: true,
                     appmetricsPackageFoundInBuildFile: true,
+                    hasTimedMetrics: false,
                 },
                 metricsDashHost: {
                     hosting: 'project',


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds support for detecting whether the project can support timedMetric runs by checking the `/appmetrics/api/v1/collections/features` API.
Will be used in the Performance Dashboard to feed back to the user.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: 

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
