### PR TITLE
Allow performance dashboard to be based on a path other than /

### DIFF
--- a/src/performance/dashboard/src/AppConstants.jsx
+++ b/src/performance/dashboard/src/AppConstants.jsx
@@ -10,7 +10,8 @@
 ******************************************************************************/
 
 export const APP_NAME = "codewind";
-export const API_SERVER = `${location.protocol}//${location.host}`;
+const API_ROOT = location.pathname.substring(0, location.pathname.indexOf('/performance/'));
+export const API_SERVER = `${location.protocol}//${location.host}${API_ROOT}`;
 export const MAX_DESC_LENGTH = 80;
 
 export const ROUTES_CHARTS = 'charts';


### PR DESCRIPTION


## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
This PR allows the performance dashboard to be based on locations other than '/'.

It takes everything before `/performance/` as the API_SERVER it prefixes to all it's urls rather than just the protocol and hostname.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No