### PR TITLE
[0.12.0] Handle http-proxy exceptions when PFE is unavailable

### DIFF
--- a/src/gatekeeper/server.js
+++ b/src/gatekeeper/server.js
@@ -158,27 +158,42 @@ async function main() {
     app.get("/api/pfe/ready", function (req, res) {
         console.log(`/api/pfe/ready - req.originalUrl = ${req.originalUrl}`);
         req.url = '/health';
-        proxy.web(req, res, {
-            target: pfe_target,
-        });
+        try {
+            proxy.web(req, res, {
+                target: pfe_target,
+            });
+        } catch (err) {
+            console.log("Proxy /api/pfe/ready error: ", err);
+            res.sendStatus(502);
+        }
     });
 
     /* PFE handles socket IO authentication*/
     app.use('/socket.io/*', function (req, res) {
         console.log(`/socket.io/* - req.originalUrl = ${req.originalUrl}`);
         req.url = req.originalUrl;
-        proxy.web(req, res, {
-            target: pfe_target
-        });
+        try {
+            proxy.web(req, res, {
+                target: pfe_target
+            });
+        } catch (err) {
+            console.log("Proxy /socket.io/* error: ", err);
+            res.sendStatus(502);
+        }
     });
 
     /* Proxy Performance container routes */
     app.use('*', authMiddleware, function (req, res) {
         console.log(`* - req.originalUrl = ${req.originalUrl}`);
         req.url = req.originalUrl;
-        proxy.web(req, res, {
-            target: pfe_target
-          });
+        try {
+            proxy.web(req, res, {
+                target: pfe_target
+            });
+        } catch (err) {
+            console.log("Proxy * error: ", err);
+            res.sendStatus(502);
+        }
     });
 
     const https = require('https');
@@ -189,7 +204,12 @@ async function main() {
 
     server.on('upgrade', function (req, socket, head) {
         console.log("Proxy: websocket connect 'upgrade'")
-        proxy.ws(req, socket, head);
+        try {
+            proxy.ws(req, socket, head);
+        } catch (err) {
+            console.log("Proxy upgrade error:", err);
+            res.sendStatus(502);
+        }
     });
 
     server.listen(port, () => console.log(`Gatekeeper listening on port ${port}!`))


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Protects Gatekeeper from PFE becoming unresponsive when trying to reverse proxy connections.

Prior to this fix if the IDE or performance dashboard were up but PFE went down, the Gatekeeper pod would restart because proxied requests would timeout. 

With this fix in place the Gatekeeper does not restart and will send back an HTTP Gateway error instead.

## Which issue(s) does this PR fix ? #2827 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/2827
## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
NO

Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>