### PR TITLE
Add target projectName to project link object

### DIFF
--- a/src/pfe/portal/modules/project/Links.js
+++ b/src/pfe/portal/modules/project/Links.js
@@ -98,8 +98,8 @@ class Links {
 }
 
 function validateLink(newLink, links) {
-  const { projectID, envName, projectURL } = newLink;
-  if (!projectID || !envName || !projectURL) {
+  const { projectID, projectName, envName, projectURL } = newLink;
+  if (!projectID || !projectName || !envName || !projectURL) {
     log.error(newLink);
     throw new ProjectLinkError(`INVALID_PARAMETERS`, newLink.envName);
   }

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -43,6 +43,7 @@ router.post('/api/v1/projects/:id/links', validateReq, checkProjectExists, async
 
     await project.createLink({
       projectID: targetProjectID,
+      projectName: targetProject.name,
       envName,
       projectURL,
     });

--- a/test/src/unit/modules/project/Links.test.js
+++ b/test/src/unit/modules/project/Links.test.js
@@ -26,6 +26,7 @@ chai.use(chaiAsPromised);
 
 const dummyLink = {
     projectID: 'dummyID',
+    projectName: 'dummyName',
     projectURL: 'projectURL',
     envName: 'ENV_NAME',
 };
@@ -255,6 +256,7 @@ describe('Links.js', function() {
                 const links = [{ envName: 'existing' }];
                 const newLink = {
                     projectID: 'id',
+                    projectName: 'name',
                     envName: 'existing',
                     projectURL: 'some',
                 };
@@ -264,6 +266,7 @@ describe('Links.js', function() {
             it('returns a validated link object', () => {
                 const newLink = {
                     projectID: 'id',
+                    projectName: 'name',
                     envName: 'existing',
                     projectURL: 'some',
                 };


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds the project name to the Link object so that the IDE's can show a nice error even if the projectID no longer exists.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: #2876

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
@tetchel fyi