### PR TITLE
[0.12.0] Cope with paths being re-written in the perf dashboard.

### DIFF
--- a/src/performance/dashboard/src/App.js
+++ b/src/performance/dashboard/src/App.js
@@ -24,9 +24,13 @@ import SocketContext from './utils/sockets/SocketContext';
 import * as ProjectIDChecker from './utils/projectUtils';
 import * as AppConstants from './AppConstants';
 
-let socketURL = `${AppConstants.API_SERVER}/default`;
+let socketURL = `${AppConstants.API_HOST}/default`;
+let socketPath = `${AppConstants.API_ROOT}/socket.io/`;
 
-const socket = io(socketURL, { timeout: '5000' });
+const socket = io(socketURL, {
+  timeout: '5000',
+  path: socketPath,
+});
 
 // Authenticate socket after connecting
 socket.on('connect', function(){
@@ -49,7 +53,7 @@ function App() {
             <NavBar projectID={projectID} />
           </ErrorBoundary>
           {(!projectID) ? <ModalNoProjectID /> :
-            <Router basename={'/performance'}>
+            <Router basename={`${AppConstants.API_ROOT}/performance`}>
               <Route exact={true} path='/' render={(props) => <PagePerformance {...props} projectID={projectID} />} />
               <Route exact={true} path='/charts' render={(props) => <PagePerformance {...props} projectID={projectID} />} />
             </Router >

--- a/src/performance/dashboard/src/AppConstants.jsx
+++ b/src/performance/dashboard/src/AppConstants.jsx
@@ -10,8 +10,9 @@
 ******************************************************************************/
 
 export const APP_NAME = "codewind";
-const API_ROOT = location.pathname.substring(0, location.pathname.indexOf('/performance/'));
-export const API_SERVER = `${location.protocol}//${location.host}${API_ROOT}`;
+export const API_ROOT = location.pathname.substring(0, location.pathname.indexOf('/performance/'));
+export const API_HOST = `${location.protocol}//${location.host}`
+export const API_SERVER = `${API_HOST}${API_ROOT}`;
 export const MAX_DESC_LENGTH = 80;
 
 export const ROUTES_CHARTS = 'charts';


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes an issue with the socket path and the path used as a base name for the react router.
This happens when the codewind performance dashboard is proxied and placed under a new path other than /.

This PR ports the fix to 0.12.0, it was merged to master under https://github.com/eclipse/codewind/pull/2814

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No