### PR TITLE
[0.12.0] fix: disable remote restart of projects

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -20,7 +20,7 @@ import { getTranslation } from "../utils/locale";
 import { LibertyValidator } from "./LibertyValidator";
 import * as dockerutil from "../utils/dockerutil";
 import { Validator, ValidationResult, Severity, ProblemType } from "./Validator";
-import { ProjectCapabilities } from  "./Project";
+import { ProjectCapabilities, defaultProjectCapabilities } from  "./Project";
 import { StartModes, ControlCommands } from "./constants";
 import * as locale from "../utils/locale";
 import * as logger from "../utils/logger";
@@ -371,5 +371,8 @@ export async function rebuild(projectInfo: ProjectInfo): Promise<void> {
  * @returns ProjectCapabilities
  */
 export function getCapabilities(): ProjectCapabilities {
+    if (process.env.IN_K8 === "true") {
+        return defaultProjectCapabilities;
+    }
     return capabilities;
 }

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -17,7 +17,7 @@ import { Validator } from "./Validator";
 import { Operation } from "./operation";
 import { ProjectInfo, BuildLog, AppLog } from "./Project";
 import { ContainerStates } from "./constants";
-import { ProjectCapabilities } from  "./Project";
+import { ProjectCapabilities, defaultProjectCapabilities } from  "./Project";
 import { StartModes, ControlCommands } from "./constants";
 import * as logHelper from "./logHelper";
 import { IFileChangeEvent } from "../utils/fileChanges";
@@ -255,6 +255,9 @@ export async function start(projectInfo: ProjectInfo): Promise<void> {
  * @returns ProjectCapabilities
  */
 export function getCapabilities(): ProjectCapabilities {
+    if (process.env.IN_K8 === "true") {
+        return defaultProjectCapabilities;
+    }
     return capabilities;
 }
 

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -18,7 +18,7 @@ import { SpringValidator } from "./SpringValidator";
 import { Validator, ValidationResult, Severity, ProblemType } from "./Validator";
 import { Operation } from "./operation";
 import { ProjectInfo, BuildLog, AppLog } from "./Project";
-import { ProjectCapabilities } from  "./Project";
+import { ProjectCapabilities, defaultProjectCapabilities } from  "./Project";
 import { StartModes, ControlCommands } from "./constants";
 import * as locale from "../utils/locale";
 import * as logger from "../utils/logger";
@@ -247,6 +247,9 @@ export async function start(projectInfo: ProjectInfo): Promise<void> {
  * @returns ProjectCapabilities
  */
 export function getCapabilities(): ProjectCapabilities {
+    if (process.env.IN_K8 === "true") {
+        return defaultProjectCapabilities;
+    }
     return capabilities;
 }
 

--- a/src/pfe/file-watcher/server/test/functional-test/configs/project.config.ts
+++ b/src/pfe/file-watcher/server/test/functional-test/configs/project.config.ts
@@ -68,30 +68,21 @@ export const projectCapabilities: any = {
                 "startModes": ["run", "debug"],
                 "controlCommands": ["restart"]
             },
-            "kube": {
-                "startModes": ["run", "debug"],
-                "controlCommands": ["restart"]
-            },
+            "kube": project.defaultProjectCapabilities,
         },
         [projectLanguges.nodejs]: {
             "local": {
                 "startModes": ["run", "debugNoInit"],
                 "controlCommands": ["restart"]
             },
-            "kube": {
-                "startModes": ["run", "debugNoInit"],
-                "controlCommands": ["restart"]
-            },
+            "kube": project.defaultProjectCapabilities,
         },
         [projectLanguges.spring]: {
             "local": {
                 "startModes": ["run", "debug", "debugNoInit"],
                 "controlCommands": ["restart"]
             },
-            "kube": {
-                "startModes": ["run", "debug", "debugNoInit"],
-                "controlCommands": ["restart"]
-            },
+            "kube": project.defaultProjectCapabilities,
         },
         [projectLanguges.swift]: {
             "local": project.defaultProjectCapabilities,


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
A minimal change to stop the IDEs allowing users to restart remote node, liberty, spring projects. 

If someone ping PFE's /projects/restart API directly I think they will still be able to restart the projects that way

This does not revert all of the changes introduced in https://github.com/eclipse/codewind/pull/2519, because I could not automatically revert that PR, and thought it safest to manually revert the minimum changes needed

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2808

## Does this PR require a documentation change ?
Yes in that we no longer have remote restart in 0.12.0

## Any special notes for your reviewer ?
