### PR TITLE
[0.12.0] Load metric after capabilities

### DIFF
--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -55,7 +55,7 @@ class PagePerformance extends React.Component {
         const uiSocket = this.props.socket;
         let thisComponent = this;
         uiSocket.on(SocketEvents.RUNLOAD_STATUS_CHANGED, data => {
-            if (data.status === 'idle' && data.projectID === this.props.projectID) {
+            if (data.status === 'completed' && data.projectID === this.props.projectID) {
                 thisComponent.reloadMetrics(this.props.projectID);
             }
         });

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -151,6 +151,7 @@ class PagePerformance extends React.Component {
     }
 
     handleCapabilityClose() {
+        this.reloadMetrics(this.props.projectID);
         this.setState({showCapabilities: false})
     }
 


### PR DESCRIPTION
Signed-off-by: markcor11 <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Resolves launch issue where performance history table would appear empty

## Which issue(s) does this PR fix ?

Loads the metrics after dismissing capabilities panel #2804 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
NO