### PR TITLE
Disable Microprofile metrics authentication

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1001,6 +1001,39 @@ paths:
         404:
           description: Project not found
 
+  /api/v1/projects/{id}/metrics/auth:
+    post:
+      summary: Disable Microprofile metrics authentication
+      description: >
+        Injects a file into the project container which disables Microprofile metrics authentication
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+          description: id of project
+      requestBody:
+        description: Value indicating whether the file that disables metrics authentication should be injected
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - disable
+              properties:
+                enable:
+                  type: boolean
+      responses:
+        202:
+          description: Successful update of project information and build triggered
+          content:
+            application/json:
+              schema:
+                type: object
+        404:
+          description: Project not found
+
 
   /api/v1/projects/{id}/metrics/types:
     post:

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -12,8 +12,6 @@ const metricsService = require('../modules/metricsService');
 const Logger = require('../modules/utils/Logger');
 const cwUtils = require('../modules/utils/sharedFunctions');
 const { getProjectFromReq } = require('../middleware/checkProjectExists');
-const path = require('path');
-const fs = require('fs-extra');
 
 const log = new Logger(__filename);
 
@@ -66,7 +64,7 @@ async function inject(req, res) {
 }
 
 async function auth(req, res) {
-  const disableMetricsAuth = req.sanitizeBody('disable');
+  const disableMetricsAuth = req.sanitizeBody('disable') === 'true';
   const user = req.cw_user;
   const project = getProjectFromReq(req);
   const projectDir = project.projectPath();

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -64,7 +64,8 @@ async function inject(req, res) {
 }
 
 async function auth(req, res) {
-  const disableMetricsAuth = req.sanitizeBody('disable') === 'true';
+  // Handle true as a string or boolean
+  const disableMetricsAuth = req.sanitizeBody('disable') === 'true' || req.sanitizeBody('disable') === true;
   const user = req.cw_user;
   const project = getProjectFromReq(req);
   const projectDir = project.projectPath();

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -74,8 +74,8 @@ async function auth(req, res) {
   try {
     if (disableMetricsAuth) {
       await metricsService.disableMicroprofileMetricsAuth(project.language, projectDir);
-    // } else {
-    //   await metricsService.removeMetricsCollectorFromProject(project.projectType, project.language, projectDir);
+    } else {
+      await metricsService.enableMicroprofileMetricsAuth(project.language, projectDir);
     }
     res.sendStatus(202);
   } catch (err) {

--- a/src/pfe/portal/controllers/metrics.controller.js
+++ b/src/pfe/portal/controllers/metrics.controller.js
@@ -11,6 +11,9 @@
 const metricsService = require('../modules/metricsService');
 const Logger = require('../modules/utils/Logger');
 const cwUtils = require('../modules/utils/sharedFunctions');
+const { getProjectFromReq } = require('../middleware/checkProjectExists');
+const path = require('path');
+const fs = require('fs-extra');
 
 const log = new Logger(__filename);
 
@@ -62,6 +65,31 @@ async function inject(req, res) {
   }
 }
 
+async function auth(req, res) {
+  const disableMetricsAuth = req.sanitizeBody('disable');
+  const project = getProjectFromReq(req);
+  const { projectID, language } = project;
+  const projectDir = project.projectPath();
+  if (disableMetricsAuth) {
+    const disableAuthFilePath = await metricsService.disableMicroprofileMetricsAuth(language, projectDir);
+    const now = new Date();
+    const timestamp = now.getTime();
+    const IFileChangeEvent = [
+      {
+        path: disableAuthFilePath,
+        timestamp,
+        type: "MODIFY",
+        directory: false
+      },
+    ];
+    // req.cw_user.fileChanged(projectID, timestamp, 1, 1, IFileChangeEvent);
+    // req.cw_user.buildProject(project, "build");
+  // } else {
+  //   await metricsService.removeMetricsCollectorFromProject(project.projectType, project.language, projectDir);
+  }
+  res.sendStatus(202);
+}
+
 async function syncProjectFilesIntoBuildContainer(project, user){
   const globalProjectPath = project.projectPath();
   const projectRoot = cwUtils.getProjectSourceRoot(project);
@@ -83,4 +111,5 @@ async function syncProjectFilesIntoBuildContainer(project, user){
 
 module.exports = {
   inject,
+  auth,
 }

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -572,11 +572,15 @@ function getNewPomXmlBuildPlugins(originalBuildPlugins) {
 }
 
 async function disableMicroprofileMetricsAuth(projectLanguage, projectDir) {
-  if (projectLanguage !== 'java') return null;
+  if (projectLanguage !== 'java') {
+    throw new Error(`Disabling of Microprofile metrics authentication is not supported for projects of language '${projectLanguage}'`);
+  }
   const contents = '<server>\n\t<mpMetrics authentication="false"/>\n</server>\n';
   const fileName = 'codewind-override-disable-mpmetrics-auth.xml';
   const pathToServerXml = await findFile('server.xml', projectDir);
-  if (!pathToServerXml) return null;
+  if (!pathToServerXml) {
+    throw new Error(`Unable to determine 'server.xml' directory, cannot create Microprofile metrics authentication override file`);
+  }
   const serverXmlDirectory = path.dirname(pathToServerXml);
   // Use overrides as it has a higher priority than /configDropins/defaults
   const overridesDir = path.join(serverXmlDirectory, '/configDropins/overrides');
@@ -587,10 +591,14 @@ async function disableMicroprofileMetricsAuth(projectLanguage, projectDir) {
 }
 
 async function enableMicroprofileMetricsAuth(projectLanguage, projectDir) {
-  if (projectLanguage !== 'java') return null;
+  if (projectLanguage !== 'java') {
+    throw new Error(`Disabling of Microprofile metrics authentication is not supported for projects of language '${projectLanguage}'`);
+  }
   const fileName = 'codewind-override-disable-mpmetrics-auth.xml';
   const pathToServerXml = await findFile('server.xml', projectDir);
-  if (!pathToServerXml) return null;
+  if (!pathToServerXml) {
+    throw new Error(`Unable to determine 'server.xml' directory, cannot remove Microprofile metrics authentication override file`);
+  }
   const serverXmlDirectory = path.dirname(pathToServerXml);
   // Use overrides as it has a higher priority than /configDropins/defaults
   const filePath = path.join(serverXmlDirectory, '/configDropins/overrides', fileName);

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -576,6 +576,7 @@ async function disableMicroprofileMetricsAuth(projectLanguage, projectDir) {
   const contents = '<server>\n\t<mpMetrics authentication="false"/>\n</server>\n';
   const fileName = 'codewind-override-disable-mpmetrics-auth.xml';
   const pathToServerXml = await findFile('server.xml', projectDir);
+  if (!pathToServerXml) return null;
   const serverXmlDirectory = path.dirname(pathToServerXml);
   // Use overrides as it has a higher priority than /configDropins/defaults
   const overridesDir = path.join(serverXmlDirectory, '/configDropins/overrides');
@@ -585,6 +586,17 @@ async function disableMicroprofileMetricsAuth(projectLanguage, projectDir) {
   return filePath;
 }
 
+async function enableMicroprofileMetricsAuth(projectLanguage, projectDir) {
+  if (projectLanguage !== 'java') return null;
+  const fileName = 'codewind-override-disable-mpmetrics-auth.xml';
+  const pathToServerXml = await findFile('server.xml', projectDir);
+  if (!pathToServerXml) return null;
+  const serverXmlDirectory = path.dirname(pathToServerXml);
+  // Use overrides as it has a higher priority than /configDropins/defaults
+  const filePath = path.join(serverXmlDirectory, '/configDropins/overrides', fileName);
+  return fs.remove(filePath);
+}
+
 module.exports = {
   injectMetricsCollectorIntoProject,
   removeMetricsCollectorFromProject,
@@ -592,4 +604,5 @@ module.exports = {
   identifyProject,
   determineIfOpenLiberty,
   disableMicroprofileMetricsAuth,
+  enableMicroprofileMetricsAuth,
 }

--- a/src/pfe/portal/modules/utils/sharedFunctions.js
+++ b/src/pfe/portal/modules/utils/sharedFunctions.js
@@ -189,6 +189,7 @@ function getProjectSourceRoot(project) {
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
 
 // List all the files or directories under a given directory
+// getDirectories: true will return directories, false will return files
 async function recursivelyListFilesOrDirectories(getDirectories, absolutePath, relativePath = '') {
   const directoryContents = await fs.readdir(absolutePath);
   const completePathArray = await Promise.all(directoryContents.map(async dir => {
@@ -208,6 +209,16 @@ async function recursivelyListFilesOrDirectories(getDirectories, absolutePath, r
   return completePathArray.reduce((a, b) => a.concat(b), []);
 }
 
+// Returns the first file that matches the fileName
+async function findFile(fileName, directory) {
+  const currentFileList = await recursivelyListFilesOrDirectories(false, directory);
+  const foundFilePath = currentFileList.find(filePath => path.basename(filePath) === fileName);
+  if (foundFilePath) {
+    return path.join(directory, foundFilePath);
+  }
+  return null;
+}
+
 module.exports = {
   ...containerFunctions,
   timeout,
@@ -221,4 +232,5 @@ module.exports = {
   getProjectSourceRoot,
   deepClone,
   recursivelyListFilesOrDirectories,
+  findFile,
 }

--- a/src/pfe/portal/pushLocal.sh
+++ b/src/pfe/portal/pushLocal.sh
@@ -9,4 +9,5 @@ docker cp docs/. codewind-pfe:/portal/docs
 docker cp middleware/. codewind-pfe:/portal/middleware
 docker cp modules/. codewind-pfe:/portal/modules
 docker cp routes/. codewind-pfe:/portal/routes
+docker cp controllers/. codewind-pfe:/portal/controllers
 docker cp server.js codewind-pfe:/portal/server.js

--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -25,7 +25,7 @@ const { ILLEGAL_PROJECT_NAME_CHARS } = require('../../config/requestConfig');
 const router = express.Router();
 const log = new Logger(__filename);
 const { validateReq } = require('../../middleware/reqValidator');
-const { recursivelyListFilesOrDirectories } = require('../utils/sharedFunctions');
+const { recursivelyListFilesOrDirectories } = require('../../modules/utils/sharedFunctions');
 
 let timerbindstart = 0;
 let timerbindend = 0;

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -161,7 +161,7 @@ router.get('/api/v1/projects/:id/metrics/:type', async function (req, res) {
 
 router.post('/api/v1/projects/:id/metrics/inject', validateReq, metricsController.inject);
 
-router.post('/api/v1/projects/:id/metrics/auth', checkProjectExists, metricsController.auth);
+router.post('/api/v1/projects/:id/metrics/auth', validateReq, checkProjectExists, metricsController.auth);
 
 /**
 * Updates the description of a specific load-test run on a specified project

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -161,6 +161,8 @@ router.get('/api/v1/projects/:id/metrics/:type', async function (req, res) {
 
 router.post('/api/v1/projects/:id/metrics/inject', validateReq, metricsController.inject);
 
+router.post('/api/v1/projects/:id/metrics/auth', checkProjectExists, metricsController.auth);
+
 /**
 * Updates the description of a specific load-test run on a specified project
 * @param id, the id of the project

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -74,8 +74,7 @@ const defaultNodeProjectDirList = [
  */
 async function createProjectFromTemplate(name, projectType, path, autoBuild = false) {
     const { url, language } = templateOptions[projectType];
-
-    const pfeProjectType = (['openliberty', 'go'].includes(projectType))
+    const pfeProjectType = (['openliberty', 'go', 'lagom'].includes(projectType))
         ? 'docker'
         : projectType;
 

--- a/test/src/API/projects/metricsAuth.test.js
+++ b/test/src/API/projects/metricsAuth.test.js
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2019 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+const chai = require('chai');
+const path = require('path');
+const chaiSubset = require('chai-subset');
+const chaiResValidator = require('chai-openapi-response-validator');
+
+const projectService = require('../../../modules/project.service');
+const reqService = require('../../../modules/request.service');
+const {
+    ADMIN_COOKIE,
+    TEMP_TEST_DIR,
+    testTimeout,
+    pathToApiSpec,
+} = require('../../../config');
+
+chai.use(chaiSubset);
+chai.use(chaiResValidator(pathToApiSpec));
+chai.should();
+
+const postMetricsAuth = (projectID, options) => reqService.chai
+    .post(`/api/v1/projects/${projectID}/metrics/auth`)
+    .set('Cookie', ADMIN_COOKIE)
+    .send(options);
+
+describe('Metrics Auth tests (/api/v1/projects/{id}/metrics/auth)', function() {
+    it('returns 404 to /metrics/auth when project does not exist', async function() {
+        const projectID = '00000000-0000-0000-0000-000000000000';
+        this.timeout(testTimeout.short);
+        const res = await postMetricsAuth(projectID, { disable: true });
+
+        res.status.should.equal(404, res.text); // print res.text if assertion fails
+        res.text.should.equal(`Project with ID \'${projectID}\' does not exist on the Codewind server`);
+    });
+
+    describe('Disables and enables the metrics authentication of an open-liberty application (these `it` blocks depend on each other passing)', function() {
+        const projectName = `test-open-liberty-metrics-auth-${Date.now()}`;
+        const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
+        let projectID;
+
+        before('create a sample project and bind to Codewind, without building', async function() {
+            this.timeout(testTimeout.med);
+            projectID = await projectService.createProjectFromTemplate(projectName, 'openliberty', pathToLocalProject); 
+        });
+
+        after(async function() {
+            this.timeout(testTimeout.med);
+            await projectService.removeProject(pathToLocalProject, projectID);
+        });
+
+        it('returns 202 to /metrics/auth and adds the disable metrics authentication file into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsAuth(projectID, { disable: true });
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
+        });
+
+        it('returns 202 to /metrics/auth and removes the disable metrics authentication file into the user\'s project', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsAuth(projectID, { disable: false });
+            res.status.should.equal(202, res.text); // print res.text if assertion fails
+        });
+    });
+});

--- a/test/src/unit/modules/metricsService.test.js
+++ b/test/src/unit/modules/metricsService.test.js
@@ -946,6 +946,70 @@ describe('metricsService/index.js', () => {
             });
         });
     });
+    describe('disableMicroprofileMetricsAuth(projectLanguage, projectDir)', () => {
+        const testDir = path.join(projectDir, 'disableMicroprofileMetricsAuth');
+        beforeEach(() => {
+            fs.ensureDirSync(testDir);
+        });
+        afterEach(() => {
+            fs.removeSync(testDir);
+        });
+        it('returns the filePath and creates the override file as the projectLanguage is java and the server.xml can be found', async() => {
+            await fs.ensureFile(path.join(testDir, 'server.xml'));
+
+            const filePath = await metricsService.disableMicroprofileMetricsAuth('java', testDir);
+            filePath.should.equal(path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml'));
+            const fileContents = await fs.readFile(filePath, 'utf8');
+            fileContents.should.equal('<server>\n\t<mpMetrics authentication="false"/>\n</server>\n');
+        });
+        it('returns null as the language is not java', async() => {
+            const filePath = await metricsService.disableMicroprofileMetricsAuth('notjava', testDir);
+            chai.expect(filePath).to.equal(null);
+        });
+        it('returns null as the server.xml does not exist', async() => {
+            const filePath = await metricsService.disableMicroprofileMetricsAuth('java', testDir);
+            chai.expect(filePath).to.equal(null);
+        });
+    });
+    describe('enableMicroprofileMetricsAuth(projectLanguage, projectDir)', () => {
+        const testDir = path.join(projectDir, 'enableMicroprofileMetricsAuth');
+        beforeEach(() => {
+            fs.ensureDirSync(testDir);
+        });
+        afterEach(() => {
+            fs.removeSync(testDir);
+        });
+        it('removes the override file as the projectType is java, the server.xml can be found and the override file exists', async() => {
+            await fs.ensureFile(path.join(testDir, 'server.xml'));
+            const filePath = path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml');
+            await fs.ensureFile(filePath);
+            await metricsService.enableMicroprofileMetricsAuth('java', testDir);
+            const fileExists = await fs.pathExists(filePath);
+            fileExists.should.be.false;
+        });
+        it('does nothing when the override file does not exist', async() => {
+            await fs.ensureFile(path.join(testDir, 'server.xml'));
+            const filePath = path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml');
+            await metricsService.enableMicroprofileMetricsAuth('java', testDir);
+            const fileExists = await fs.pathExists(filePath);
+            fileExists.should.be.false;
+        });
+        it('does nothing when the projectType is not java', async() => {
+            await fs.ensureFile(path.join(testDir, 'server.xml'));
+            const filePath = path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml');
+            await fs.ensureFile(filePath);
+            await metricsService.enableMicroprofileMetricsAuth('notjava', testDir);
+            const fileExists = await fs.pathExists(filePath);
+            fileExists.should.be.true;
+        });
+        it('does nothing when the server.xml cannot be found', async() => {
+            const filePath = path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml');
+            await fs.ensureFile(filePath);
+            await metricsService.enableMicroprofileMetricsAuth('java', testDir);
+            const fileExists = await fs.pathExists(filePath);
+            fileExists.should.be.true;
+        });
+    });
 });
 
 describe('metricsService/node.js', () => {

--- a/test/src/unit/modules/metricsService.test.js
+++ b/test/src/unit/modules/metricsService.test.js
@@ -962,13 +962,13 @@ describe('metricsService/index.js', () => {
             const fileContents = await fs.readFile(filePath, 'utf8');
             fileContents.should.equal('<server>\n\t<mpMetrics authentication="false"/>\n</server>\n');
         });
-        it('returns null as the language is not java', async() => {
-            const filePath = await metricsService.disableMicroprofileMetricsAuth('notjava', testDir);
-            chai.expect(filePath).to.equal(null);
+        it('throws an error as the language is not java', () => {
+            return metricsService.disableMicroprofileMetricsAuth('notjava', testDir)
+                .should.eventually.be.rejectedWith('Disabling of Microprofile metrics authentication is not supported for projects of language \'notjava\'');
         });
-        it('returns null as the server.xml does not exist', async() => {
-            const filePath = await metricsService.disableMicroprofileMetricsAuth('java', testDir);
-            chai.expect(filePath).to.equal(null);
+        it('throws an error as the server.xml does not exist', () => {
+            return metricsService.disableMicroprofileMetricsAuth('java', testDir)
+                .should.eventually.be.rejectedWith('Unable to determine \'server.xml\' directory, cannot create Microprofile metrics authentication override file');
         });
     });
     describe('enableMicroprofileMetricsAuth(projectLanguage, projectDir)', () => {
@@ -994,18 +994,20 @@ describe('metricsService/index.js', () => {
             const fileExists = await fs.pathExists(filePath);
             fileExists.should.be.false;
         });
-        it('does nothing when the projectType is not java', async() => {
+        it('throws an error when the projectType is not java', async() => {
             await fs.ensureFile(path.join(testDir, 'server.xml'));
             const filePath = path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml');
             await fs.ensureFile(filePath);
-            await metricsService.enableMicroprofileMetricsAuth('notjava', testDir);
+            await metricsService.enableMicroprofileMetricsAuth('notjava', testDir)
+                .should.be.rejectedWith('Disabling of Microprofile metrics authentication is not supported for projects of language \'notjava\'');
             const fileExists = await fs.pathExists(filePath);
             fileExists.should.be.true;
         });
-        it('does nothing when the server.xml cannot be found', async() => {
+        it('throws an error when the server.xml cannot be found', async() => {
             const filePath = path.join(testDir, '/configDropins/overrides', 'codewind-override-disable-mpmetrics-auth.xml');
             await fs.ensureFile(filePath);
-            await metricsService.enableMicroprofileMetricsAuth('java', testDir);
+            await metricsService.enableMicroprofileMetricsAuth('java', testDir)
+                .should.be.rejectedWith('Unable to determine \'server.xml\' directory, cannot remove Microprofile metrics authentication override file');
             const fileExists = await fs.pathExists(filePath);
             fileExists.should.be.true;
         });

--- a/test/src/unit/modules/utils/sharedFunctions.test.js
+++ b/test/src/unit/modules/utils/sharedFunctions.test.js
@@ -14,12 +14,14 @@ const path = require('path');
 const rewire = require('rewire');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const deepEqualInAnyOrder = require('deep-equal-in-any-order');
 
 const sharedFunctions = rewire('../../../../../src/pfe/portal/modules/utils/sharedFunctions');
 
 const { suppressLogOutput } = require('../../../../modules/log.service');
 
 chai.use(chaiAsPromised);
+chai.use(deepEqualInAnyOrder);
 chai.should();
 
 const testDirectory = path.join(__dirname, 'sharedFunctionsTest');
@@ -93,4 +95,90 @@ describe('sharedFunctions.js', () => {
             isWindowsPath.should.be.false;
         });
     });
+    describe('recursivelyListFilesOrDirectories', function() {
+        const { recursivelyListFilesOrDirectories } = sharedFunctions;
+        const testDir = path.join(testDirectory, 'recursivelyListFilesOrDirectories');
+        describe('when getDirectories is true', function() {
+            beforeEach(function() {
+                fs.ensureDirSync(testDir);
+            });
+            afterEach(function() {
+                fs.removeSync(testDir);
+            });
+            it('returns an empty array when only files and no directories exist', async function() {
+                await createFilesFromArray(testDir, ['file1', 'file2', 'file3']);
+                const dirs = await recursivelyListFilesOrDirectories(true, testDir);
+                dirs.length.should.equal(0);
+            });
+            it('returns an empty array the given directory is empty', async function() {
+                const dirs = await recursivelyListFilesOrDirectories(true, testDir);
+                dirs.length.should.equal(0);
+            });
+            it('returns an array with 4 elements when the given directory has 2 subdirectories and they have 1 subdirectory each', async function() {
+                await createDirectoriesFromArray(testDir, ['dir1/subdir1', 'dir2/subdir2']);
+                const dirs = await recursivelyListFilesOrDirectories(true, testDir);
+                dirs.length.should.equal(4);
+                dirs.should.deep.equal([
+                    'dir1',
+                    'dir1/subdir1',
+                    'dir2',
+                    'dir2/subdir2',
+                ]);
+            });
+        });
+        describe('when getDirectories is false', function() {
+            beforeEach(function() {
+                fs.ensureDirSync(testDir);
+            });
+            afterEach(function() {
+                fs.removeSync(testDir);
+            });
+            it('returns an empty array when only directories and no files exist', async function() {
+                await createDirectoriesFromArray(testDir, ['dir1/subdir1', 'dir2/subdir2']);
+                const files = await recursivelyListFilesOrDirectories(false, testDir);
+                files.length.should.equal(0);
+            });
+            it('returns an empty array the given directory is empty', async function() {
+                const files = await recursivelyListFilesOrDirectories(false, testDir);
+                files.length.should.equal(0);
+            });
+            it('returns an array of files when files exist in the top level directory and also in subdirectories', async function() {
+                const relativeFilePaths = ['file1', 'dir1/file2', 'dir1/dir2/file3'];
+                await createFilesFromArray(testDir, relativeFilePaths);
+                const files = await recursivelyListFilesOrDirectories(false, testDir);
+                files.length.should.equal(3);
+                files.should.deep.equalInAnyOrder(relativeFilePaths);
+            });
+        });
+    });
+    describe('findFile(fileName, directory)', function() {
+        const { findFile } = sharedFunctions;
+        const testDir = path.join(testDirectory, 'findFile');
+        beforeEach(function() {
+            fs.ensureDirSync(testDir);
+        });
+        afterEach(function() {
+            fs.removeSync(testDir);
+        });
+        it('returns absolute file path when found', async function() {
+            const relativeFilePaths = ['file1', 'dir1/file2', 'dir1/dir2/fileToFind'];
+            await createFilesFromArray(testDir, relativeFilePaths);
+            const file = await findFile('fileToFind', testDir);
+            file.should.equal(path.join(testDir, 'dir1/dir2/fileToFind'));
+        });
+        it('returns null when not found', async function() {
+            const relativeFilePaths = ['file1', 'dir1/file2'];
+            await createFilesFromArray(testDir, relativeFilePaths);
+            const file = await findFile('fileToFind', testDir);
+            chai.expect(file).to.equal(null);
+        });
+    });
 });
+
+const createFilesFromArray = (parentDir, fileArray) => {
+    return Promise.all(fileArray.map(file => fs.ensureFile(path.join(parentDir, file))));
+};
+
+const createDirectoriesFromArray = (parentDir, dirArray) => {
+    return Promise.all(dirArray.map(file => fs.ensureDir(path.join(parentDir, file))));
+};


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
Adds functionality to disable the authentication for Microprofile `/metrics` (Appsody Open Liberty have authentication enabled by default).
* Adds a `'/api/v1/projects/:id/metrics/auth` to disable/re-enable.
* To disable it as a file into the project `configDropins/overrides` directory, to re-enable it just deletes this file.
* Moves the `recursivelyListFilesOrDirectories` out of the `bind.route.js` file into `sharedFunctions` and adds tests for it.


### Testing 
* Added test for new functions

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2712

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
Need to test using Appsody Open Liberty project type - this implemention would work for Codewind Open Liberty but currently the Dockerfile does not support the configDropins directory existing.