### PR TITLE
Fix intermittent failing tests (KubernetesFunctions.js + LoadRunner.js)

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -618,12 +618,13 @@ module.exports = class LoadRunner {
    */
   async endProfiling() {
     if (this.profilingSocket !== null) {
-      await fs.writeJson(this.workingDir + '/profiling.json', this.profilingSamples, { spaces: '  ' }, function (err) {
-        if (err) {
-          log.error('endProfiling: Error writing profiling samples');
-          log.error(err);
-        }
-      });
+      try {
+        const profilingPath = path.join(this.workingDir + '/profiling.json');
+        await fs.writeJson(profilingPath, this.profilingSamples, { spaces: '  ' });
+      } catch(err) {
+        log.error('endProfiling: Error writing profiling samples');
+        log.error(err);
+      }
       log.info(`profiling.json saved for project ${this.project.name}`);
       const data = { projectID: this.project.projectID, status: 'profilingReady', timestamp: this.metricsFolder }
       this.user.uiSocket.emit('runloadStatusChanged', data);

--- a/src/pfe/portal/modules/utils/kubernetesFunctions.js
+++ b/src/pfe/portal/modules/utils/kubernetesFunctions.js
@@ -149,5 +149,6 @@ module.exports = {
   updateConfigMap,
   getProjectDeployments,
   patchProjectDeployments,
+  getProjectIngress,
   getServicePortFromProjectIngress,
 }

--- a/test/src/unit/modules/utils/kubernetesFunctions.test.js
+++ b/test/src/unit/modules/utils/kubernetesFunctions.test.js
@@ -12,6 +12,8 @@ const proxyquire = require('proxyquire');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 
+const { testTimeout } = require('../../../../config');
+
 chai.use(chaiAsPromised);
 chai.should();
 
@@ -36,6 +38,7 @@ const MOCKED_CONFIG = {
 };
 
 describe('kubernetesFunctions.js', function() {
+    this.timeout(testTimeout.short);
     describe('getProjectIngress(projectID)', function() {
         it('returns the first ingress when the items array has a length of atleast one', async function() {
             const mockResponse = {


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Refactors the `kubernetesFunctions.js` tests to remove duplicated code and reduce the time the tests take by adding the `@noCallThru` option which will stop the test from pulling in the `kubernetes-client` package which we're mocking. More info: https://github.com/thlorenz/proxyquire#preventing-call-thru-to-original-dependency

Fixes a bug in `Loadrunner.js` that causes an intermittent test failure - removes the callback from an awaited function (I think the callback would override the promise).

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
