### PR TITLE
[0.12.0] fix: stop overwriting app helm chart with tail

### DIFF
--- a/src/pfe/file-watcher/scripts/nodejs-container.sh
+++ b/src/pfe/file-watcher/scripts/nodejs-container.sh
@@ -141,8 +141,6 @@ function deployK8s() {
 
 	# Add the necessary labels and serviceaccount to the chart
 	/file-watcher/scripts/kubeScripts/modify-helm-chart.sh $deploymentFile $serviceFile $project $PROJECT_ID $ROOT
-	# Overwrite the container args with `tail` so that we can restart the node process without the container dying
-	/file-watcher/scripts/kubeScripts/modify-helm-chart-node.sh "$deploymentFile"
 
 	# Push app container image to docker registry if one is set up
 	if [[ ! -z $IMAGE_PUSH_REGISTRY ]]; then
@@ -250,11 +248,6 @@ function deployK8s() {
 
 	# Delete any pods left that are terminating, to ensure they go away
 	/file-watcher/scripts/kubeScripts/clear-terminating-pods.sh $project
-
-	local podName
-	podName=$(getNameOfRunningProjectPod "$project")
-	kubectl cp /file-watcher/scripts/nodejsScripts "$podName":/scripts
-	kubectl exec "$podName" -- /scripts/noderun.sh start false "$START_MODE" "$HOST_OS"
 
 	echo -e "Touching application log file: "$LOG_FOLDER/$APP_LOG.log""
 	touch "$LOG_FOLDER/$APP_LOG.log"


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
A minimal change to fix the app log of remote node projects, by reverting a change I introduced in https://github.com/eclipse/codewind/pull/2519/files#diff-01158df81e32898a658c7bf563f5924aR146 to overwrite the user's helm chart with a `tail` command (allowing us to restart the node process in debug mode)

This does not revert all of the changes introduced in #2519, because I could not automatically revert that PR, and thought it safest to manually revert the minimum changes needed

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2761

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
