### PR TITLE
[0.12.0] Quote filenames when deleting

### DIFF
--- a/src/pfe/portal/modules/utils/dockerFunctions.js
+++ b/src/pfe/portal/modules/utils/dockerFunctions.js
@@ -148,7 +148,7 @@ async function copyFileFromContainer(project, sourceName, destinationName) {
 }
 
 async function deleteFile(project, projectRoot, relativePathOfFile) {
-  const dockerCommand = `docker exec ${project.containerId} rm -rf ${projectRoot}/${relativePathOfFile}`;
+  const dockerCommand = `docker exec ${project.containerId} rm -rf "${projectRoot}/${relativePathOfFile}"`;
   log.debug(`[docker rm command] ${dockerCommand}`);
   await exec(dockerCommand);
 }


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes our docker rm command to quote filenames to ensure that they can be deleted when the names contain spaces.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2833

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2833

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
