### PR TITLE
Enhancement 2506: Add new profiling API

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -593,6 +593,85 @@ paths:
         500:
           description: Internal error
 
+
+  /api/v1/projects/{id}/profiling/{testRunTime}/querytree:
+    post:
+      summary: Queries the profiling tree data for the given timestamp
+      description: >
+        Reads profiling data from pfe, runs the supplied JSONPath query against it and returns the results.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: id of project
+        - in: path
+          schema:
+            type: string
+          name: testRunTime
+          required: true
+          description: Time of loadtest run
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  description: a JSONPath expression to run.
+      responses:
+        200:
+          description: Successful read of load run data
+        400:
+          description: Incorrect parameters given
+        404:
+          $ref: '#/components/responses/ProjectNotFound'
+        500:
+          description: Internal error
+
+  /api/v1/projects/{id}/profiling/{testRunTime}/querysummary:
+    post:
+      summary: Queries the profiling summary data for the given timestamp
+      description: >
+        Reads profiling summary data from pfe, runs the supplied JSONPath query against it and returns the results.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+          required: true
+          description: id of project
+        - in: path
+          schema:
+            type: string
+          name: testRunTime
+          required: true
+          description: Time of loadtest run
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - path
+              properties:
+                path:
+                  type: string
+                  description: a JSONPath expression to run.
+      responses:
+        200:
+          description: Successful read of load run data
+        400:
+          description: Incorrect parameters given
+        404:
+          $ref: '#/components/responses/ProjectNotFound'
+        500:
+          description: Internal error
+
   /api/v1/projects/{id}/unbind:
       post:
         summary: Unbind a given project from codewind

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -651,17 +651,34 @@ module.exports = class LoadRunner {
     const normalisedProfilingPath = this.project.getPathToProfilingTreeFile(this.metricsFolder);
     const mergeCommand = `${process.execPath} /portal/scripts/mergeNodeProfiles.js ${profilingPath} ${normalisedProfilingPath}`;
     log.debug(`Running: ${mergeCommand}`);
-    const mergeProcess = await exec(mergeCommand);
-    log.trace(mergeProcess.stdout);
-    log.trace(mergeProcess.stderr);
-    log.debug('Merging done');
+    try {
+      const mergeProcess = await exec(mergeCommand);
+      // Log these but they should be empty in the success case.
+      log.trace(mergeProcess.stdout);
+      log.trace(mergeProcess.stderr);
+      log.debug('Merging done');
+    } catch (err) {
+      // stdout/stderr may contain useful feedback if there was an error.
+      log.trace(err.stdout);
+      log.trace(err.stderr);
+      throw new Error(`Error running merge command. Exit code ${err.code}`);
+    }
 
     const summarisedProfilingPath = this.project.getPathToProfilingSummaryFile(this.metricsFolder);
     const summariseCommand = `${process.execPath} /portal/scripts/summariseProfile.js ${normalisedProfilingPath} ${summarisedProfilingPath}`;
     log.debug(`Running: ${summariseCommand}`);
-    const summariseProcess = await exec(summariseCommand);
-    log.trace(summariseProcess.stdout);
-    log.trace(summariseProcess.stderr);
+    try {
+      const summariseProcess = await exec(mergeCommand);
+      // Log these but they should be empty in the success case.
+      log.trace(summariseProcess.stdout);
+      log.trace(summariseProcess.stderr);
+      log.debug('Merging done');
+    } catch (err) {
+      // stdout/stderr may contain useful feedback if there was an error.
+      log.trace(err.stdout);
+      log.trace(err.stderr);
+      throw new Error(`Error running summarise command. Exit code ${err.code}`);
+    }
     log.debug('Summarising done');
   }
 

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -13,6 +13,7 @@ const dateFormat = require('dateformat');
 const fs = require('fs-extra');
 const io = require('socket.io-client');
 const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
 const path = require('path');
 const http = require('http');
 
@@ -626,6 +627,14 @@ module.exports = class LoadRunner {
         log.error(err);
       }
       log.info(`profiling.json saved for project ${this.project.name}`);
+
+      try {
+        await this.postProcessProfilingData();
+      } catch (err) {
+        log.error('endProfiling: Error post processing profiling data.');
+        log.error(err);
+      }
+
       const data = { projectID: this.project.projectID, status: 'profilingReady', timestamp: this.metricsFolder }
       this.user.uiSocket.emit('runloadStatusChanged', data);
       this.profilingSocket.emit('disableprofiling');
@@ -634,6 +643,26 @@ module.exports = class LoadRunner {
       this.profilingSamples = null;
     }
     this.emitCompleted();
+  }
+
+  async postProcessProfilingData() {
+    /* Run the merge out of process as the profiling data could potentially be quite large. */
+    const profilingPath = path.join(this.workingDir + '/profiling.json');
+    const normalisedProfilingPath = this.project.getPathToProfilingTreeFile(this.metricsFolder);
+    const mergeCommand = `${process.execPath} /portal/scripts/mergeNodeProfiles.js ${profilingPath} ${normalisedProfilingPath}`;
+    log.debug(`Running: ${mergeCommand}`);
+    const mergeProcess = await exec(mergeCommand);
+    log.trace(mergeProcess.stdout);
+    log.trace(mergeProcess.stderr);
+    log.debug('Merging done');
+
+    const summarisedProfilingPath = this.project.getPathToProfilingSummaryFile(this.metricsFolder);
+    const summariseCommand = `${process.execPath} /portal/scripts/summariseProfile.js ${normalisedProfilingPath} ${summarisedProfilingPath}`;
+    log.debug(`Running: ${summariseCommand}`);
+    const summariseProcess = await exec(summariseCommand);
+    log.trace(summariseProcess.stdout);
+    log.trace(summariseProcess.stderr);
+    log.debug('Summarising done');
   }
 
   async cancelProfiling() {

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -668,18 +668,17 @@ module.exports = class LoadRunner {
     const summariseCommand = `${process.execPath} /portal/scripts/summariseProfile.js ${normalisedProfilingPath} ${summarisedProfilingPath}`;
     log.debug(`Running: ${summariseCommand}`);
     try {
-      const summariseProcess = await exec(mergeCommand);
+      const summariseProcess = await exec(summariseCommand);
       // Log these but they should be empty in the success case.
       log.trace(summariseProcess.stdout);
       log.trace(summariseProcess.stderr);
-      log.debug('Merging done');
+      log.debug('Summarising done');
     } catch (err) {
       // stdout/stderr may contain useful feedback if there was an error.
       log.trace(err.stdout);
       log.trace(err.stderr);
       throw new Error(`Error running summarise command. Exit code ${err.code}`);
     }
-    log.debug('Summarising done');
   }
 
   async cancelProfiling() {

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -408,7 +408,25 @@ module.exports = class Project {
     }
     log.info(`Returning profiling file stream ${pathToProfilingFile} for ${this.name}`);
     return profilingStream;
-  } 
+  }
+
+  /**
+   * @param {String|Int} timeOfTestRun in 'yyyymmddHHMMss' format
+   */
+  getPathToProfilingTreeFile(timeOfTestRun) {
+    const pathToLoadTestDir = join(this.loadTestPath, String(timeOfTestRun));
+    const pathToProfilingJson = join(pathToLoadTestDir, 'cw-profile.json');
+    return pathToProfilingJson;
+  }
+
+  /**
+   * @param {String|Int} timeOfTestRun in 'yyyymmddHHMMss' format
+   */
+  getPathToProfilingSummaryFile(timeOfTestRun) {
+    const pathToLoadTestDir = join(this.loadTestPath, String(timeOfTestRun));
+    const pathToProfilingJson = join(pathToLoadTestDir, 'cw-profile-summary.json');
+    return pathToProfilingJson;
+  }
 
   /**
    * @param {String|Int} timeOfTestRun in 'yyyymmddHHMMss' format

--- a/src/pfe/portal/package-lock.json
+++ b/src/pfe/portal/package-lock.json
@@ -352,6 +352,11 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.21.tgz",
           "integrity": "sha512-PQKsydPxYxF1DsAFWmunaxd3sOi3iMt6Zmx/tgaagHYmwJ/9cRH91hQkeJZaUGWbvn0K5HlSVEXkn5U/llWPpQ=="
         },
+        "jsonpath-plus": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
+          "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg=="
+        },
         "ws": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -4646,9 +4651,9 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonpath-plus": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
-      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
+      "integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
     },
     "jsonwebtoken": {
       "version": "8.5.1",

--- a/src/pfe/portal/package.json
+++ b/src/pfe/portal/package.json
@@ -31,6 +31,7 @@
     "i18next": "^15.0.9",
     "i18next-node-fs-backend": "^2.1.3",
     "js-yaml": "^3.12.0",
+    "jsonpath-plus": "^4.0.0",
     "jsonwebtoken": "^8.5.1",
     "kubernetes-client": "^8.3.7",
     "lock": "^1.1.0",

--- a/src/pfe/portal/routes/projects/loadtest.route.js
+++ b/src/pfe/portal/routes/projects/loadtest.route.js
@@ -210,6 +210,17 @@ router.get('/api/v1/projects/:id/profiling/:testRunTime', validateReq, async fun
   }
 });
 
+/**
+ * Function to query the profiling tree data for a given project and test time
+ * with a JSONPath query.
+ * @param id, the id of the project
+ * @param testRunTime, the timestamp of the load runner test
+ * @return 200 if project existed and the profiling tree was found
+ * @return 400 if input is invalid
+ * @return 404 if project is not found
+ * @return 500 on internal error
+ */
+// We use POST rather than GET as GET requests are not supposed to have a body.
 router.post('/api/v1/projects/:id/profiling/:testRunTime/querytree', validateReq, async function (req, res) {
   try {
     const user = req.cw_user;
@@ -239,6 +250,17 @@ router.post('/api/v1/projects/:id/profiling/:testRunTime/querytree', validateReq
   }
 });
 
+/**
+ * Function to query the profiling summary data for a given project and test time
+ * with a JSONPath query.
+ * @param id, the id of the project
+ * @param testRunTime, the timestamp of the load runner test
+ * @return 200 if project existed and the profiling summary was found
+ * @return 400 if input is invalid
+ * @return 404 if project is not found
+ * @return 500 on internal error
+ */
+// We use POST rather than GET as GET requests are not supposed to have a body.
 router.post('/api/v1/projects/:id/profiling/:testRunTime/querysummary', validateReq, async function (req, res) {
   try {
     const user = req.cw_user;

--- a/src/pfe/portal/routes/projects/loadtest.route.js
+++ b/src/pfe/portal/routes/projects/loadtest.route.js
@@ -10,6 +10,8 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 const express = require('express');
+const fs = require('fs-extra');
+const {JSONPath} = require('jsonpath-plus');
 const path = require('path');
 const queryString = require('query-string');
 
@@ -202,6 +204,64 @@ router.get('/api/v1/projects/:id/profiling/:testRunTime', validateReq, async fun
     res.status(200)
     profilingStream.on('end', () => res.end());
     profilingStream.pipe(res);
+  } catch (err) {
+    log.error(err.info || err);
+    res.status(500).send(err.info || err);
+  }
+});
+
+router.post('/api/v1/projects/:id/profiling/:testRunTime/querytree', validateReq, async function (req, res) {
+  try {
+    const user = req.cw_user;
+    const projectID = req.sanitizeParams('id');
+    const project = user.projectList.retrieveProject(projectID);
+    if (!project) {
+      res.status(404).send(`Unable to find project ${projectID}`);
+      return;
+    }
+    const testRunTime = req.sanitizeParams('testRunTime');
+    const profilingTreeFile = await project.getPathToProfilingTreeFile(testRunTime);
+    if (!await fs.pathExists(profilingTreeFile)) {
+      res.status(404).send(`Unable to find profiling tree for ${testRunTime}`);
+      return;
+    }
+    // eslint-disable-next-line microclimate-portal-eslint/sanitise-body-parameters
+    const path = req.body['path'];
+    const options = {
+      wrap: false,
+    }
+    const profilingTree = await fs.readJSON(profilingTreeFile);
+    const result = JSONPath({options, path, json: profilingTree});
+    res.status(200).send(result);
+  } catch (err) {
+    log.error(err.info || err);
+    res.status(500).send(err.info || err);
+  }
+});
+
+router.post('/api/v1/projects/:id/profiling/:testRunTime/querysummary', validateReq, async function (req, res) {
+  try {
+    const user = req.cw_user;
+    const projectID = req.sanitizeParams('id');
+    const project = user.projectList.retrieveProject(projectID);
+    if (!project) {
+      res.status(404).send(`Unable to find project ${projectID}`);
+      return;
+    }
+    const testRunTime = req.sanitizeParams('testRunTime');
+    const profilingSummaryFile = await project.getPathToProfilingSummaryFile(testRunTime);
+    if (!await fs.pathExists(profilingSummaryFile)) {
+      res.status(404).send(`Unable to find profiling summary for ${testRunTime}`);
+      return;
+    }
+    // eslint-disable-next-line microclimate-portal-eslint/sanitise-body-parameters
+    const path = req.body['path'];
+    const options = {
+      wrap: false,
+    }
+    const profilingTree = await fs.readJSON(profilingSummaryFile);
+    const result = JSONPath({options, path, json: profilingTree});
+    res.status(200).send(result);
   } catch (err) {
     log.error(err.info || err);
     res.status(500).send(err.info || err);

--- a/src/pfe/portal/scripts/mergeNodeProfiles.js
+++ b/src/pfe/portal/scripts/mergeNodeProfiles.js
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+// This is a batch script intended to be started and run to completion.
+// We can disable the linter rule for no sync functions.
+/* eslint-disable no-sync */
+"use strict";
+const fs = require('fs-extra');
+
+// Map to provide fast lookups for existing functions.
+let functionsMap = {};
+
+// We use 0 for the magical parent node.
+let currentFunctionId = 1;
+
+// Initialise a new, empty profile and merge everything into this.
+let newProfile = {};
+
+// Allow this file to be loaded by others
+if (require.main === module) {
+  main(process.argv);
+}
+
+function main(argv) {
+
+  // Reset globals so this can be run more than once.
+  functionsMap = {}
+  currentFunctionId = 1;
+  newProfile = {
+    totalCount: 0,
+    "functions": [
+      {
+        self: 0,
+        location: {
+          file: "(root)",
+        },
+        depth: 0,
+        children: [],
+        count: 0,
+      }
+    ]
+  };
+
+  const inFile = argv[2];
+  const outFile = argv[3];
+  const perfData = fs.readJSONSync(inFile);
+
+  // TODO - Go through the output in detail and check all the parent/child relationships
+  // are correct.
+
+  // Don't think I can quite do this with JSONPath.
+  for (const profile of perfData) {
+    const existingIdToNewId = [0];
+    for (const fn of profile.functions) {
+      const parentId = existingIdToNewId[fn.parent];
+      newProfile.totalCount += fn.count;
+      if (parentId === undefined) {
+        console.error(`Found function with a parent we haven't seen yet: ${parentId}. Failing.`);
+        process.exit(1);
+      }
+      const profiledFunction = findOrCreateFn(fn, parentId);
+      existingIdToNewId[fn.self] = profiledFunction.self;
+    }
+  }
+
+  // Start at the root node and total up all the child call counts.
+  totalChildCounts(newProfile.functions[0]);
+
+  fs.writeJSONSync(outFile, newProfile, { spaces: 2 });
+}
+
+/* Generates a key we can use to lookup this function
+ * without doing a linear search of all the functions
+ * in newProfile.functions.
+ */
+function getFunctionKey(fn, parentId) {
+  // Parent must be the parent from the *merged* profile tree.
+  return `${fn.file}:${fn.name || "-"}:${fn.line}:parent=${parentId}`
+}
+
+function findOrCreateFn(fn, parentId) {
+  const fnKey = getFunctionKey(fn, parentId)
+  let foundFunction = functionsMap[fnKey];
+  if (foundFunction === undefined) {
+    const depth = newProfile.functions[parentId].depth + 1;
+    const newFunction = {
+      self: currentFunctionId++,
+      parent: parentId,
+      location: {
+        file: fn.file,
+        name: fn.name,
+        line: fn.line,
+      },
+      count: 0,
+      depth: depth,
+      children: [],
+    }
+    newProfile.functions[newFunction.self] = newFunction;
+    newProfile.functions[parentId].children.push(newFunction.self);
+    functionsMap[fnKey] = newFunction;
+    foundFunction = newFunction;
+  }
+  foundFunction.count += fn.count;
+  // console.dir(foundFunction.children)
+  return functionsMap[fnKey];
+}
+
+function totalChildCounts(fn) {
+  let total = 0;
+  for (const childId of fn.children) {
+    const child = newProfile.functions[childId];
+    total += totalChildCounts(child);
+    total += child.count;
+  }
+  fn.child_count = total;
+  return fn.child_count;
+}

--- a/src/pfe/portal/scripts/summariseProfile.js
+++ b/src/pfe/portal/scripts/summariseProfile.js
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+// This is a batch script intended to be started and run to completion.
+// We can disable the linter rule for no sync functions.
+/* eslint-disable no-sync */
+"use strict";
+const fs = require('fs-extra');
+
+// Create total entries for each function/method (code location/call site)
+// but lose the call stack information.
+
+let functionTable = {};
+
+let summary = {}
+
+// Allow this file to be loaded by others
+if (require.main === module) {
+  main(process.argv);
+}
+
+function main(argv) {
+
+  functionTable = {};
+  summary = {
+    total_count: 0,
+    functions: [],
+  }
+  const inFile = argv[2];
+  const outFile = argv[3];
+  const profile = fs.readJSONSync(inFile);
+
+  for (const fn of profile.functions) {
+    const key = getFunctionKey(fn);
+    let functionEntry = functionTable[key];
+    if (functionEntry === undefined) {
+      functionEntry = {
+        self_ids: [],
+        location: fn.location,
+        total_self_count: 0,
+        total_child_count: 0,
+      }
+      functionTable[key] = functionEntry;
+      summary.functions.push(functionEntry);
+    }
+    functionEntry.self_ids.push(fn.self);
+    functionEntry.total_self_count += fn.count;
+    functionEntry.total_child_count += fn.child_count;
+
+    // summary_total += fn.count;
+  }
+
+  summary.total_count = profile.totalCount;
+
+  // console.dir(summary, {depth: 5});
+  // console.log(`Summary.total_count = ${summary_total} profile.total_count = ${profile.totalCount}`);
+
+  fs.writeJSONSync(outFile, summary, { spaces: 2 });
+}
+
+/* Generates a key we can use to lookup this function
+ * that doesn't depend on it's position in the tree,
+ * just the source code.
+ */
+function getFunctionKey(fn) {
+  let fnKey = "";
+  // console.dir(fn);
+  for (const key of Object.keys(fn.location)) {
+    fnKey += fn.location[key] + ":";
+  }
+  return fnKey;
+}

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -416,6 +416,23 @@ async function cancelLoad(projectID) {
     return res;
 }
 
+
+async function queryProfileTree(projectID, testRun, jsonPath) {
+    const res = await reqService.chai
+        .post(`/api/v1/projects/${projectID}/profiling/${testRun}/querytree`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send({ path: jsonPath });
+    return res;
+}
+
+async function queryProfileSummary(projectID, testRun, jsonPath) {
+    const res = await reqService.chai
+        .post(`/api/v1/projects/${projectID}/profiling/${testRun}/querysummary`)
+        .set('Cookie', ADMIN_COOKIE)
+        .send({ path: jsonPath });
+    return res;
+}
+
 async function getLogStreams(projectID) {
     const res = await reqService.chai
         .get(`/api/v1/projects/${projectID}/logs`)
@@ -531,6 +548,8 @@ module.exports = {
     awaitProjectBuilding,
     runLoad,
     cancelLoad,
+    queryProfileTree,
+    queryProfileSummary,
     getLogStreams,
     startLogStreams,
     bindProject,

--- a/test/src/API/projects/loadtest.test.js
+++ b/test/src/API/projects/loadtest.test.js
@@ -207,6 +207,36 @@ describe('Load Runner Tests', function() {
             res.status.should.equal(409, res.text); // print res.text if assertion fails
         });
     });
+
+    describe('query profiling data (POST /profiling/:testRunTime/querytree and /profiling/:testRunTime/querysummary)', function() {
+        it('querytree fails with 404 against a project with an invalid id', async function() {
+            this.timeout(testTimeout.short);
+            const res = await projectService.queryProfileTree('invalidID', '20200101', '{"path": "$.total_count"}');
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
+            res.should.satisfyApiSpec;
+        });
+
+        it('querysummary fails with 404 on a project with an invalid id', async function() {
+            this.timeout(testTimeout.short);
+            const res = await projectService.queryProfileSummary('invalidID', '20200101', '{"path": "$.total_count"}');
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
+            res.should.satisfyApiSpec;
+        });
+
+        it('querytree fails with 404 against a testrun with an invalid id', async function() {
+            this.timeout(testTimeout.short);
+            const res = await projectService.queryProfileTree(projectID, 'invalidID', '{"path": "$.total_count"}');
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
+            res.should.satisfyApiSpec;
+        });
+
+        it('querysummary fails with 404 on a testrun with an invalid id', async function() {
+            this.timeout(testTimeout.short);
+            const res = await projectService.queryProfileSummary(projectID, 'invalidID', '{"path": "$.total_count"}');
+            res.status.should.equal(404, res.text); // print res.text if assertion fails
+            res.should.satisfyApiSpec;
+        });
+    });
 });
 
 async function writeToLoadTestConfig(projectID, configOptions) {

--- a/test/src/unit/script/mergeNodeProfiles.test.js
+++ b/test/src/unit/script/mergeNodeProfiles.test.js
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+const chai = require('chai');
+const fs = require('fs-extra');
+const path = require('path');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+const { testTimeout, TEMP_TEST_DIR } = require('../../../config');
+
+const sampleInputFile = path.join(__dirname, 'node-profiling.json');
+const expectedOutputFile = path.join(__dirname, 'node-cw-profile.json');
+const scriptPath = path.join(__dirname, '../../../../src/pfe/portal/scripts/mergeNodeProfiles.js');
+
+chai.should();
+
+describe('mergeNodeProfiles.js', () => {
+    const outputFile  = path.join(TEMP_TEST_DIR, 'cw-profile.json');
+
+    after(async function() {
+        this.timeout(testTimeout.med);
+        await fs.remove(outputFile);
+    });
+
+    it('Merge data for a Node.js profile', async function() {
+        this.timeout(testTimeout.short);
+        const outputFile = path.join(TEMP_TEST_DIR, 'node-merged-output.json');
+        const mergeCommand = `${process.execPath} ${scriptPath} ${sampleInputFile} ${outputFile}`;
+        await exec(mergeCommand);
+
+        const actual = await fs.readJson(outputFile);
+        const expected = await fs.readJson(expectedOutputFile);
+
+        actual.should.deep.equal(expected);
+    });
+
+});

--- a/test/src/unit/script/node-cw-profile-summary.json
+++ b/test/src/unit/script/node-cw-profile-summary.json
@@ -1,0 +1,2567 @@
+{
+  "total_count": 20779,
+  "functions": [
+    {
+      "self_ids": [
+        0
+      ],
+      "location": {
+        "file": "(root)"
+      },
+      "total_self_count": 0,
+      "total_child_count": 20779
+    },
+    {
+      "self_ids": [
+        1
+      ],
+      "location": {
+        "file": "",
+        "name": "(root)",
+        "line": 0
+      },
+      "total_self_count": 0,
+      "total_child_count": 20779
+    },
+    {
+      "self_ids": [
+        2
+      ],
+      "location": {
+        "file": "",
+        "name": "(program)",
+        "line": 0
+      },
+      "total_self_count": 20725,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        3
+      ],
+      "location": {
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194
+      },
+      "total_self_count": 1,
+      "total_child_count": 16
+    },
+    {
+      "self_ids": [
+        4
+      ],
+      "location": {
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130
+      },
+      "total_self_count": 0,
+      "total_child_count": 15
+    },
+    {
+      "self_ids": [
+        5,
+        126,
+        132,
+        140,
+        224,
+        287
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "total_self_count": 0,
+      "total_child_count": 27
+    },
+    {
+      "self_ids": [
+        6,
+        227
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        7
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "onCorkedFinish",
+        "line": 632
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        8
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "onEnd",
+        "line": 117
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        9,
+        22,
+        39,
+        52,
+        165,
+        188,
+        254,
+        270,
+        297,
+        305
+      ],
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "total_self_count": 1,
+      "total_child_count": 25
+    },
+    {
+      "self_ids": [
+        10,
+        23,
+        40,
+        166
+      ],
+      "location": {
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104
+      },
+      "total_self_count": 0,
+      "total_child_count": 12
+    },
+    {
+      "self_ids": [
+        11,
+        202
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        12,
+        203
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        13,
+        204
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        14,
+        205
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        15,
+        206
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        16,
+        207
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        17,
+        208
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        18,
+        231
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        19,
+        232
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        20,
+        233
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478
+      },
+      "total_self_count": 1,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        21
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "endReadableNT",
+        "line": 1059
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        24,
+        167
+      ],
+      "location": {
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        25
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "onend",
+        "line": 593
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        26
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 100
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        27
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 52
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        28
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "HttpProbe.metricsEnd",
+        "line": 102
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        29
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/index.js",
+        "name": "module.exports.emit",
+        "line": 279
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        30
+      ],
+      "location": {
+        "file": "",
+        "name": "getObjectHistogram",
+        "line": 0
+      },
+      "total_self_count": 3,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        31
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "",
+        "line": 1985
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        32,
+        168
+      ],
+      "location": {
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4
+      },
+      "total_self_count": 1,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        33
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream._destroy",
+        "line": 2070
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        34
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream.close",
+        "line": 2077
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        35,
+        122
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 576
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        36,
+        244,
+        280
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391
+      },
+      "total_self_count": 1,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        37
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "union",
+        "line": 60
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        38
+      ],
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "onFinish",
+        "line": 719
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        41
+      ],
+      "location": {
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "onResFinished",
+        "line": 58
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        42
+      ],
+      "location": {
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "LOG",
+        "line": 30
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        43
+      ],
+      "location": {
+        "file": "/app/node_modules/pino/lib/proto.js",
+        "name": "write",
+        "line": 122
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        44
+      ],
+      "location": {
+        "file": "/app/node_modules/sonic-boom/index.js",
+        "name": "SonicBoom.write",
+        "line": 160
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        45
+      ],
+      "location": {
+        "file": "/app/node_modules/sonic-boom/index.js",
+        "name": "actualWrite",
+        "line": 272
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        46
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "fs.writeSync",
+        "line": 727
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        47
+      ],
+      "location": {
+        "file": "",
+        "name": "writeString",
+        "line": 0
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        48
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "listOnTimeout",
+        "line": 231
+      },
+      "total_self_count": 3,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        49
+      ],
+      "location": {
+        "file": "internal/linkedlist.js",
+        "name": "remove",
+        "line": 15
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        50
+      ],
+      "location": {
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        51
+      ],
+      "location": {
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        53
+      ],
+      "location": {
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        54
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        55
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        56,
+        85
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38
+      },
+      "total_self_count": 0,
+      "total_child_count": 10
+    },
+    {
+      "self_ids": [
+        57,
+        86
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158
+      },
+      "total_self_count": 0,
+      "total_child_count": 10
+    },
+    {
+      "self_ids": [
+        58,
+        87,
+        112,
+        148
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136
+      },
+      "total_self_count": 0,
+      "total_child_count": 14
+    },
+    {
+      "self_ids": [
+        59,
+        65,
+        71,
+        77,
+        88,
+        94,
+        100,
+        106,
+        113,
+        142,
+        149,
+        257
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "total_self_count": 0,
+      "total_child_count": 42
+    },
+    {
+      "self_ids": [
+        60,
+        66,
+        72,
+        78,
+        89,
+        95,
+        101,
+        107,
+        114,
+        143,
+        150
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "total_self_count": 1,
+      "total_child_count": 40
+    },
+    {
+      "self_ids": [
+        61,
+        67,
+        73,
+        79,
+        90,
+        96,
+        102,
+        108,
+        115,
+        144,
+        151
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "total_self_count": 0,
+      "total_child_count": 40
+    },
+    {
+      "self_ids": [
+        62,
+        68,
+        74,
+        80,
+        91,
+        97,
+        103,
+        109,
+        116,
+        145
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "total_self_count": 0,
+      "total_child_count": 39
+    },
+    {
+      "self_ids": [
+        63,
+        69,
+        75,
+        81,
+        92,
+        98,
+        104,
+        110,
+        117,
+        146,
+        152,
+        155
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "total_self_count": 0,
+      "total_child_count": 41
+    },
+    {
+      "self_ids": [
+        64,
+        93
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39
+      },
+      "total_self_count": 0,
+      "total_child_count": 10
+    },
+    {
+      "self_ids": [
+        70,
+        99
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29
+      },
+      "total_self_count": 1,
+      "total_child_count": 8
+    },
+    {
+      "self_ids": [
+        76
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "defaultMiddleware",
+        "line": 56
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        82
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 217
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        83
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 25
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        84
+      ],
+      "location": {
+        "file": "/app/node_modules/ibmapm-embed/appmetrics-zipkin/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 26
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        105
+      ],
+      "location": {
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "loggingMiddleware",
+        "line": 83
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        111,
+        147
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "router",
+        "line": 46
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        118
+      ],
+      "location": {
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "serveStatic",
+        "line": 72
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        119
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "pipe",
+        "line": 510
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        120
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "sendIndex",
+        "line": 757
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        121
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 761
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        123
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "fs.stat",
+        "line": 923
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        124
+      ],
+      "location": {
+        "file": "",
+        "name": "stat",
+        "line": 0
+      },
+      "total_self_count": 3,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        125
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "",
+        "line": 151
+      },
+      "total_self_count": 0,
+      "total_child_count": 7
+    },
+    {
+      "self_ids": [
+        127
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        128
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606
+      },
+      "total_self_count": 0,
+      "total_child_count": 6
+    },
+    {
+      "self_ids": [
+        129
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "stream",
+        "line": 789
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        130
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.pipe",
+        "line": 554
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        131
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "pipeOnDrain",
+        "line": 699
+      },
+      "total_self_count": 2,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        133
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "onconnection",
+        "line": 1539
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        134
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "Socket",
+        "line": 189
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        135
+      ],
+      "location": {
+        "file": "_stream_duplex.js",
+        "name": "Duplex",
+        "line": 47
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        136
+      ],
+      "location": {
+        "file": "events.js",
+        "name": "once",
+        "line": 338
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        137
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "processImmediate",
+        "line": 720
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        138
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "tryOnImmediate",
+        "line": 763
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        139
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "runCallback",
+        "line": 802
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        141
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 629
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        153
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/route.js",
+        "name": "dispatch",
+        "line": 98
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        154
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/router/route.js",
+        "name": "next",
+        "line": 114
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        156
+      ],
+      "location": {
+        "file": "/app/server/routers/health.js",
+        "name": "",
+        "line": 6
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        157
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/response.js",
+        "name": "json",
+        "line": 239
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        158
+      ],
+      "location": {
+        "file": "/app/node_modules/express/lib/response.js",
+        "name": "header",
+        "line": 754
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        159,
+        283
+      ],
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "setHeader",
+        "line": 497
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        160,
+        284
+      ],
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "validateHeader",
+        "line": 485
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        161,
+        285
+      ],
+      "location": {
+        "file": "_http_common.js",
+        "name": "checkIsHttpToken",
+        "line": 281
+      },
+      "total_self_count": 2,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        162
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "afterShutdown",
+        "line": 321
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        163
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "stream._final",
+        "line": 584
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        164
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "finishMaybe",
+        "line": 607
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        169
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "Socket._destroy",
+        "line": 541
+      },
+      "total_self_count": 1,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        170
+      ],
+      "location": {
+        "file": "",
+        "name": "close",
+        "line": 0
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        171
+      ],
+      "location": {
+        "file": "",
+        "name": "(garbage collector)",
+        "line": 0
+      },
+      "total_self_count": 4,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        172
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "resume_",
+        "line": 819
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        173
+      ],
+      "location": {
+        "file": "_http_incoming.js",
+        "name": "read",
+        "line": 93
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        174,
+        247,
+        292
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365
+      },
+      "total_self_count": 1,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        175
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "endReadable",
+        "line": 1045
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        176,
+        242
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 626
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        177,
+        243,
+        259
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        178
+      ],
+      "location": {
+        "file": "internal/process/next_tick.js",
+        "name": "nextTick",
+        "line": 246
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        179,
+        218,
+        234,
+        310
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388
+      },
+      "total_self_count": 0,
+      "total_child_count": 5
+    },
+    {
+      "self_ids": [
+        180,
+        235
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "Socket._writev",
+        "line": 781
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        181,
+        236
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "Socket._writeGeneric",
+        "line": 715
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        182,
+        237
+      ],
+      "location": {
+        "file": "",
+        "name": "writev",
+        "line": 0
+      },
+      "total_self_count": 3,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        183
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "events",
+        "line": 238
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        184
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "raiseEvent",
+        "line": 32
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        185
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "formatProfiling",
+        "line": 180
+      },
+      "total_self_count": 0,
+      "total_child_count": 4
+    },
+    {
+      "self_ids": [
+        186
+      ],
+      "location": {
+        "file": "",
+        "name": "forEach",
+        "line": 0
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        187
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "",
+        "line": 189
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        189,
+        255,
+        271,
+        306
+      ],
+      "location": {
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114
+      },
+      "total_self_count": 0,
+      "total_child_count": 7
+    },
+    {
+      "self_ids": [
+        190
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 277
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        191
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "Server.(anonymous function)",
+        "line": 504
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        192
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 79
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        193
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/namespace.js",
+        "name": "Namespace.emit",
+        "line": 211
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        194
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "Adapter.broadcast",
+        "line": 122
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        195
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "Encoder.encode",
+        "line": 128
+      },
+      "total_self_count": 0,
+      "total_child_count": 3
+    },
+    {
+      "self_ids": [
+        196
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "",
+        "line": 136
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        197
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/socket.js",
+        "name": "Socket.packet",
+        "line": 220
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        198
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/client.js",
+        "name": "Client.packet",
+        "line": 162
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        199
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/client.js",
+        "name": "writeToEngine",
+        "line": 167
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        200
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.send.Socket.write",
+        "line": 366
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        201
+      ],
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.sendPacket",
+        "line": 380
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        209
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "compress",
+        "line": 319
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        210
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/limiter.js",
+        "name": "add",
+        "line": 32
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        211
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/limiter.js",
+        "name": "",
+        "line": 42
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        212
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "zlibLimiter.add",
+        "line": 320
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        213
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_compress",
+        "line": 397
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        214,
+        215
+      ],
+      "location": {
+        "file": "zlib.js",
+        "name": "DeflateRaw",
+        "line": 565
+      },
+      "total_self_count": 1,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        216,
+        308
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "Writable.write",
+        "line": 264
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        217,
+        309
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "writeOrBuffer",
+        "line": 348
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        219
+      ],
+      "location": {
+        "file": "_stream_transform.js",
+        "name": "Transform._write",
+        "line": 164
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        220
+      ],
+      "location": {
+        "file": "_stream_transform.js",
+        "name": "Transform._read",
+        "line": 181
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        221
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 582
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        222
+      ],
+      "location": {
+        "file": "zlib.js",
+        "name": "_transform",
+        "line": 360
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        223
+      ],
+      "location": {
+        "file": "zlib.js",
+        "name": "callback",
+        "line": 447
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        225
+      ],
+      "location": {
+        "file": "_stream_transform.js",
+        "name": "afterTransform",
+        "line": 73
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        226
+      ],
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "onwrite",
+        "line": 431
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        228
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_deflate.flush",
+        "line": 428
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        229
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_compress",
+        "line": 321
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        230
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "perMessageDeflate.compress",
+        "line": 322
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        238
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "unrefdHandle",
+        "line": 608
+      },
+      "total_self_count": 2,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        239
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.on",
+        "line": 771
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        240
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.resume",
+        "line": 802
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        241
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "resume",
+        "line": 812
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        245,
+        281
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "asyncWrap",
+        "line": 137
+      },
+      "total_self_count": 2,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        246
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "flow",
+        "line": 843
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        248
+      ],
+      "location": {
+        "file": "/app/node_modules/on-finished/index.js",
+        "name": "onFinished",
+        "line": 45
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        249
+      ],
+      "location": {
+        "file": "/app/node_modules/on-finished/index.js",
+        "name": "attachListener",
+        "line": 140
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        250
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "onstat",
+        "line": 721
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        251
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 732
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        252
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "onStatError",
+        "line": 416
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        253
+      ],
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "error",
+        "line": 267
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        256
+      ],
+      "location": {
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "error",
+        "line": 115
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        258
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 644
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        260
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "setImmediate",
+        "line": 842
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        261
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "createImmediate",
+        "line": 877
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        262
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "Immediate",
+        "line": 824
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        263
+      ],
+      "location": {
+        "file": "domain.js",
+        "name": "get",
+        "line": 43
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        264
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "encodeAsString",
+        "line": 147
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        265
+      ],
+      "location": {
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "tryStringify",
+        "line": 182
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        266
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 42
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        267
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/probe.js",
+        "name": "Probe.metricsStart",
+        "line": 62
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        268
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/timer.js",
+        "name": "exports.start",
+        "line": 33
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        269
+      ],
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/timer.js",
+        "name": "Timer",
+        "line": 18
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        272
+      ],
+      "location": {
+        "file": "_http_server.js",
+        "name": "connectionListener",
+        "line": 312
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        273
+      ],
+      "location": {
+        "file": "internal/async_hooks.js",
+        "name": "defaultTriggerAsyncIdScope",
+        "line": 273
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        274
+      ],
+      "location": {
+        "file": "_http_server.js",
+        "name": "connectionListenerInternal",
+        "line": 318
+      },
+      "total_self_count": 1,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        275
+      ],
+      "location": {
+        "file": "internal/http.js",
+        "name": "nowDate",
+        "line": 8
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        276
+      ],
+      "location": {
+        "file": "internal/http.js",
+        "name": "cache",
+        "line": 18
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        277
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "exports._unrefActive",
+        "line": 157
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        278
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "insert",
+        "line": 167
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        279
+      ],
+      "location": {
+        "file": "timers.js",
+        "name": "createTimersList",
+        "line": 196
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        282
+      ],
+      "location": {
+        "file": "internal/process/promises.js",
+        "name": "emitPendingUnhandledRejections",
+        "line": 100
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        286
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "wrapper",
+        "line": 656
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        288
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "fs.read",
+        "line": 2046
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        289,
+        302
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.push",
+        "line": 191
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        290,
+        303
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "readableAddChunk",
+        "line": 216
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        291,
+        304
+      ],
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "addChunk",
+        "line": 261
+      },
+      "total_self_count": 0,
+      "total_child_count": 2
+    },
+    {
+      "self_ids": [
+        293
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream._read",
+        "line": 2013
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        294
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 600
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        295
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "fs.read",
+        "line": 649
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        296
+      ],
+      "location": {
+        "file": "",
+        "name": "read",
+        "line": 0
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        298
+      ],
+      "location": {
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "asJson",
+        "line": 73
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        299
+      ],
+      "location": {
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "stringify",
+        "line": 358
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        300
+      ],
+      "location": {
+        "file": "",
+        "name": "now",
+        "line": 0
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        301
+      ],
+      "location": {
+        "file": "net.js",
+        "name": "onread",
+        "line": 583
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        307
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "socketOnData",
+        "line": 875
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        311
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "_write",
+        "line": 72
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        312
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "startLoop",
+        "line": 123
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        313
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "getData",
+        "line": 336
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        314
+      ],
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "dataMessage",
+        "line": 406
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        315
+      ],
+      "location": {
+        "file": "buffer.js",
+        "name": "Buffer.toString",
+        "line": 609
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    },
+    {
+      "self_ids": [
+        316
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "fs.createReadStream",
+        "line": 1930
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        317
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream",
+        "line": 1937
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        318
+      ],
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream.open",
+        "line": 1994
+      },
+      "total_self_count": 0,
+      "total_child_count": 1
+    },
+    {
+      "self_ids": [
+        319
+      ],
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 588
+      },
+      "total_self_count": 1,
+      "total_child_count": 0
+    }
+  ]
+}

--- a/test/src/unit/script/node-cw-profile.json
+++ b/test/src/unit/script/node-cw-profile.json
@@ -1,0 +1,4766 @@
+{
+  "totalCount": 20779,
+  "functions": [
+    {
+      "self": 0,
+      "location": {
+        "file": "(root)"
+      },
+      "depth": 0,
+      "children": [
+        1
+      ],
+      "count": 0,
+      "child_count": 20779
+    },
+    {
+      "self": 1,
+      "parent": 0,
+      "location": {
+        "file": "",
+        "name": "(root)",
+        "line": 0
+      },
+      "count": 0,
+      "depth": 1,
+      "children": [
+        2,
+        3,
+        48,
+        50,
+        125,
+        132,
+        137,
+        162,
+        171,
+        183,
+        223,
+        238,
+        286
+      ],
+      "child_count": 20779
+    },
+    {
+      "self": 2,
+      "parent": 1,
+      "location": {
+        "file": "",
+        "name": "(program)",
+        "line": 0
+      },
+      "count": 20725,
+      "depth": 2,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 3,
+      "parent": 1,
+      "location": {
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194
+      },
+      "count": 1,
+      "depth": 2,
+      "children": [
+        4,
+        282
+      ],
+      "child_count": 16
+    },
+    {
+      "self": 4,
+      "parent": 3,
+      "location": {
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        5,
+        38
+      ],
+      "child_count": 15
+    },
+    {
+      "self": 5,
+      "parent": 4,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        6,
+        21,
+        37,
+        172
+      ],
+      "child_count": 13
+    },
+    {
+      "self": 6,
+      "parent": 5,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        7
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 7,
+      "parent": 6,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "onCorkedFinish",
+        "line": 632
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        8
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 8,
+      "parent": 7,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "onEnd",
+        "line": 117
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        9
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 9,
+      "parent": 8,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        10
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 10,
+      "parent": 9,
+      "location": {
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        11
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 11,
+      "parent": 10,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        12
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 12,
+      "parent": 11,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        13
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 13,
+      "parent": 12,
+      "location": {
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        14
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 14,
+      "parent": 13,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        15
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 15,
+      "parent": 14,
+      "location": {
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        16
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 16,
+      "parent": 15,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        17
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 17,
+      "parent": 16,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313
+      },
+      "count": 0,
+      "depth": 16,
+      "children": [
+        18
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 18,
+      "parent": 17,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378
+      },
+      "count": 0,
+      "depth": 17,
+      "children": [
+        19
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 19,
+      "parent": 18,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302
+      },
+      "count": 0,
+      "depth": 18,
+      "children": [
+        20
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 20,
+      "parent": 19,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478
+      },
+      "count": 1,
+      "depth": 19,
+      "children": [
+        179
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 21,
+      "parent": 5,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "endReadableNT",
+        "line": 1059
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        22
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 22,
+      "parent": 21,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        23
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 23,
+      "parent": 22,
+      "location": {
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        24,
+        31
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 24,
+      "parent": 23,
+      "location": {
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        25
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 25,
+      "parent": 24,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "onend",
+        "line": 593
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        26
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 26,
+      "parent": 25,
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 100
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        27
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 27,
+      "parent": 26,
+      "location": {
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 52
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        28
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 28,
+      "parent": 27,
+      "location": {
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "HttpProbe.metricsEnd",
+        "line": 102
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        29
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 29,
+      "parent": 28,
+      "location": {
+        "file": "/app/node_modules/appmetrics/index.js",
+        "name": "module.exports.emit",
+        "line": 279
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        30
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 30,
+      "parent": 29,
+      "location": {
+        "file": "",
+        "name": "getObjectHistogram",
+        "line": 0
+      },
+      "count": 3,
+      "depth": 14,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 31,
+      "parent": 23,
+      "location": {
+        "file": "fs.js",
+        "name": "",
+        "line": 1985
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        32
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 32,
+      "parent": 31,
+      "location": {
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4
+      },
+      "count": 1,
+      "depth": 9,
+      "children": [
+        33
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 33,
+      "parent": 32,
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream._destroy",
+        "line": 2070
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        34
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 34,
+      "parent": 33,
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream.close",
+        "line": 2077
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        35
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 35,
+      "parent": 34,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 576
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        36
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 36,
+      "parent": 35,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391
+      },
+      "count": 1,
+      "depth": 13,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 37,
+      "parent": 5,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "union",
+        "line": 60
+      },
+      "count": 1,
+      "depth": 5,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 38,
+      "parent": 4,
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "onFinish",
+        "line": 719
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        39
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 39,
+      "parent": 38,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        40
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 40,
+      "parent": 39,
+      "location": {
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        41
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 41,
+      "parent": 40,
+      "location": {
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "onResFinished",
+        "line": 58
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        42
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 42,
+      "parent": 41,
+      "location": {
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "LOG",
+        "line": 30
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        43
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 43,
+      "parent": 42,
+      "location": {
+        "file": "/app/node_modules/pino/lib/proto.js",
+        "name": "write",
+        "line": 122
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        44,
+        298
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 44,
+      "parent": 43,
+      "location": {
+        "file": "/app/node_modules/sonic-boom/index.js",
+        "name": "SonicBoom.write",
+        "line": 160
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        45
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 45,
+      "parent": 44,
+      "location": {
+        "file": "/app/node_modules/sonic-boom/index.js",
+        "name": "actualWrite",
+        "line": 272
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        46
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 46,
+      "parent": 45,
+      "location": {
+        "file": "fs.js",
+        "name": "fs.writeSync",
+        "line": 727
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        47
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 47,
+      "parent": 46,
+      "location": {
+        "file": "",
+        "name": "writeString",
+        "line": 0
+      },
+      "count": 1,
+      "depth": 13,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 48,
+      "parent": 1,
+      "location": {
+        "file": "timers.js",
+        "name": "listOnTimeout",
+        "line": 231
+      },
+      "count": 3,
+      "depth": 2,
+      "children": [
+        49,
+        300
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 49,
+      "parent": 48,
+      "location": {
+        "file": "internal/linkedlist.js",
+        "name": "remove",
+        "line": 15
+      },
+      "count": 1,
+      "depth": 3,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 50,
+      "parent": 1,
+      "location": {
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        51
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 51,
+      "parent": 50,
+      "location": {
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        52
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 52,
+      "parent": 51,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        53
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 53,
+      "parent": 52,
+      "location": {
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        54
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 54,
+      "parent": 53,
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        55
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 55,
+      "parent": 54,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        56
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 56,
+      "parent": 55,
+      "location": {
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        57
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 57,
+      "parent": 56,
+      "location": {
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        58
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 58,
+      "parent": 57,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        59
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 59,
+      "parent": 58,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        60
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 60,
+      "parent": 59,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        61
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 61,
+      "parent": 60,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        62
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 62,
+      "parent": 61,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        63
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 63,
+      "parent": 62,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        64
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 64,
+      "parent": 63,
+      "location": {
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39
+      },
+      "count": 0,
+      "depth": 16,
+      "children": [
+        65
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 65,
+      "parent": 64,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 17,
+      "children": [
+        66
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 66,
+      "parent": 65,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 18,
+      "children": [
+        67
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 67,
+      "parent": 66,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 19,
+      "children": [
+        68
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 68,
+      "parent": 67,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 20,
+      "children": [
+        69
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 69,
+      "parent": 68,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 21,
+      "children": [
+        70
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 70,
+      "parent": 69,
+      "location": {
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29
+      },
+      "count": 1,
+      "depth": 22,
+      "children": [
+        71
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 71,
+      "parent": 70,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 23,
+      "children": [
+        72
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 72,
+      "parent": 71,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 24,
+      "children": [
+        73
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 73,
+      "parent": 72,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 25,
+      "children": [
+        74
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 74,
+      "parent": 73,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 26,
+      "children": [
+        75
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 75,
+      "parent": 74,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 27,
+      "children": [
+        76
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 76,
+      "parent": 75,
+      "location": {
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "defaultMiddleware",
+        "line": 56
+      },
+      "count": 0,
+      "depth": 28,
+      "children": [
+        77
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 77,
+      "parent": 76,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 29,
+      "children": [
+        78
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 78,
+      "parent": 77,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 30,
+      "children": [
+        79
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 79,
+      "parent": 78,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 31,
+      "children": [
+        80
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 80,
+      "parent": 79,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 32,
+      "children": [
+        81
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 81,
+      "parent": 80,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 33,
+      "children": [
+        82
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 82,
+      "parent": 81,
+      "location": {
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 217
+      },
+      "count": 0,
+      "depth": 34,
+      "children": [
+        83
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 83,
+      "parent": 82,
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 25
+      },
+      "count": 0,
+      "depth": 35,
+      "children": [
+        84,
+        266
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 84,
+      "parent": 83,
+      "location": {
+        "file": "/app/node_modules/ibmapm-embed/appmetrics-zipkin/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 26
+      },
+      "count": 0,
+      "depth": 36,
+      "children": [
+        85
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 85,
+      "parent": 84,
+      "location": {
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38
+      },
+      "count": 0,
+      "depth": 37,
+      "children": [
+        86
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 86,
+      "parent": 85,
+      "location": {
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158
+      },
+      "count": 0,
+      "depth": 38,
+      "children": [
+        87
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 87,
+      "parent": 86,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136
+      },
+      "count": 0,
+      "depth": 39,
+      "children": [
+        88
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 88,
+      "parent": 87,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 40,
+      "children": [
+        89
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 89,
+      "parent": 88,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 41,
+      "children": [
+        90
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 90,
+      "parent": 89,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 42,
+      "children": [
+        91
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 91,
+      "parent": 90,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 43,
+      "children": [
+        92
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 92,
+      "parent": 91,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 44,
+      "children": [
+        93
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 93,
+      "parent": 92,
+      "location": {
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39
+      },
+      "count": 0,
+      "depth": 45,
+      "children": [
+        94
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 94,
+      "parent": 93,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 46,
+      "children": [
+        95
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 95,
+      "parent": 94,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 1,
+      "depth": 47,
+      "children": [
+        96
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 96,
+      "parent": 95,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 48,
+      "children": [
+        97
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 97,
+      "parent": 96,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 49,
+      "children": [
+        98
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 98,
+      "parent": 97,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 50,
+      "children": [
+        99
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 99,
+      "parent": 98,
+      "location": {
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29
+      },
+      "count": 0,
+      "depth": 51,
+      "children": [
+        100
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 100,
+      "parent": 99,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 52,
+      "children": [
+        101
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 101,
+      "parent": 100,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 53,
+      "children": [
+        102
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 102,
+      "parent": 101,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 54,
+      "children": [
+        103
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 103,
+      "parent": 102,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 55,
+      "children": [
+        104
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 104,
+      "parent": 103,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 56,
+      "children": [
+        105
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 105,
+      "parent": 104,
+      "location": {
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "loggingMiddleware",
+        "line": 83
+      },
+      "count": 0,
+      "depth": 57,
+      "children": [
+        106
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 106,
+      "parent": 105,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 58,
+      "children": [
+        107
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 107,
+      "parent": 106,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 59,
+      "children": [
+        108
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 108,
+      "parent": 107,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 60,
+      "children": [
+        109
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 109,
+      "parent": 108,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 61,
+      "children": [
+        110
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 110,
+      "parent": 109,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 62,
+      "children": [
+        111
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 111,
+      "parent": 110,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "router",
+        "line": 46
+      },
+      "count": 0,
+      "depth": 63,
+      "children": [
+        112
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 112,
+      "parent": 111,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136
+      },
+      "count": 0,
+      "depth": 64,
+      "children": [
+        113
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 113,
+      "parent": 112,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 65,
+      "children": [
+        114
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 114,
+      "parent": 113,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 66,
+      "children": [
+        115
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 115,
+      "parent": 114,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 67,
+      "children": [
+        116
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 116,
+      "parent": 115,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 68,
+      "children": [
+        117
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 117,
+      "parent": 116,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 69,
+      "children": [
+        118
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 118,
+      "parent": 117,
+      "location": {
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "serveStatic",
+        "line": 72
+      },
+      "count": 0,
+      "depth": 70,
+      "children": [
+        119
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 119,
+      "parent": 118,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "pipe",
+        "line": 510
+      },
+      "count": 0,
+      "depth": 71,
+      "children": [
+        120
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 120,
+      "parent": 119,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "sendIndex",
+        "line": 757
+      },
+      "count": 0,
+      "depth": 72,
+      "children": [
+        121
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 121,
+      "parent": 120,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 761
+      },
+      "count": 0,
+      "depth": 73,
+      "children": [
+        122
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 122,
+      "parent": 121,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 576
+      },
+      "count": 0,
+      "depth": 74,
+      "children": [
+        123
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 123,
+      "parent": 122,
+      "location": {
+        "file": "fs.js",
+        "name": "fs.stat",
+        "line": 923
+      },
+      "count": 0,
+      "depth": 75,
+      "children": [
+        124
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 124,
+      "parent": 123,
+      "location": {
+        "file": "",
+        "name": "stat",
+        "line": 0
+      },
+      "count": 3,
+      "depth": 76,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 125,
+      "parent": 1,
+      "location": {
+        "file": "fs.js",
+        "name": "",
+        "line": 151
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        126
+      ],
+      "child_count": 7
+    },
+    {
+      "self": 126,
+      "parent": 125,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        127,
+        250
+      ],
+      "child_count": 7
+    },
+    {
+      "self": 127,
+      "parent": 126,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        128
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 128,
+      "parent": 127,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        129,
+        283
+      ],
+      "child_count": 6
+    },
+    {
+      "self": 129,
+      "parent": 128,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "stream",
+        "line": 789
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        130,
+        248,
+        316
+      ],
+      "child_count": 5
+    },
+    {
+      "self": 130,
+      "parent": 129,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.pipe",
+        "line": 554
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        131,
+        239
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 131,
+      "parent": 130,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "pipeOnDrain",
+        "line": 699
+      },
+      "count": 2,
+      "depth": 8,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 132,
+      "parent": 1,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        133,
+        301
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 133,
+      "parent": 132,
+      "location": {
+        "file": "net.js",
+        "name": "onconnection",
+        "line": 1539
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        134,
+        270
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 134,
+      "parent": 133,
+      "location": {
+        "file": "net.js",
+        "name": "Socket",
+        "line": 189
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        135
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 135,
+      "parent": 134,
+      "location": {
+        "file": "_stream_duplex.js",
+        "name": "Duplex",
+        "line": 47
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        136
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 136,
+      "parent": 135,
+      "location": {
+        "file": "events.js",
+        "name": "once",
+        "line": 338
+      },
+      "count": 1,
+      "depth": 6,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 137,
+      "parent": 1,
+      "location": {
+        "file": "timers.js",
+        "name": "processImmediate",
+        "line": 720
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        138
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 138,
+      "parent": 137,
+      "location": {
+        "file": "timers.js",
+        "name": "tryOnImmediate",
+        "line": 763
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        139
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 139,
+      "parent": 138,
+      "location": {
+        "file": "timers.js",
+        "name": "runCallback",
+        "line": 802
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        140
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 140,
+      "parent": 139,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        141
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 141,
+      "parent": 140,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 629
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        142
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 142,
+      "parent": 141,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        143
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 143,
+      "parent": 142,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        144
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 144,
+      "parent": 143,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        145
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 145,
+      "parent": 144,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        146
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 146,
+      "parent": 145,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        147
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 147,
+      "parent": 146,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "router",
+        "line": 46
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        148
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 148,
+      "parent": 147,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        149
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 149,
+      "parent": 148,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        150
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 150,
+      "parent": 149,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        151
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 151,
+      "parent": 150,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275
+      },
+      "count": 0,
+      "depth": 16,
+      "children": [
+        152
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 152,
+      "parent": 151,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 17,
+      "children": [
+        153
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 153,
+      "parent": 152,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/route.js",
+        "name": "dispatch",
+        "line": 98
+      },
+      "count": 0,
+      "depth": 18,
+      "children": [
+        154
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 154,
+      "parent": 153,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/route.js",
+        "name": "next",
+        "line": 114
+      },
+      "count": 0,
+      "depth": 19,
+      "children": [
+        155
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 155,
+      "parent": 154,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86
+      },
+      "count": 0,
+      "depth": 20,
+      "children": [
+        156
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 156,
+      "parent": 155,
+      "location": {
+        "file": "/app/server/routers/health.js",
+        "name": "",
+        "line": 6
+      },
+      "count": 0,
+      "depth": 21,
+      "children": [
+        157
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 157,
+      "parent": 156,
+      "location": {
+        "file": "/app/node_modules/express/lib/response.js",
+        "name": "json",
+        "line": 239
+      },
+      "count": 0,
+      "depth": 22,
+      "children": [
+        158
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 158,
+      "parent": 157,
+      "location": {
+        "file": "/app/node_modules/express/lib/response.js",
+        "name": "header",
+        "line": 754
+      },
+      "count": 0,
+      "depth": 23,
+      "children": [
+        159
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 159,
+      "parent": 158,
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "setHeader",
+        "line": 497
+      },
+      "count": 0,
+      "depth": 24,
+      "children": [
+        160
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 160,
+      "parent": 159,
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "validateHeader",
+        "line": 485
+      },
+      "count": 0,
+      "depth": 25,
+      "children": [
+        161
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 161,
+      "parent": 160,
+      "location": {
+        "file": "_http_common.js",
+        "name": "checkIsHttpToken",
+        "line": 281
+      },
+      "count": 1,
+      "depth": 26,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 162,
+      "parent": 1,
+      "location": {
+        "file": "net.js",
+        "name": "afterShutdown",
+        "line": 321
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        163
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 163,
+      "parent": 162,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "stream._final",
+        "line": 584
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        164
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 164,
+      "parent": 163,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "finishMaybe",
+        "line": 607
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        165
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 165,
+      "parent": 164,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        166
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 166,
+      "parent": 165,
+      "location": {
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        167
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 167,
+      "parent": 166,
+      "location": {
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        168
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 168,
+      "parent": 167,
+      "location": {
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        169
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 169,
+      "parent": 168,
+      "location": {
+        "file": "net.js",
+        "name": "Socket._destroy",
+        "line": 541
+      },
+      "count": 1,
+      "depth": 9,
+      "children": [
+        170
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 170,
+      "parent": 169,
+      "location": {
+        "file": "",
+        "name": "close",
+        "line": 0
+      },
+      "count": 1,
+      "depth": 10,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 171,
+      "parent": 1,
+      "location": {
+        "file": "",
+        "name": "(garbage collector)",
+        "line": 0
+      },
+      "count": 4,
+      "depth": 2,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 172,
+      "parent": 5,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "resume_",
+        "line": 819
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        173,
+        246,
+        297
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 173,
+      "parent": 172,
+      "location": {
+        "file": "_http_incoming.js",
+        "name": "read",
+        "line": 93
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        174
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 174,
+      "parent": 173,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        175
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 175,
+      "parent": 174,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "endReadable",
+        "line": 1045
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        176
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 176,
+      "parent": 175,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 626
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        177
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 177,
+      "parent": 176,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        178,
+        280
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 178,
+      "parent": 177,
+      "location": {
+        "file": "internal/process/next_tick.js",
+        "name": "nextTick",
+        "line": 246
+      },
+      "count": 1,
+      "depth": 11,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 179,
+      "parent": 20,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388
+      },
+      "count": 0,
+      "depth": 20,
+      "children": [
+        180
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 180,
+      "parent": 179,
+      "location": {
+        "file": "net.js",
+        "name": "Socket._writev",
+        "line": 781
+      },
+      "count": 0,
+      "depth": 21,
+      "children": [
+        181
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 181,
+      "parent": 180,
+      "location": {
+        "file": "net.js",
+        "name": "Socket._writeGeneric",
+        "line": 715
+      },
+      "count": 0,
+      "depth": 22,
+      "children": [
+        182
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 182,
+      "parent": 181,
+      "location": {
+        "file": "",
+        "name": "writev",
+        "line": 0
+      },
+      "count": 2,
+      "depth": 23,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 183,
+      "parent": 1,
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "events",
+        "line": 238
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        184
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 184,
+      "parent": 183,
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "raiseEvent",
+        "line": 32
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        185
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 185,
+      "parent": 184,
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "formatProfiling",
+        "line": 180
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        186,
+        188
+      ],
+      "child_count": 4
+    },
+    {
+      "self": 186,
+      "parent": 185,
+      "location": {
+        "file": "",
+        "name": "forEach",
+        "line": 0
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        187
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 187,
+      "parent": 186,
+      "location": {
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "",
+        "line": 189
+      },
+      "count": 1,
+      "depth": 6,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 188,
+      "parent": 185,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        189
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 189,
+      "parent": 188,
+      "location": {
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        190
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 190,
+      "parent": 189,
+      "location": {
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 277
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        191
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 191,
+      "parent": 190,
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "Server.(anonymous function)",
+        "line": 504
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        192
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 192,
+      "parent": 191,
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 79
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        193
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 193,
+      "parent": 192,
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/namespace.js",
+        "name": "Namespace.emit",
+        "line": 211
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        194
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 194,
+      "parent": 193,
+      "location": {
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "Adapter.broadcast",
+        "line": 122
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        195
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 195,
+      "parent": 194,
+      "location": {
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "Encoder.encode",
+        "line": 128
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        196,
+        264
+      ],
+      "child_count": 3
+    },
+    {
+      "self": 196,
+      "parent": 195,
+      "location": {
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "",
+        "line": 136
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        197
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 197,
+      "parent": 196,
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/socket.js",
+        "name": "Socket.packet",
+        "line": 220
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        198
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 198,
+      "parent": 197,
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/client.js",
+        "name": "Client.packet",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        199
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 199,
+      "parent": 198,
+      "location": {
+        "file": "/app/node_modules/socket.io/lib/client.js",
+        "name": "writeToEngine",
+        "line": 167
+      },
+      "count": 0,
+      "depth": 16,
+      "children": [
+        200
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 200,
+      "parent": 199,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.send.Socket.write",
+        "line": 366
+      },
+      "count": 0,
+      "depth": 17,
+      "children": [
+        201
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 201,
+      "parent": 200,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.sendPacket",
+        "line": 380
+      },
+      "count": 0,
+      "depth": 18,
+      "children": [
+        202
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 202,
+      "parent": 201,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416
+      },
+      "count": 0,
+      "depth": 19,
+      "children": [
+        203
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 203,
+      "parent": 202,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89
+      },
+      "count": 0,
+      "depth": 20,
+      "children": [
+        204
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 204,
+      "parent": 203,
+      "location": {
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55
+      },
+      "count": 0,
+      "depth": 21,
+      "children": [
+        205
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 205,
+      "parent": 204,
+      "location": {
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97
+      },
+      "count": 0,
+      "depth": 22,
+      "children": [
+        206
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 206,
+      "parent": 205,
+      "location": {
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326
+      },
+      "count": 0,
+      "depth": 23,
+      "children": [
+        207
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 207,
+      "parent": 206,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252
+      },
+      "count": 0,
+      "depth": 24,
+      "children": [
+        208
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 208,
+      "parent": 207,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313
+      },
+      "count": 0,
+      "depth": 25,
+      "children": [
+        209
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 209,
+      "parent": 208,
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "compress",
+        "line": 319
+      },
+      "count": 0,
+      "depth": 26,
+      "children": [
+        210
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 210,
+      "parent": 209,
+      "location": {
+        "file": "/app/node_modules/ws/lib/limiter.js",
+        "name": "add",
+        "line": 32
+      },
+      "count": 0,
+      "depth": 27,
+      "children": [
+        211
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 211,
+      "parent": 210,
+      "location": {
+        "file": "/app/node_modules/ws/lib/limiter.js",
+        "name": "",
+        "line": 42
+      },
+      "count": 0,
+      "depth": 28,
+      "children": [
+        212
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 212,
+      "parent": 211,
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "zlibLimiter.add",
+        "line": 320
+      },
+      "count": 0,
+      "depth": 29,
+      "children": [
+        213
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 213,
+      "parent": 212,
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_compress",
+        "line": 397
+      },
+      "count": 0,
+      "depth": 30,
+      "children": [
+        214,
+        216
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 214,
+      "parent": 213,
+      "location": {
+        "file": "zlib.js",
+        "name": "DeflateRaw",
+        "line": 565
+      },
+      "count": 0,
+      "depth": 31,
+      "children": [
+        215
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 215,
+      "parent": 214,
+      "location": {
+        "file": "zlib.js",
+        "name": "DeflateRaw",
+        "line": 565
+      },
+      "count": 1,
+      "depth": 32,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 216,
+      "parent": 213,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "Writable.write",
+        "line": 264
+      },
+      "count": 0,
+      "depth": 31,
+      "children": [
+        217
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 217,
+      "parent": 216,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "writeOrBuffer",
+        "line": 348
+      },
+      "count": 0,
+      "depth": 32,
+      "children": [
+        218
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 218,
+      "parent": 217,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388
+      },
+      "count": 0,
+      "depth": 33,
+      "children": [
+        219
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 219,
+      "parent": 218,
+      "location": {
+        "file": "_stream_transform.js",
+        "name": "Transform._write",
+        "line": 164
+      },
+      "count": 0,
+      "depth": 34,
+      "children": [
+        220
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 220,
+      "parent": 219,
+      "location": {
+        "file": "_stream_transform.js",
+        "name": "Transform._read",
+        "line": 181
+      },
+      "count": 0,
+      "depth": 35,
+      "children": [
+        221
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 221,
+      "parent": 220,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 582
+      },
+      "count": 0,
+      "depth": 36,
+      "children": [
+        222
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 222,
+      "parent": 221,
+      "location": {
+        "file": "zlib.js",
+        "name": "_transform",
+        "line": 360
+      },
+      "count": 1,
+      "depth": 37,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 223,
+      "parent": 1,
+      "location": {
+        "file": "zlib.js",
+        "name": "callback",
+        "line": 447
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        224
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 224,
+      "parent": 223,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        225
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 225,
+      "parent": 224,
+      "location": {
+        "file": "_stream_transform.js",
+        "name": "afterTransform",
+        "line": 73
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        226
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 226,
+      "parent": 225,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "onwrite",
+        "line": 431
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        227
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 227,
+      "parent": 226,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        228
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 228,
+      "parent": 227,
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_deflate.flush",
+        "line": 428
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        229
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 229,
+      "parent": 228,
+      "location": {
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_compress",
+        "line": 321
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        230
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 230,
+      "parent": 229,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "perMessageDeflate.compress",
+        "line": 322
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        231
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 231,
+      "parent": 230,
+      "location": {
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        232
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 232,
+      "parent": 231,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        233
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 233,
+      "parent": 232,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        234
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 234,
+      "parent": 233,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        235
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 235,
+      "parent": 234,
+      "location": {
+        "file": "net.js",
+        "name": "Socket._writev",
+        "line": 781
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        236
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 236,
+      "parent": 235,
+      "location": {
+        "file": "net.js",
+        "name": "Socket._writeGeneric",
+        "line": 715
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        237
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 237,
+      "parent": 236,
+      "location": {
+        "file": "",
+        "name": "writev",
+        "line": 0
+      },
+      "count": 1,
+      "depth": 16,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 238,
+      "parent": 1,
+      "location": {
+        "file": "timers.js",
+        "name": "unrefdHandle",
+        "line": 608
+      },
+      "count": 2,
+      "depth": 2,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 239,
+      "parent": 130,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.on",
+        "line": 771
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        240
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 240,
+      "parent": 239,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.resume",
+        "line": 802
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        241
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 241,
+      "parent": 240,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "resume",
+        "line": 812
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        242
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 242,
+      "parent": 241,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 626
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        243
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 243,
+      "parent": 242,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        244
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 244,
+      "parent": 243,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        245
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 245,
+      "parent": 244,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "asyncWrap",
+        "line": 137
+      },
+      "count": 1,
+      "depth": 14,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 246,
+      "parent": 172,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "flow",
+        "line": 843
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        247
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 247,
+      "parent": 246,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365
+      },
+      "count": 1,
+      "depth": 7,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 248,
+      "parent": 129,
+      "location": {
+        "file": "/app/node_modules/on-finished/index.js",
+        "name": "onFinished",
+        "line": 45
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        249
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 249,
+      "parent": 248,
+      "location": {
+        "file": "/app/node_modules/on-finished/index.js",
+        "name": "attachListener",
+        "line": 140
+      },
+      "count": 1,
+      "depth": 8,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 250,
+      "parent": 126,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "onstat",
+        "line": 721
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        251
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 251,
+      "parent": 250,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 732
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        252
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 252,
+      "parent": 251,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "onStatError",
+        "line": 416
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        253
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 253,
+      "parent": 252,
+      "location": {
+        "file": "/app/node_modules/send/index.js",
+        "name": "error",
+        "line": 267
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        254
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 254,
+      "parent": 253,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        255
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 255,
+      "parent": 254,
+      "location": {
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        256
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 256,
+      "parent": 255,
+      "location": {
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "error",
+        "line": 115
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        257
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 257,
+      "parent": 256,
+      "location": {
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        258
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 258,
+      "parent": 257,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 644
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        259
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 259,
+      "parent": 258,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        260
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 260,
+      "parent": 259,
+      "location": {
+        "file": "timers.js",
+        "name": "setImmediate",
+        "line": 842
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        261
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 261,
+      "parent": 260,
+      "location": {
+        "file": "timers.js",
+        "name": "createImmediate",
+        "line": 877
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        262
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 262,
+      "parent": 261,
+      "location": {
+        "file": "timers.js",
+        "name": "Immediate",
+        "line": 824
+      },
+      "count": 0,
+      "depth": 16,
+      "children": [
+        263
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 263,
+      "parent": 262,
+      "location": {
+        "file": "domain.js",
+        "name": "get",
+        "line": 43
+      },
+      "count": 1,
+      "depth": 17,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 264,
+      "parent": 195,
+      "location": {
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "encodeAsString",
+        "line": 147
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        265
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 265,
+      "parent": 264,
+      "location": {
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "tryStringify",
+        "line": 182
+      },
+      "count": 1,
+      "depth": 14,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 266,
+      "parent": 83,
+      "location": {
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 42
+      },
+      "count": 0,
+      "depth": 36,
+      "children": [
+        267
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 267,
+      "parent": 266,
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/probe.js",
+        "name": "Probe.metricsStart",
+        "line": 62
+      },
+      "count": 0,
+      "depth": 37,
+      "children": [
+        268
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 268,
+      "parent": 267,
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/timer.js",
+        "name": "exports.start",
+        "line": 33
+      },
+      "count": 0,
+      "depth": 38,
+      "children": [
+        269
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 269,
+      "parent": 268,
+      "location": {
+        "file": "/app/node_modules/appmetrics/lib/timer.js",
+        "name": "Timer",
+        "line": 18
+      },
+      "count": 1,
+      "depth": 39,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 270,
+      "parent": 133,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        271
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 271,
+      "parent": 270,
+      "location": {
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        272
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 272,
+      "parent": 271,
+      "location": {
+        "file": "_http_server.js",
+        "name": "connectionListener",
+        "line": 312
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        273
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 273,
+      "parent": 272,
+      "location": {
+        "file": "internal/async_hooks.js",
+        "name": "defaultTriggerAsyncIdScope",
+        "line": 273
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        274
+      ],
+      "child_count": 2
+    },
+    {
+      "self": 274,
+      "parent": 273,
+      "location": {
+        "file": "_http_server.js",
+        "name": "connectionListenerInternal",
+        "line": 318
+      },
+      "count": 1,
+      "depth": 8,
+      "children": [
+        275
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 275,
+      "parent": 274,
+      "location": {
+        "file": "internal/http.js",
+        "name": "nowDate",
+        "line": 8
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        276
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 276,
+      "parent": 275,
+      "location": {
+        "file": "internal/http.js",
+        "name": "cache",
+        "line": 18
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        277
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 277,
+      "parent": 276,
+      "location": {
+        "file": "timers.js",
+        "name": "exports._unrefActive",
+        "line": 157
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        278
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 278,
+      "parent": 277,
+      "location": {
+        "file": "timers.js",
+        "name": "insert",
+        "line": 167
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        279
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 279,
+      "parent": 278,
+      "location": {
+        "file": "timers.js",
+        "name": "createTimersList",
+        "line": 196
+      },
+      "count": 1,
+      "depth": 13,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 280,
+      "parent": 177,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        281
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 281,
+      "parent": 280,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "asyncWrap",
+        "line": 137
+      },
+      "count": 1,
+      "depth": 12,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 282,
+      "parent": 3,
+      "location": {
+        "file": "internal/process/promises.js",
+        "name": "emitPendingUnhandledRejections",
+        "line": 100
+      },
+      "count": 1,
+      "depth": 3,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 283,
+      "parent": 128,
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "setHeader",
+        "line": 497
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        284
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 284,
+      "parent": 283,
+      "location": {
+        "file": "_http_outgoing.js",
+        "name": "validateHeader",
+        "line": 485
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        285
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 285,
+      "parent": 284,
+      "location": {
+        "file": "_http_common.js",
+        "name": "checkIsHttpToken",
+        "line": 281
+      },
+      "count": 1,
+      "depth": 8,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 286,
+      "parent": 1,
+      "location": {
+        "file": "fs.js",
+        "name": "wrapper",
+        "line": 656
+      },
+      "count": 0,
+      "depth": 2,
+      "children": [
+        287
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 287,
+      "parent": 286,
+      "location": {
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        288
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 288,
+      "parent": 287,
+      "location": {
+        "file": "fs.js",
+        "name": "fs.read",
+        "line": 2046
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        289
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 289,
+      "parent": 288,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.push",
+        "line": 191
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        290
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 290,
+      "parent": 289,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "readableAddChunk",
+        "line": 216
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        291
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 291,
+      "parent": 290,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "addChunk",
+        "line": 261
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        292
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 292,
+      "parent": 291,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        293
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 293,
+      "parent": 292,
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream._read",
+        "line": 2013
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        294
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 294,
+      "parent": 293,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 600
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        295
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 295,
+      "parent": 294,
+      "location": {
+        "file": "fs.js",
+        "name": "fs.read",
+        "line": 649
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        296
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 296,
+      "parent": 295,
+      "location": {
+        "file": "",
+        "name": "read",
+        "line": 0
+      },
+      "count": 1,
+      "depth": 12,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 297,
+      "parent": 172,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 1,
+      "depth": 6,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 298,
+      "parent": 43,
+      "location": {
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "asJson",
+        "line": 73
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        299
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 299,
+      "parent": 298,
+      "location": {
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "stringify",
+        "line": 358
+      },
+      "count": 1,
+      "depth": 11,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 300,
+      "parent": 48,
+      "location": {
+        "file": "",
+        "name": "now",
+        "line": 0
+      },
+      "count": 1,
+      "depth": 3,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 301,
+      "parent": 132,
+      "location": {
+        "file": "net.js",
+        "name": "onread",
+        "line": 583
+      },
+      "count": 0,
+      "depth": 3,
+      "children": [
+        302
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 302,
+      "parent": 301,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "Readable.push",
+        "line": 191
+      },
+      "count": 0,
+      "depth": 4,
+      "children": [
+        303
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 303,
+      "parent": 302,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "readableAddChunk",
+        "line": 216
+      },
+      "count": 0,
+      "depth": 5,
+      "children": [
+        304
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 304,
+      "parent": 303,
+      "location": {
+        "file": "_stream_readable.js",
+        "name": "addChunk",
+        "line": 261
+      },
+      "count": 0,
+      "depth": 6,
+      "children": [
+        305
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 305,
+      "parent": 304,
+      "location": {
+        "file": "events.js",
+        "name": "emit",
+        "line": 156
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        306
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 306,
+      "parent": 305,
+      "location": {
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        307
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 307,
+      "parent": 306,
+      "location": {
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "socketOnData",
+        "line": 875
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        308
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 308,
+      "parent": 307,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "Writable.write",
+        "line": 264
+      },
+      "count": 0,
+      "depth": 10,
+      "children": [
+        309
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 309,
+      "parent": 308,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "writeOrBuffer",
+        "line": 348
+      },
+      "count": 0,
+      "depth": 11,
+      "children": [
+        310
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 310,
+      "parent": 309,
+      "location": {
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388
+      },
+      "count": 0,
+      "depth": 12,
+      "children": [
+        311
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 311,
+      "parent": 310,
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "_write",
+        "line": 72
+      },
+      "count": 0,
+      "depth": 13,
+      "children": [
+        312
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 312,
+      "parent": 311,
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "startLoop",
+        "line": 123
+      },
+      "count": 0,
+      "depth": 14,
+      "children": [
+        313
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 313,
+      "parent": 312,
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "getData",
+        "line": 336
+      },
+      "count": 0,
+      "depth": 15,
+      "children": [
+        314
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 314,
+      "parent": 313,
+      "location": {
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "dataMessage",
+        "line": 406
+      },
+      "count": 0,
+      "depth": 16,
+      "children": [
+        315
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 315,
+      "parent": 314,
+      "location": {
+        "file": "buffer.js",
+        "name": "Buffer.toString",
+        "line": 609
+      },
+      "count": 1,
+      "depth": 17,
+      "children": [],
+      "child_count": 0
+    },
+    {
+      "self": 316,
+      "parent": 129,
+      "location": {
+        "file": "fs.js",
+        "name": "fs.createReadStream",
+        "line": 1930
+      },
+      "count": 0,
+      "depth": 7,
+      "children": [
+        317
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 317,
+      "parent": 316,
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream",
+        "line": 1937
+      },
+      "count": 0,
+      "depth": 8,
+      "children": [
+        318
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 318,
+      "parent": 317,
+      "location": {
+        "file": "fs.js",
+        "name": "ReadStream.open",
+        "line": 1994
+      },
+      "count": 0,
+      "depth": 9,
+      "children": [
+        319
+      ],
+      "child_count": 1
+    },
+    {
+      "self": 319,
+      "parent": 318,
+      "location": {
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 588
+      },
+      "count": 1,
+      "depth": 10,
+      "children": [],
+      "child_count": 0
+    }
+  ]
+}

--- a/test/src/unit/script/node-profiling.json
+++ b/test/src/unit/script/node-profiling.json
@@ -1,0 +1,5152 @@
+[
+  {
+    "date": 0,
+    "functions": [
+      {
+        "self": 1,
+        "parent": 0,
+        "file": "",
+        "name": "(root)",
+        "line": 0,
+        "count": 0
+      },
+      {
+        "self": 2,
+        "parent": 1,
+        "file": "",
+        "name": "(program)",
+        "line": 0,
+        "count": 4052
+      },
+      {
+        "self": 3,
+        "parent": 1,
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194,
+        "count": 0
+      },
+      {
+        "self": 4,
+        "parent": 3,
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130,
+        "count": 0
+      },
+      {
+        "self": 5,
+        "parent": 4,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 6,
+        "parent": 5,
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459,
+        "count": 0
+      },
+      {
+        "self": 7,
+        "parent": 6,
+        "file": "_stream_writable.js",
+        "name": "onCorkedFinish",
+        "line": 632,
+        "count": 0
+      },
+      {
+        "self": 8,
+        "parent": 7,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "onEnd",
+        "line": 117,
+        "count": 0
+      },
+      {
+        "self": 9,
+        "parent": 8,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 10,
+        "parent": 9,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 11,
+        "parent": 10,
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416,
+        "count": 0
+      },
+      {
+        "self": 12,
+        "parent": 11,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89,
+        "count": 0
+      },
+      {
+        "self": 13,
+        "parent": 12,
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55,
+        "count": 0
+      },
+      {
+        "self": 14,
+        "parent": 13,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97,
+        "count": 0
+      },
+      {
+        "self": 15,
+        "parent": 14,
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326,
+        "count": 0
+      },
+      {
+        "self": 16,
+        "parent": 15,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252,
+        "count": 0
+      },
+      {
+        "self": 17,
+        "parent": 16,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313,
+        "count": 0
+      },
+      {
+        "self": 18,
+        "parent": 17,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378,
+        "count": 0
+      },
+      {
+        "self": 19,
+        "parent": 18,
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302,
+        "count": 0
+      },
+      {
+        "self": 20,
+        "parent": 19,
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478,
+        "count": 1
+      },
+      {
+        "self": 21,
+        "parent": 5,
+        "file": "_stream_readable.js",
+        "name": "endReadableNT",
+        "line": 1059,
+        "count": 0
+      },
+      {
+        "self": 22,
+        "parent": 21,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 23,
+        "parent": 22,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 24,
+        "parent": 23,
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307,
+        "count": 0
+      },
+      {
+        "self": 25,
+        "parent": 24,
+        "file": "_stream_readable.js",
+        "name": "onend",
+        "line": 593,
+        "count": 0
+      },
+      {
+        "self": 26,
+        "parent": 25,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 100,
+        "count": 0
+      },
+      {
+        "self": 27,
+        "parent": 26,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 52,
+        "count": 0
+      },
+      {
+        "self": 28,
+        "parent": 27,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "HttpProbe.metricsEnd",
+        "line": 102,
+        "count": 0
+      },
+      {
+        "self": 29,
+        "parent": 28,
+        "file": "/app/node_modules/appmetrics/index.js",
+        "name": "module.exports.emit",
+        "line": 279,
+        "count": 0
+      },
+      {
+        "self": 30,
+        "parent": 29,
+        "file": "",
+        "name": "getObjectHistogram",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 31,
+        "parent": 23,
+        "file": "fs.js",
+        "name": "",
+        "line": 1985,
+        "count": 0
+      },
+      {
+        "self": 32,
+        "parent": 31,
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4,
+        "count": 0
+      },
+      {
+        "self": 33,
+        "parent": 32,
+        "file": "fs.js",
+        "name": "ReadStream._destroy",
+        "line": 2070,
+        "count": 0
+      },
+      {
+        "self": 34,
+        "parent": 33,
+        "file": "fs.js",
+        "name": "ReadStream.close",
+        "line": 2077,
+        "count": 0
+      },
+      {
+        "self": 35,
+        "parent": 34,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 576,
+        "count": 0
+      },
+      {
+        "self": 36,
+        "parent": 35,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391,
+        "count": 1
+      },
+      {
+        "self": 37,
+        "parent": 5,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "union",
+        "line": 60,
+        "count": 1
+      },
+      {
+        "self": 38,
+        "parent": 4,
+        "file": "_http_outgoing.js",
+        "name": "onFinish",
+        "line": 719,
+        "count": 0
+      },
+      {
+        "self": 39,
+        "parent": 38,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 40,
+        "parent": 39,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 41,
+        "parent": 40,
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "onResFinished",
+        "line": 58,
+        "count": 0
+      },
+      {
+        "self": 42,
+        "parent": 41,
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "LOG",
+        "line": 30,
+        "count": 0
+      },
+      {
+        "self": 43,
+        "parent": 42,
+        "file": "/app/node_modules/pino/lib/proto.js",
+        "name": "write",
+        "line": 122,
+        "count": 0
+      },
+      {
+        "self": 44,
+        "parent": 43,
+        "file": "/app/node_modules/sonic-boom/index.js",
+        "name": "SonicBoom.write",
+        "line": 160,
+        "count": 0
+      },
+      {
+        "self": 45,
+        "parent": 44,
+        "file": "/app/node_modules/sonic-boom/index.js",
+        "name": "actualWrite",
+        "line": 272,
+        "count": 0
+      },
+      {
+        "self": 46,
+        "parent": 45,
+        "file": "fs.js",
+        "name": "fs.writeSync",
+        "line": 727,
+        "count": 0
+      },
+      {
+        "self": 47,
+        "parent": 46,
+        "file": "",
+        "name": "writeString",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 48,
+        "parent": 1,
+        "file": "timers.js",
+        "name": "listOnTimeout",
+        "line": 231,
+        "count": 1
+      },
+      {
+        "self": 49,
+        "parent": 48,
+        "file": "internal/linkedlist.js",
+        "name": "remove",
+        "line": 15,
+        "count": 1
+      },
+      {
+        "self": 50,
+        "parent": 1,
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62,
+        "count": 0
+      },
+      {
+        "self": 51,
+        "parent": 50,
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596,
+        "count": 0
+      },
+      {
+        "self": 52,
+        "parent": 51,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 53,
+        "parent": 52,
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124,
+        "count": 0
+      },
+      {
+        "self": 54,
+        "parent": 53,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336,
+        "count": 0
+      },
+      {
+        "self": 55,
+        "parent": 54,
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463,
+        "count": 0
+      },
+      {
+        "self": 56,
+        "parent": 55,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 57,
+        "parent": 56,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 58,
+        "parent": 57,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 59,
+        "parent": 58,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 60,
+        "parent": 59,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 61,
+        "parent": 60,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 62,
+        "parent": 61,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 63,
+        "parent": 62,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 64,
+        "parent": 63,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 65,
+        "parent": 64,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 66,
+        "parent": 65,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 67,
+        "parent": 66,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 68,
+        "parent": 67,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 69,
+        "parent": 68,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 70,
+        "parent": 69,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 0
+      },
+      {
+        "self": 71,
+        "parent": 70,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 72,
+        "parent": 71,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 73,
+        "parent": 72,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 74,
+        "parent": 73,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 75,
+        "parent": 74,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 76,
+        "parent": 75,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "defaultMiddleware",
+        "line": 56,
+        "count": 0
+      },
+      {
+        "self": 77,
+        "parent": 76,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 78,
+        "parent": 77,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 79,
+        "parent": 78,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 80,
+        "parent": 79,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 81,
+        "parent": 80,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 82,
+        "parent": 81,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 217,
+        "count": 0
+      },
+      {
+        "self": 83,
+        "parent": 82,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 25,
+        "count": 0
+      },
+      {
+        "self": 84,
+        "parent": 83,
+        "file": "/app/node_modules/ibmapm-embed/appmetrics-zipkin/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 26,
+        "count": 0
+      },
+      {
+        "self": 85,
+        "parent": 84,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 86,
+        "parent": 85,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 87,
+        "parent": 86,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 88,
+        "parent": 87,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 89,
+        "parent": 88,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 90,
+        "parent": 89,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 91,
+        "parent": 90,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 92,
+        "parent": 91,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 93,
+        "parent": 92,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 94,
+        "parent": 93,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 95,
+        "parent": 94,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 96,
+        "parent": 95,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 97,
+        "parent": 96,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 98,
+        "parent": 97,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 99,
+        "parent": 98,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 0
+      },
+      {
+        "self": 100,
+        "parent": 99,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 101,
+        "parent": 100,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 102,
+        "parent": 101,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 103,
+        "parent": 102,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 104,
+        "parent": 103,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 105,
+        "parent": 104,
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "loggingMiddleware",
+        "line": 83,
+        "count": 0
+      },
+      {
+        "self": 106,
+        "parent": 105,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 107,
+        "parent": 106,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 108,
+        "parent": 107,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 109,
+        "parent": 108,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 110,
+        "parent": 109,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 111,
+        "parent": 110,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "router",
+        "line": 46,
+        "count": 0
+      },
+      {
+        "self": 112,
+        "parent": 111,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 113,
+        "parent": 112,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 114,
+        "parent": 113,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 115,
+        "parent": 114,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 116,
+        "parent": 115,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 117,
+        "parent": 116,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 118,
+        "parent": 117,
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "serveStatic",
+        "line": 72,
+        "count": 0
+      },
+      {
+        "self": 119,
+        "parent": 118,
+        "file": "/app/node_modules/send/index.js",
+        "name": "pipe",
+        "line": 510,
+        "count": 0
+      },
+      {
+        "self": 120,
+        "parent": 119,
+        "file": "/app/node_modules/send/index.js",
+        "name": "sendIndex",
+        "line": 757,
+        "count": 0
+      },
+      {
+        "self": 121,
+        "parent": 120,
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 761,
+        "count": 0
+      },
+      {
+        "self": 122,
+        "parent": 121,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 576,
+        "count": 0
+      },
+      {
+        "self": 123,
+        "parent": 122,
+        "file": "fs.js",
+        "name": "fs.stat",
+        "line": 923,
+        "count": 0
+      },
+      {
+        "self": 124,
+        "parent": 123,
+        "file": "",
+        "name": "stat",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 125,
+        "parent": 1,
+        "file": "fs.js",
+        "name": "",
+        "line": 151,
+        "count": 0
+      },
+      {
+        "self": 126,
+        "parent": 125,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 127,
+        "parent": 126,
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770,
+        "count": 0
+      },
+      {
+        "self": 128,
+        "parent": 127,
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606,
+        "count": 0
+      },
+      {
+        "self": 129,
+        "parent": 128,
+        "file": "/app/node_modules/send/index.js",
+        "name": "stream",
+        "line": 789,
+        "count": 0
+      },
+      {
+        "self": 130,
+        "parent": 129,
+        "file": "_stream_readable.js",
+        "name": "Readable.pipe",
+        "line": 554,
+        "count": 0
+      },
+      {
+        "self": 131,
+        "parent": 130,
+        "file": "_stream_readable.js",
+        "name": "pipeOnDrain",
+        "line": 699,
+        "count": 1
+      },
+      {
+        "self": 132,
+        "parent": 1,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 133,
+        "parent": 132,
+        "file": "net.js",
+        "name": "onconnection",
+        "line": 1539,
+        "count": 0
+      },
+      {
+        "self": 134,
+        "parent": 133,
+        "file": "net.js",
+        "name": "Socket",
+        "line": 189,
+        "count": 0
+      },
+      {
+        "self": 135,
+        "parent": 134,
+        "file": "_stream_duplex.js",
+        "name": "Duplex",
+        "line": 47,
+        "count": 0
+      },
+      {
+        "self": 136,
+        "parent": 135,
+        "file": "events.js",
+        "name": "once",
+        "line": 338,
+        "count": 1
+      },
+      {
+        "self": 137,
+        "parent": 1,
+        "file": "timers.js",
+        "name": "processImmediate",
+        "line": 720,
+        "count": 0
+      },
+      {
+        "self": 138,
+        "parent": 137,
+        "file": "timers.js",
+        "name": "tryOnImmediate",
+        "line": 763,
+        "count": 0
+      },
+      {
+        "self": 139,
+        "parent": 138,
+        "file": "timers.js",
+        "name": "runCallback",
+        "line": 802,
+        "count": 0
+      },
+      {
+        "self": 140,
+        "parent": 139,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 141,
+        "parent": 140,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 629,
+        "count": 0
+      },
+      {
+        "self": 142,
+        "parent": 141,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 143,
+        "parent": 142,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 144,
+        "parent": 143,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 145,
+        "parent": 144,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 146,
+        "parent": 145,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 147,
+        "parent": 146,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "router",
+        "line": 46,
+        "count": 0
+      },
+      {
+        "self": 148,
+        "parent": 147,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 149,
+        "parent": 148,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 150,
+        "parent": 149,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 151,
+        "parent": 150,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 152,
+        "parent": 151,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 153,
+        "parent": 152,
+        "file": "/app/node_modules/express/lib/router/route.js",
+        "name": "dispatch",
+        "line": 98,
+        "count": 0
+      },
+      {
+        "self": 154,
+        "parent": 153,
+        "file": "/app/node_modules/express/lib/router/route.js",
+        "name": "next",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 155,
+        "parent": 154,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 156,
+        "parent": 155,
+        "file": "/app/server/routers/health.js",
+        "name": "",
+        "line": 6,
+        "count": 0
+      },
+      {
+        "self": 157,
+        "parent": 156,
+        "file": "/app/node_modules/express/lib/response.js",
+        "name": "json",
+        "line": 239,
+        "count": 0
+      },
+      {
+        "self": 158,
+        "parent": 157,
+        "file": "/app/node_modules/express/lib/response.js",
+        "name": "header",
+        "line": 754,
+        "count": 0
+      },
+      {
+        "self": 159,
+        "parent": 158,
+        "file": "_http_outgoing.js",
+        "name": "setHeader",
+        "line": 497,
+        "count": 0
+      },
+      {
+        "self": 160,
+        "parent": 159,
+        "file": "_http_outgoing.js",
+        "name": "validateHeader",
+        "line": 485,
+        "count": 0
+      },
+      {
+        "self": 161,
+        "parent": 160,
+        "file": "_http_common.js",
+        "name": "checkIsHttpToken",
+        "line": 281,
+        "count": 1
+      },
+      {
+        "self": 162,
+        "parent": 1,
+        "file": "net.js",
+        "name": "afterShutdown",
+        "line": 321,
+        "count": 0
+      },
+      {
+        "self": 163,
+        "parent": 162,
+        "file": "_stream_writable.js",
+        "name": "stream._final",
+        "line": 584,
+        "count": 0
+      },
+      {
+        "self": 164,
+        "parent": 163,
+        "file": "_stream_writable.js",
+        "name": "finishMaybe",
+        "line": 607,
+        "count": 0
+      },
+      {
+        "self": 165,
+        "parent": 164,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 166,
+        "parent": 165,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 167,
+        "parent": 166,
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307,
+        "count": 0
+      },
+      {
+        "self": 168,
+        "parent": 167,
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4,
+        "count": 0
+      },
+      {
+        "self": 169,
+        "parent": 168,
+        "file": "net.js",
+        "name": "Socket._destroy",
+        "line": 541,
+        "count": 0
+      },
+      {
+        "self": 170,
+        "parent": 169,
+        "file": "",
+        "name": "close",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 171,
+        "parent": 1,
+        "file": "",
+        "name": "(garbage collector)",
+        "line": 0,
+        "count": 2
+      }
+    ],
+    "time": 1589367954299
+  },
+  {
+    "date": 0,
+    "functions": [
+      {
+        "self": 172,
+        "parent": 0,
+        "file": "",
+        "name": "(root)",
+        "line": 0,
+        "count": 0
+      },
+      {
+        "self": 173,
+        "parent": 172,
+        "file": "",
+        "name": "(program)",
+        "line": 0,
+        "count": 4150
+      },
+      {
+        "self": 174,
+        "parent": 172,
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194,
+        "count": 0
+      },
+      {
+        "self": 175,
+        "parent": 174,
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130,
+        "count": 0
+      },
+      {
+        "self": 176,
+        "parent": 175,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 177,
+        "parent": 176,
+        "file": "_stream_readable.js",
+        "name": "resume_",
+        "line": 819,
+        "count": 0
+      },
+      {
+        "self": 178,
+        "parent": 177,
+        "file": "_http_incoming.js",
+        "name": "read",
+        "line": 93,
+        "count": 0
+      },
+      {
+        "self": 179,
+        "parent": 178,
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365,
+        "count": 0
+      },
+      {
+        "self": 180,
+        "parent": 179,
+        "file": "_stream_readable.js",
+        "name": "endReadable",
+        "line": 1045,
+        "count": 0
+      },
+      {
+        "self": 181,
+        "parent": 180,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 626,
+        "count": 0
+      },
+      {
+        "self": 182,
+        "parent": 181,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612,
+        "count": 0
+      },
+      {
+        "self": 183,
+        "parent": 182,
+        "file": "internal/process/next_tick.js",
+        "name": "nextTick",
+        "line": 246,
+        "count": 1
+      },
+      {
+        "self": 184,
+        "parent": 176,
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459,
+        "count": 0
+      },
+      {
+        "self": 185,
+        "parent": 184,
+        "file": "_stream_writable.js",
+        "name": "onCorkedFinish",
+        "line": 632,
+        "count": 0
+      },
+      {
+        "self": 186,
+        "parent": 185,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "onEnd",
+        "line": 117,
+        "count": 0
+      },
+      {
+        "self": 187,
+        "parent": 186,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 188,
+        "parent": 187,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 189,
+        "parent": 188,
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416,
+        "count": 0
+      },
+      {
+        "self": 190,
+        "parent": 189,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89,
+        "count": 0
+      },
+      {
+        "self": 191,
+        "parent": 190,
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55,
+        "count": 0
+      },
+      {
+        "self": 192,
+        "parent": 191,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97,
+        "count": 0
+      },
+      {
+        "self": 193,
+        "parent": 192,
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326,
+        "count": 0
+      },
+      {
+        "self": 194,
+        "parent": 193,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252,
+        "count": 0
+      },
+      {
+        "self": 195,
+        "parent": 194,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313,
+        "count": 0
+      },
+      {
+        "self": 196,
+        "parent": 195,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378,
+        "count": 0
+      },
+      {
+        "self": 197,
+        "parent": 196,
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302,
+        "count": 0
+      },
+      {
+        "self": 198,
+        "parent": 197,
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478,
+        "count": 0
+      },
+      {
+        "self": 199,
+        "parent": 198,
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388,
+        "count": 0
+      },
+      {
+        "self": 200,
+        "parent": 199,
+        "file": "net.js",
+        "name": "Socket._writev",
+        "line": 781,
+        "count": 0
+      },
+      {
+        "self": 201,
+        "parent": 200,
+        "file": "net.js",
+        "name": "Socket._writeGeneric",
+        "line": 715,
+        "count": 0
+      },
+      {
+        "self": 202,
+        "parent": 201,
+        "file": "",
+        "name": "writev",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 203,
+        "parent": 172,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "events",
+        "line": 238,
+        "count": 0
+      },
+      {
+        "self": 204,
+        "parent": 203,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "raiseEvent",
+        "line": 32,
+        "count": 0
+      },
+      {
+        "self": 205,
+        "parent": 204,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "formatProfiling",
+        "line": 180,
+        "count": 0
+      },
+      {
+        "self": 206,
+        "parent": 205,
+        "file": "",
+        "name": "forEach",
+        "line": 0,
+        "count": 0
+      },
+      {
+        "self": 207,
+        "parent": 206,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "",
+        "line": 189,
+        "count": 1
+      },
+      {
+        "self": 208,
+        "parent": 205,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 209,
+        "parent": 208,
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 210,
+        "parent": 209,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 277,
+        "count": 0
+      },
+      {
+        "self": 211,
+        "parent": 210,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "Server.(anonymous function)",
+        "line": 504,
+        "count": 0
+      },
+      {
+        "self": 212,
+        "parent": 211,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 79,
+        "count": 0
+      },
+      {
+        "self": 213,
+        "parent": 212,
+        "file": "/app/node_modules/socket.io/lib/namespace.js",
+        "name": "Namespace.emit",
+        "line": 211,
+        "count": 0
+      },
+      {
+        "self": 214,
+        "parent": 213,
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "Adapter.broadcast",
+        "line": 122,
+        "count": 0
+      },
+      {
+        "self": 215,
+        "parent": 214,
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "Encoder.encode",
+        "line": 128,
+        "count": 0
+      },
+      {
+        "self": 216,
+        "parent": 215,
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 217,
+        "parent": 216,
+        "file": "/app/node_modules/socket.io/lib/socket.js",
+        "name": "Socket.packet",
+        "line": 220,
+        "count": 0
+      },
+      {
+        "self": 218,
+        "parent": 217,
+        "file": "/app/node_modules/socket.io/lib/client.js",
+        "name": "Client.packet",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 219,
+        "parent": 218,
+        "file": "/app/node_modules/socket.io/lib/client.js",
+        "name": "writeToEngine",
+        "line": 167,
+        "count": 0
+      },
+      {
+        "self": 220,
+        "parent": 219,
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.send.Socket.write",
+        "line": 366,
+        "count": 0
+      },
+      {
+        "self": 221,
+        "parent": 220,
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.sendPacket",
+        "line": 380,
+        "count": 0
+      },
+      {
+        "self": 222,
+        "parent": 221,
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416,
+        "count": 0
+      },
+      {
+        "self": 223,
+        "parent": 222,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89,
+        "count": 0
+      },
+      {
+        "self": 224,
+        "parent": 223,
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55,
+        "count": 0
+      },
+      {
+        "self": 225,
+        "parent": 224,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97,
+        "count": 0
+      },
+      {
+        "self": 226,
+        "parent": 225,
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326,
+        "count": 0
+      },
+      {
+        "self": 227,
+        "parent": 226,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252,
+        "count": 0
+      },
+      {
+        "self": 228,
+        "parent": 227,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313,
+        "count": 0
+      },
+      {
+        "self": 229,
+        "parent": 228,
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "compress",
+        "line": 319,
+        "count": 0
+      },
+      {
+        "self": 230,
+        "parent": 229,
+        "file": "/app/node_modules/ws/lib/limiter.js",
+        "name": "add",
+        "line": 32,
+        "count": 0
+      },
+      {
+        "self": 231,
+        "parent": 230,
+        "file": "/app/node_modules/ws/lib/limiter.js",
+        "name": "",
+        "line": 42,
+        "count": 0
+      },
+      {
+        "self": 232,
+        "parent": 231,
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "zlibLimiter.add",
+        "line": 320,
+        "count": 0
+      },
+      {
+        "self": 233,
+        "parent": 232,
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_compress",
+        "line": 397,
+        "count": 0
+      },
+      {
+        "self": 234,
+        "parent": 233,
+        "file": "zlib.js",
+        "name": "DeflateRaw",
+        "line": 565,
+        "count": 0
+      },
+      {
+        "self": 235,
+        "parent": 234,
+        "file": "zlib.js",
+        "name": "DeflateRaw",
+        "line": 565,
+        "count": 1
+      },
+      {
+        "self": 236,
+        "parent": 233,
+        "file": "_stream_writable.js",
+        "name": "Writable.write",
+        "line": 264,
+        "count": 0
+      },
+      {
+        "self": 237,
+        "parent": 236,
+        "file": "_stream_writable.js",
+        "name": "writeOrBuffer",
+        "line": 348,
+        "count": 0
+      },
+      {
+        "self": 238,
+        "parent": 237,
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388,
+        "count": 0
+      },
+      {
+        "self": 239,
+        "parent": 238,
+        "file": "_stream_transform.js",
+        "name": "Transform._write",
+        "line": 164,
+        "count": 0
+      },
+      {
+        "self": 240,
+        "parent": 239,
+        "file": "_stream_transform.js",
+        "name": "Transform._read",
+        "line": 181,
+        "count": 0
+      },
+      {
+        "self": 241,
+        "parent": 240,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 582,
+        "count": 0
+      },
+      {
+        "self": 242,
+        "parent": 241,
+        "file": "zlib.js",
+        "name": "_transform",
+        "line": 360,
+        "count": 1
+      },
+      {
+        "self": 243,
+        "parent": 172,
+        "file": "zlib.js",
+        "name": "callback",
+        "line": 447,
+        "count": 0
+      },
+      {
+        "self": 244,
+        "parent": 243,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 245,
+        "parent": 244,
+        "file": "_stream_transform.js",
+        "name": "afterTransform",
+        "line": 73,
+        "count": 0
+      },
+      {
+        "self": 246,
+        "parent": 245,
+        "file": "_stream_writable.js",
+        "name": "onwrite",
+        "line": 431,
+        "count": 0
+      },
+      {
+        "self": 247,
+        "parent": 246,
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459,
+        "count": 0
+      },
+      {
+        "self": 248,
+        "parent": 247,
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_deflate.flush",
+        "line": 428,
+        "count": 0
+      },
+      {
+        "self": 249,
+        "parent": 248,
+        "file": "/app/node_modules/ws/lib/permessage-deflate.js",
+        "name": "_compress",
+        "line": 321,
+        "count": 0
+      },
+      {
+        "self": 250,
+        "parent": 249,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "perMessageDeflate.compress",
+        "line": 322,
+        "count": 0
+      },
+      {
+        "self": 251,
+        "parent": 250,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378,
+        "count": 0
+      },
+      {
+        "self": 252,
+        "parent": 251,
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302,
+        "count": 0
+      },
+      {
+        "self": 253,
+        "parent": 252,
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478,
+        "count": 0
+      },
+      {
+        "self": 254,
+        "parent": 253,
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388,
+        "count": 0
+      },
+      {
+        "self": 255,
+        "parent": 254,
+        "file": "net.js",
+        "name": "Socket._writev",
+        "line": 781,
+        "count": 0
+      },
+      {
+        "self": 256,
+        "parent": 255,
+        "file": "net.js",
+        "name": "Socket._writeGeneric",
+        "line": 715,
+        "count": 0
+      },
+      {
+        "self": 257,
+        "parent": 256,
+        "file": "",
+        "name": "writev",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 258,
+        "parent": 172,
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62,
+        "count": 0
+      },
+      {
+        "self": 259,
+        "parent": 258,
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596,
+        "count": 0
+      },
+      {
+        "self": 260,
+        "parent": 259,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 261,
+        "parent": 260,
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124,
+        "count": 0
+      },
+      {
+        "self": 262,
+        "parent": 261,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336,
+        "count": 0
+      },
+      {
+        "self": 263,
+        "parent": 262,
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463,
+        "count": 0
+      },
+      {
+        "self": 264,
+        "parent": 263,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 265,
+        "parent": 264,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 266,
+        "parent": 265,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 267,
+        "parent": 266,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 268,
+        "parent": 267,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 269,
+        "parent": 268,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 270,
+        "parent": 269,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 271,
+        "parent": 270,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 272,
+        "parent": 271,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 273,
+        "parent": 272,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 274,
+        "parent": 273,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 275,
+        "parent": 274,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 276,
+        "parent": 275,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 277,
+        "parent": 276,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 278,
+        "parent": 277,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 0
+      },
+      {
+        "self": 279,
+        "parent": 278,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 280,
+        "parent": 279,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 281,
+        "parent": 280,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 282,
+        "parent": 281,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 283,
+        "parent": 282,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 284,
+        "parent": 283,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "defaultMiddleware",
+        "line": 56,
+        "count": 0
+      },
+      {
+        "self": 285,
+        "parent": 284,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 286,
+        "parent": 285,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 287,
+        "parent": 286,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 288,
+        "parent": 287,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 289,
+        "parent": 288,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 290,
+        "parent": 289,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 217,
+        "count": 0
+      },
+      {
+        "self": 291,
+        "parent": 290,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 25,
+        "count": 0
+      },
+      {
+        "self": 292,
+        "parent": 291,
+        "file": "/app/node_modules/ibmapm-embed/appmetrics-zipkin/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 26,
+        "count": 0
+      },
+      {
+        "self": 293,
+        "parent": 292,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 294,
+        "parent": 293,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 295,
+        "parent": 294,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 296,
+        "parent": 295,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 297,
+        "parent": 296,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 298,
+        "parent": 297,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 299,
+        "parent": 298,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 300,
+        "parent": 299,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 301,
+        "parent": 300,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 302,
+        "parent": 301,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 303,
+        "parent": 302,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 304,
+        "parent": 303,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 305,
+        "parent": 304,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 306,
+        "parent": 305,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 307,
+        "parent": 306,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 0
+      },
+      {
+        "self": 308,
+        "parent": 307,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 309,
+        "parent": 308,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 310,
+        "parent": 309,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 311,
+        "parent": 310,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 312,
+        "parent": 311,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 313,
+        "parent": 312,
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "loggingMiddleware",
+        "line": 83,
+        "count": 0
+      },
+      {
+        "self": 314,
+        "parent": 313,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 315,
+        "parent": 314,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 316,
+        "parent": 315,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 317,
+        "parent": 316,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 318,
+        "parent": 317,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 319,
+        "parent": 318,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "router",
+        "line": 46,
+        "count": 0
+      },
+      {
+        "self": 320,
+        "parent": 319,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 321,
+        "parent": 320,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 322,
+        "parent": 321,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 323,
+        "parent": 322,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 324,
+        "parent": 323,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 325,
+        "parent": 324,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 326,
+        "parent": 325,
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "serveStatic",
+        "line": 72,
+        "count": 0
+      },
+      {
+        "self": 327,
+        "parent": 326,
+        "file": "/app/node_modules/send/index.js",
+        "name": "pipe",
+        "line": 510,
+        "count": 0
+      },
+      {
+        "self": 328,
+        "parent": 327,
+        "file": "/app/node_modules/send/index.js",
+        "name": "sendIndex",
+        "line": 757,
+        "count": 0
+      },
+      {
+        "self": 329,
+        "parent": 328,
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 761,
+        "count": 0
+      },
+      {
+        "self": 330,
+        "parent": 329,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 576,
+        "count": 0
+      },
+      {
+        "self": 331,
+        "parent": 330,
+        "file": "fs.js",
+        "name": "fs.stat",
+        "line": 923,
+        "count": 0
+      },
+      {
+        "self": 332,
+        "parent": 331,
+        "file": "",
+        "name": "stat",
+        "line": 0,
+        "count": 2
+      },
+      {
+        "self": 333,
+        "parent": 172,
+        "file": "",
+        "name": "(garbage collector)",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 334,
+        "parent": 172,
+        "file": "timers.js",
+        "name": "unrefdHandle",
+        "line": 608,
+        "count": 1
+      },
+      {
+        "self": 335,
+        "parent": 172,
+        "file": "fs.js",
+        "name": "",
+        "line": 151,
+        "count": 0
+      },
+      {
+        "self": 336,
+        "parent": 335,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 337,
+        "parent": 336,
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770,
+        "count": 0
+      },
+      {
+        "self": 338,
+        "parent": 337,
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606,
+        "count": 0
+      },
+      {
+        "self": 339,
+        "parent": 338,
+        "file": "/app/node_modules/send/index.js",
+        "name": "stream",
+        "line": 789,
+        "count": 0
+      },
+      {
+        "self": 340,
+        "parent": 339,
+        "file": "_stream_readable.js",
+        "name": "Readable.pipe",
+        "line": 554,
+        "count": 0
+      },
+      {
+        "self": 341,
+        "parent": 340,
+        "file": "_stream_readable.js",
+        "name": "Readable.on",
+        "line": 771,
+        "count": 0
+      },
+      {
+        "self": 342,
+        "parent": 341,
+        "file": "_stream_readable.js",
+        "name": "Readable.resume",
+        "line": 802,
+        "count": 0
+      },
+      {
+        "self": 343,
+        "parent": 342,
+        "file": "_stream_readable.js",
+        "name": "resume",
+        "line": 812,
+        "count": 0
+      },
+      {
+        "self": 344,
+        "parent": 343,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 626,
+        "count": 0
+      },
+      {
+        "self": 345,
+        "parent": 344,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612,
+        "count": 0
+      },
+      {
+        "self": 346,
+        "parent": 345,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391,
+        "count": 0
+      },
+      {
+        "self": 347,
+        "parent": 346,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "asyncWrap",
+        "line": 137,
+        "count": 1
+      }
+    ],
+    "time": 1589367959296
+  },
+  {
+    "date": 0,
+    "functions": [
+      {
+        "self": 348,
+        "parent": 0,
+        "file": "",
+        "name": "(root)",
+        "line": 0,
+        "count": 0
+      },
+      {
+        "self": 349,
+        "parent": 348,
+        "file": "",
+        "name": "(program)",
+        "line": 0,
+        "count": 4183
+      },
+      {
+        "self": 350,
+        "parent": 348,
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194,
+        "count": 1
+      },
+      {
+        "self": 351,
+        "parent": 350,
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130,
+        "count": 0
+      },
+      {
+        "self": 352,
+        "parent": 351,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 353,
+        "parent": 352,
+        "file": "_stream_readable.js",
+        "name": "resume_",
+        "line": 819,
+        "count": 0
+      },
+      {
+        "self": 354,
+        "parent": 353,
+        "file": "_stream_readable.js",
+        "name": "flow",
+        "line": 843,
+        "count": 0
+      },
+      {
+        "self": 355,
+        "parent": 354,
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365,
+        "count": 1
+      },
+      {
+        "self": 356,
+        "parent": 348,
+        "file": "net.js",
+        "name": "afterShutdown",
+        "line": 321,
+        "count": 0
+      },
+      {
+        "self": 357,
+        "parent": 356,
+        "file": "_stream_writable.js",
+        "name": "stream._final",
+        "line": 584,
+        "count": 0
+      },
+      {
+        "self": 358,
+        "parent": 357,
+        "file": "_stream_writable.js",
+        "name": "finishMaybe",
+        "line": 607,
+        "count": 0
+      },
+      {
+        "self": 359,
+        "parent": 358,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 360,
+        "parent": 359,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 361,
+        "parent": 360,
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307,
+        "count": 0
+      },
+      {
+        "self": 362,
+        "parent": 361,
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4,
+        "count": 0
+      },
+      {
+        "self": 363,
+        "parent": 362,
+        "file": "net.js",
+        "name": "Socket._destroy",
+        "line": 541,
+        "count": 1
+      },
+      {
+        "self": 364,
+        "parent": 348,
+        "file": "fs.js",
+        "name": "",
+        "line": 151,
+        "count": 0
+      },
+      {
+        "self": 365,
+        "parent": 364,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 366,
+        "parent": 365,
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770,
+        "count": 0
+      },
+      {
+        "self": 367,
+        "parent": 366,
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606,
+        "count": 0
+      },
+      {
+        "self": 368,
+        "parent": 367,
+        "file": "/app/node_modules/send/index.js",
+        "name": "stream",
+        "line": 789,
+        "count": 0
+      },
+      {
+        "self": 369,
+        "parent": 368,
+        "file": "/app/node_modules/on-finished/index.js",
+        "name": "onFinished",
+        "line": 45,
+        "count": 0
+      },
+      {
+        "self": 370,
+        "parent": 369,
+        "file": "/app/node_modules/on-finished/index.js",
+        "name": "attachListener",
+        "line": 140,
+        "count": 1
+      },
+      {
+        "self": 371,
+        "parent": 368,
+        "file": "_stream_readable.js",
+        "name": "Readable.pipe",
+        "line": 554,
+        "count": 0
+      },
+      {
+        "self": 372,
+        "parent": 371,
+        "file": "_stream_readable.js",
+        "name": "pipeOnDrain",
+        "line": 699,
+        "count": 1
+      },
+      {
+        "self": 373,
+        "parent": 365,
+        "file": "/app/node_modules/send/index.js",
+        "name": "onstat",
+        "line": 721,
+        "count": 0
+      },
+      {
+        "self": 374,
+        "parent": 373,
+        "file": "/app/node_modules/send/index.js",
+        "name": "next",
+        "line": 732,
+        "count": 0
+      },
+      {
+        "self": 375,
+        "parent": 374,
+        "file": "/app/node_modules/send/index.js",
+        "name": "onStatError",
+        "line": 416,
+        "count": 0
+      },
+      {
+        "self": 376,
+        "parent": 375,
+        "file": "/app/node_modules/send/index.js",
+        "name": "error",
+        "line": 267,
+        "count": 0
+      },
+      {
+        "self": 377,
+        "parent": 376,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 378,
+        "parent": 377,
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 379,
+        "parent": 378,
+        "file": "/app/node_modules/serve-static/index.js",
+        "name": "error",
+        "line": 115,
+        "count": 0
+      },
+      {
+        "self": 380,
+        "parent": 379,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 381,
+        "parent": 380,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 644,
+        "count": 0
+      },
+      {
+        "self": 382,
+        "parent": 381,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612,
+        "count": 0
+      },
+      {
+        "self": 383,
+        "parent": 382,
+        "file": "timers.js",
+        "name": "setImmediate",
+        "line": 842,
+        "count": 0
+      },
+      {
+        "self": 384,
+        "parent": 383,
+        "file": "timers.js",
+        "name": "createImmediate",
+        "line": 877,
+        "count": 0
+      },
+      {
+        "self": 385,
+        "parent": 384,
+        "file": "timers.js",
+        "name": "Immediate",
+        "line": 824,
+        "count": 0
+      },
+      {
+        "self": 386,
+        "parent": 385,
+        "file": "domain.js",
+        "name": "get",
+        "line": 43,
+        "count": 1
+      },
+      {
+        "self": 387,
+        "parent": 348,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "events",
+        "line": 238,
+        "count": 0
+      },
+      {
+        "self": 388,
+        "parent": 387,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "raiseEvent",
+        "line": 32,
+        "count": 0
+      },
+      {
+        "self": 389,
+        "parent": 388,
+        "file": "/app/node_modules/appmetrics/appmetrics-api.js",
+        "name": "formatProfiling",
+        "line": 180,
+        "count": 0
+      },
+      {
+        "self": 390,
+        "parent": 389,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 391,
+        "parent": 390,
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 392,
+        "parent": 391,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 277,
+        "count": 0
+      },
+      {
+        "self": 393,
+        "parent": 392,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "Server.(anonymous function)",
+        "line": 504,
+        "count": 0
+      },
+      {
+        "self": 394,
+        "parent": 393,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 79,
+        "count": 0
+      },
+      {
+        "self": 395,
+        "parent": 394,
+        "file": "/app/node_modules/socket.io/lib/namespace.js",
+        "name": "Namespace.emit",
+        "line": 211,
+        "count": 0
+      },
+      {
+        "self": 396,
+        "parent": 395,
+        "file": "/app/node_modules/socket.io-adapter/index.js",
+        "name": "Adapter.broadcast",
+        "line": 122,
+        "count": 0
+      },
+      {
+        "self": 397,
+        "parent": 396,
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "Encoder.encode",
+        "line": 128,
+        "count": 0
+      },
+      {
+        "self": 398,
+        "parent": 397,
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "encodeAsString",
+        "line": 147,
+        "count": 0
+      },
+      {
+        "self": 399,
+        "parent": 398,
+        "file": "/app/node_modules/socket.io-parser/index.js",
+        "name": "tryStringify",
+        "line": 182,
+        "count": 1
+      },
+      {
+        "self": 400,
+        "parent": 348,
+        "file": "timers.js",
+        "name": "unrefdHandle",
+        "line": 608,
+        "count": 1
+      },
+      {
+        "self": 401,
+        "parent": 348,
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62,
+        "count": 0
+      },
+      {
+        "self": 402,
+        "parent": 401,
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596,
+        "count": 0
+      },
+      {
+        "self": 403,
+        "parent": 402,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 404,
+        "parent": 403,
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124,
+        "count": 0
+      },
+      {
+        "self": 405,
+        "parent": 404,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336,
+        "count": 0
+      },
+      {
+        "self": 406,
+        "parent": 405,
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463,
+        "count": 0
+      },
+      {
+        "self": 407,
+        "parent": 406,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 408,
+        "parent": 407,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 409,
+        "parent": 408,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 410,
+        "parent": 409,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 411,
+        "parent": 410,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 412,
+        "parent": 411,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 413,
+        "parent": 412,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 414,
+        "parent": 413,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 415,
+        "parent": 414,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 416,
+        "parent": 415,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 417,
+        "parent": 416,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 418,
+        "parent": 417,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 419,
+        "parent": 418,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 420,
+        "parent": 419,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 421,
+        "parent": 420,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 0
+      },
+      {
+        "self": 422,
+        "parent": 421,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 423,
+        "parent": 422,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 424,
+        "parent": 423,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 425,
+        "parent": 424,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 426,
+        "parent": 425,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 427,
+        "parent": 426,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "defaultMiddleware",
+        "line": 56,
+        "count": 0
+      },
+      {
+        "self": 428,
+        "parent": 427,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 429,
+        "parent": 428,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 430,
+        "parent": 429,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 431,
+        "parent": 430,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 432,
+        "parent": 431,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 433,
+        "parent": 432,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 217,
+        "count": 0
+      },
+      {
+        "self": 434,
+        "parent": 433,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 25,
+        "count": 0
+      },
+      {
+        "self": 435,
+        "parent": 434,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 42,
+        "count": 0
+      },
+      {
+        "self": 436,
+        "parent": 435,
+        "file": "/app/node_modules/appmetrics/lib/probe.js",
+        "name": "Probe.metricsStart",
+        "line": 62,
+        "count": 0
+      },
+      {
+        "self": 437,
+        "parent": 436,
+        "file": "/app/node_modules/appmetrics/lib/timer.js",
+        "name": "exports.start",
+        "line": 33,
+        "count": 0
+      },
+      {
+        "self": 438,
+        "parent": 437,
+        "file": "/app/node_modules/appmetrics/lib/timer.js",
+        "name": "Timer",
+        "line": 18,
+        "count": 1
+      }
+    ],
+    "time": 1589367964296
+  },
+  {
+    "date": 0,
+    "functions": [
+      {
+        "self": 439,
+        "parent": 0,
+        "file": "",
+        "name": "(root)",
+        "line": 0,
+        "count": 0
+      },
+      {
+        "self": 440,
+        "parent": 439,
+        "file": "",
+        "name": "(program)",
+        "line": 0,
+        "count": 4170
+      },
+      {
+        "self": 441,
+        "parent": 439,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 442,
+        "parent": 441,
+        "file": "net.js",
+        "name": "onconnection",
+        "line": 1539,
+        "count": 0
+      },
+      {
+        "self": 443,
+        "parent": 442,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 444,
+        "parent": 443,
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 445,
+        "parent": 444,
+        "file": "_http_server.js",
+        "name": "connectionListener",
+        "line": 312,
+        "count": 0
+      },
+      {
+        "self": 446,
+        "parent": 445,
+        "file": "internal/async_hooks.js",
+        "name": "defaultTriggerAsyncIdScope",
+        "line": 273,
+        "count": 0
+      },
+      {
+        "self": 447,
+        "parent": 446,
+        "file": "_http_server.js",
+        "name": "connectionListenerInternal",
+        "line": 318,
+        "count": 0
+      },
+      {
+        "self": 448,
+        "parent": 447,
+        "file": "internal/http.js",
+        "name": "nowDate",
+        "line": 8,
+        "count": 0
+      },
+      {
+        "self": 449,
+        "parent": 448,
+        "file": "internal/http.js",
+        "name": "cache",
+        "line": 18,
+        "count": 0
+      },
+      {
+        "self": 450,
+        "parent": 449,
+        "file": "timers.js",
+        "name": "exports._unrefActive",
+        "line": 157,
+        "count": 0
+      },
+      {
+        "self": 451,
+        "parent": 450,
+        "file": "timers.js",
+        "name": "insert",
+        "line": 167,
+        "count": 0
+      },
+      {
+        "self": 452,
+        "parent": 451,
+        "file": "timers.js",
+        "name": "createTimersList",
+        "line": 196,
+        "count": 1
+      },
+      {
+        "self": 453,
+        "parent": 439,
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194,
+        "count": 0
+      },
+      {
+        "self": 454,
+        "parent": 453,
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130,
+        "count": 0
+      },
+      {
+        "self": 455,
+        "parent": 454,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 456,
+        "parent": 455,
+        "file": "_stream_readable.js",
+        "name": "endReadableNT",
+        "line": 1059,
+        "count": 0
+      },
+      {
+        "self": 457,
+        "parent": 456,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 458,
+        "parent": 457,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 459,
+        "parent": 458,
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307,
+        "count": 0
+      },
+      {
+        "self": 460,
+        "parent": 459,
+        "file": "_stream_readable.js",
+        "name": "onend",
+        "line": 593,
+        "count": 0
+      },
+      {
+        "self": 461,
+        "parent": 460,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 100,
+        "count": 0
+      },
+      {
+        "self": 462,
+        "parent": 461,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 52,
+        "count": 0
+      },
+      {
+        "self": 463,
+        "parent": 462,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "HttpProbe.metricsEnd",
+        "line": 102,
+        "count": 0
+      },
+      {
+        "self": 464,
+        "parent": 463,
+        "file": "/app/node_modules/appmetrics/index.js",
+        "name": "module.exports.emit",
+        "line": 279,
+        "count": 0
+      },
+      {
+        "self": 465,
+        "parent": 464,
+        "file": "",
+        "name": "getObjectHistogram",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 466,
+        "parent": 455,
+        "file": "_stream_writable.js",
+        "name": "afterWrite",
+        "line": 459,
+        "count": 0
+      },
+      {
+        "self": 467,
+        "parent": 466,
+        "file": "_stream_writable.js",
+        "name": "onCorkedFinish",
+        "line": 632,
+        "count": 0
+      },
+      {
+        "self": 468,
+        "parent": 467,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "onEnd",
+        "line": 117,
+        "count": 0
+      },
+      {
+        "self": 469,
+        "parent": 468,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 470,
+        "parent": 469,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 471,
+        "parent": 470,
+        "file": "/app/node_modules/engine.io/lib/socket.js",
+        "name": "Socket.flush",
+        "line": 416,
+        "count": 0
+      },
+      {
+        "self": 472,
+        "parent": 471,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "WebSocket.send",
+        "line": 89,
+        "count": 0
+      },
+      {
+        "self": 473,
+        "parent": 472,
+        "file": "/app/node_modules/engine.io-parser/lib/index.js",
+        "name": "exports.encodePacket",
+        "line": 55,
+        "count": 0
+      },
+      {
+        "self": 474,
+        "parent": 473,
+        "file": "/app/node_modules/engine.io/lib/transports/websocket.js",
+        "name": "send",
+        "line": 97,
+        "count": 0
+      },
+      {
+        "self": 475,
+        "parent": 474,
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "send",
+        "line": 326,
+        "count": 0
+      },
+      {
+        "self": 476,
+        "parent": 475,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "send",
+        "line": 252,
+        "count": 0
+      },
+      {
+        "self": 477,
+        "parent": 476,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "dispatch",
+        "line": 313,
+        "count": 0
+      },
+      {
+        "self": 478,
+        "parent": 477,
+        "file": "/app/node_modules/ws/lib/sender.js",
+        "name": "sendFrame",
+        "line": 378,
+        "count": 0
+      },
+      {
+        "self": 479,
+        "parent": 478,
+        "file": "_stream_writable.js",
+        "name": "Writable.uncork",
+        "line": 302,
+        "count": 0
+      },
+      {
+        "self": 480,
+        "parent": 479,
+        "file": "_stream_writable.js",
+        "name": "clearBuffer",
+        "line": 478,
+        "count": 0
+      },
+      {
+        "self": 481,
+        "parent": 480,
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388,
+        "count": 0
+      },
+      {
+        "self": 482,
+        "parent": 481,
+        "file": "net.js",
+        "name": "Socket._writev",
+        "line": 781,
+        "count": 0
+      },
+      {
+        "self": 483,
+        "parent": 482,
+        "file": "net.js",
+        "name": "Socket._writeGeneric",
+        "line": 715,
+        "count": 0
+      },
+      {
+        "self": 484,
+        "parent": 483,
+        "file": "",
+        "name": "writev",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 485,
+        "parent": 455,
+        "file": "_stream_readable.js",
+        "name": "resume_",
+        "line": 819,
+        "count": 0
+      },
+      {
+        "self": 486,
+        "parent": 485,
+        "file": "_http_incoming.js",
+        "name": "read",
+        "line": 93,
+        "count": 0
+      },
+      {
+        "self": 487,
+        "parent": 486,
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365,
+        "count": 0
+      },
+      {
+        "self": 488,
+        "parent": 487,
+        "file": "_stream_readable.js",
+        "name": "endReadable",
+        "line": 1045,
+        "count": 0
+      },
+      {
+        "self": 489,
+        "parent": 488,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 626,
+        "count": 0
+      },
+      {
+        "self": 490,
+        "parent": 489,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "fallback",
+        "line": 612,
+        "count": 0
+      },
+      {
+        "self": 491,
+        "parent": 490,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "wrapCallback",
+        "line": 391,
+        "count": 0
+      },
+      {
+        "self": 492,
+        "parent": 491,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "asyncWrap",
+        "line": 137,
+        "count": 1
+      },
+      {
+        "self": 493,
+        "parent": 453,
+        "file": "internal/process/promises.js",
+        "name": "emitPendingUnhandledRejections",
+        "line": 100,
+        "count": 1
+      },
+      {
+        "self": 494,
+        "parent": 439,
+        "file": "fs.js",
+        "name": "",
+        "line": 151,
+        "count": 0
+      },
+      {
+        "self": 495,
+        "parent": 494,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 496,
+        "parent": 495,
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770,
+        "count": 0
+      },
+      {
+        "self": 497,
+        "parent": 496,
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606,
+        "count": 0
+      },
+      {
+        "self": 498,
+        "parent": 497,
+        "file": "_http_outgoing.js",
+        "name": "setHeader",
+        "line": 497,
+        "count": 0
+      },
+      {
+        "self": 499,
+        "parent": 498,
+        "file": "_http_outgoing.js",
+        "name": "validateHeader",
+        "line": 485,
+        "count": 0
+      },
+      {
+        "self": 500,
+        "parent": 499,
+        "file": "_http_common.js",
+        "name": "checkIsHttpToken",
+        "line": 281,
+        "count": 1
+      },
+      {
+        "self": 501,
+        "parent": 439,
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62,
+        "count": 0
+      },
+      {
+        "self": 502,
+        "parent": 501,
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596,
+        "count": 0
+      },
+      {
+        "self": 503,
+        "parent": 502,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 504,
+        "parent": 503,
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124,
+        "count": 0
+      },
+      {
+        "self": 505,
+        "parent": 504,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336,
+        "count": 0
+      },
+      {
+        "self": 506,
+        "parent": 505,
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463,
+        "count": 0
+      },
+      {
+        "self": 507,
+        "parent": 506,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 508,
+        "parent": 507,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 509,
+        "parent": 508,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 510,
+        "parent": 509,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 511,
+        "parent": 510,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 512,
+        "parent": 511,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 513,
+        "parent": 512,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 514,
+        "parent": 513,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 515,
+        "parent": 514,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 516,
+        "parent": 515,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 517,
+        "parent": 516,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 518,
+        "parent": 517,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 519,
+        "parent": 518,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 520,
+        "parent": 519,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 521,
+        "parent": 520,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 1
+      },
+      {
+        "self": 522,
+        "parent": 439,
+        "file": "timers.js",
+        "name": "listOnTimeout",
+        "line": 231,
+        "count": 1
+      },
+      {
+        "self": 523,
+        "parent": 439,
+        "file": "fs.js",
+        "name": "wrapper",
+        "line": 656,
+        "count": 0
+      },
+      {
+        "self": 524,
+        "parent": 523,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 525,
+        "parent": 524,
+        "file": "fs.js",
+        "name": "fs.read",
+        "line": 2046,
+        "count": 0
+      },
+      {
+        "self": 526,
+        "parent": 525,
+        "file": "_stream_readable.js",
+        "name": "Readable.push",
+        "line": 191,
+        "count": 0
+      },
+      {
+        "self": 527,
+        "parent": 526,
+        "file": "_stream_readable.js",
+        "name": "readableAddChunk",
+        "line": 216,
+        "count": 0
+      },
+      {
+        "self": 528,
+        "parent": 527,
+        "file": "_stream_readable.js",
+        "name": "addChunk",
+        "line": 261,
+        "count": 0
+      },
+      {
+        "self": 529,
+        "parent": 528,
+        "file": "_stream_readable.js",
+        "name": "Readable.read",
+        "line": 365,
+        "count": 0
+      },
+      {
+        "self": 530,
+        "parent": 529,
+        "file": "fs.js",
+        "name": "ReadStream._read",
+        "line": 2013,
+        "count": 0
+      },
+      {
+        "self": 531,
+        "parent": 530,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 600,
+        "count": 0
+      },
+      {
+        "self": 532,
+        "parent": 531,
+        "file": "fs.js",
+        "name": "fs.read",
+        "line": 649,
+        "count": 0
+      },
+      {
+        "self": 533,
+        "parent": 532,
+        "file": "",
+        "name": "read",
+        "line": 0,
+        "count": 1
+      }
+    ],
+    "time": 1589367969296
+  },
+  {
+    "date": 0,
+    "functions": [
+      {
+        "self": 534,
+        "parent": 0,
+        "file": "",
+        "name": "(root)",
+        "line": 0,
+        "count": 0
+      },
+      {
+        "self": 535,
+        "parent": 534,
+        "file": "",
+        "name": "(program)",
+        "line": 0,
+        "count": 4170
+      },
+      {
+        "self": 536,
+        "parent": 534,
+        "file": "internal/process/next_tick.js",
+        "name": "_tickDomainCallback",
+        "line": 194,
+        "count": 0
+      },
+      {
+        "self": 537,
+        "parent": 536,
+        "file": "internal/process/next_tick.js",
+        "name": "_combinedTickCallback",
+        "line": 130,
+        "count": 0
+      },
+      {
+        "self": 538,
+        "parent": 537,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 539,
+        "parent": 538,
+        "file": "_stream_readable.js",
+        "name": "endReadableNT",
+        "line": 1059,
+        "count": 0
+      },
+      {
+        "self": 540,
+        "parent": 539,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 541,
+        "parent": 540,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 542,
+        "parent": 541,
+        "file": "events.js",
+        "name": "onceWrapper",
+        "line": 307,
+        "count": 0
+      },
+      {
+        "self": 543,
+        "parent": 542,
+        "file": "_stream_readable.js",
+        "name": "onend",
+        "line": 593,
+        "count": 0
+      },
+      {
+        "self": 544,
+        "parent": 543,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "newFunc",
+        "line": 100,
+        "count": 0
+      },
+      {
+        "self": 545,
+        "parent": 544,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "",
+        "line": 52,
+        "count": 0
+      },
+      {
+        "self": 546,
+        "parent": 545,
+        "file": "/app/node_modules/appmetrics/probes/http-probe.js",
+        "name": "HttpProbe.metricsEnd",
+        "line": 102,
+        "count": 0
+      },
+      {
+        "self": 547,
+        "parent": 546,
+        "file": "/app/node_modules/appmetrics/index.js",
+        "name": "module.exports.emit",
+        "line": 279,
+        "count": 0
+      },
+      {
+        "self": 548,
+        "parent": 547,
+        "file": "",
+        "name": "getObjectHistogram",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 549,
+        "parent": 541,
+        "file": "fs.js",
+        "name": "",
+        "line": 1985,
+        "count": 0
+      },
+      {
+        "self": 550,
+        "parent": 549,
+        "file": "internal/streams/destroy.js",
+        "name": "destroy",
+        "line": 4,
+        "count": 1
+      },
+      {
+        "self": 551,
+        "parent": 538,
+        "file": "_stream_readable.js",
+        "name": "resume_",
+        "line": 819,
+        "count": 0
+      },
+      {
+        "self": 552,
+        "parent": 551,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 1
+      },
+      {
+        "self": 553,
+        "parent": 537,
+        "file": "_http_outgoing.js",
+        "name": "onFinish",
+        "line": 719,
+        "count": 0
+      },
+      {
+        "self": 554,
+        "parent": 553,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 555,
+        "parent": 554,
+        "file": "events.js",
+        "name": "emitNone",
+        "line": 104,
+        "count": 0
+      },
+      {
+        "self": 556,
+        "parent": 555,
+        "file": "/app/node_modules/pino-http/logger.js",
+        "name": "onResFinished",
+        "line": 58,
+        "count": 0
+      },
+      {
+        "self": 557,
+        "parent": 556,
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "LOG",
+        "line": 30,
+        "count": 0
+      },
+      {
+        "self": 558,
+        "parent": 557,
+        "file": "/app/node_modules/pino/lib/proto.js",
+        "name": "write",
+        "line": 122,
+        "count": 0
+      },
+      {
+        "self": 559,
+        "parent": 558,
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "asJson",
+        "line": 73,
+        "count": 0
+      },
+      {
+        "self": 560,
+        "parent": 559,
+        "file": "/app/node_modules/pino/lib/tools.js",
+        "name": "stringify",
+        "line": 358,
+        "count": 1
+      },
+      {
+        "self": 561,
+        "parent": 534,
+        "file": "timers.js",
+        "name": "listOnTimeout",
+        "line": 231,
+        "count": 1
+      },
+      {
+        "self": 562,
+        "parent": 561,
+        "file": "",
+        "name": "now",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 563,
+        "parent": 534,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 564,
+        "parent": 563,
+        "file": "net.js",
+        "name": "onconnection",
+        "line": 1539,
+        "count": 0
+      },
+      {
+        "self": 565,
+        "parent": 564,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 566,
+        "parent": 565,
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 567,
+        "parent": 566,
+        "file": "_http_server.js",
+        "name": "connectionListener",
+        "line": 312,
+        "count": 0
+      },
+      {
+        "self": 568,
+        "parent": 567,
+        "file": "internal/async_hooks.js",
+        "name": "defaultTriggerAsyncIdScope",
+        "line": 273,
+        "count": 0
+      },
+      {
+        "self": 569,
+        "parent": 568,
+        "file": "_http_server.js",
+        "name": "connectionListenerInternal",
+        "line": 318,
+        "count": 1
+      },
+      {
+        "self": 570,
+        "parent": 563,
+        "file": "net.js",
+        "name": "onread",
+        "line": 583,
+        "count": 0
+      },
+      {
+        "self": 571,
+        "parent": 570,
+        "file": "_stream_readable.js",
+        "name": "Readable.push",
+        "line": 191,
+        "count": 0
+      },
+      {
+        "self": 572,
+        "parent": 571,
+        "file": "_stream_readable.js",
+        "name": "readableAddChunk",
+        "line": 216,
+        "count": 0
+      },
+      {
+        "self": 573,
+        "parent": 572,
+        "file": "_stream_readable.js",
+        "name": "addChunk",
+        "line": 261,
+        "count": 0
+      },
+      {
+        "self": 574,
+        "parent": 573,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 575,
+        "parent": 574,
+        "file": "events.js",
+        "name": "emitOne",
+        "line": 114,
+        "count": 0
+      },
+      {
+        "self": 576,
+        "parent": 575,
+        "file": "/app/node_modules/ws/lib/websocket.js",
+        "name": "socketOnData",
+        "line": 875,
+        "count": 0
+      },
+      {
+        "self": 577,
+        "parent": 576,
+        "file": "_stream_writable.js",
+        "name": "Writable.write",
+        "line": 264,
+        "count": 0
+      },
+      {
+        "self": 578,
+        "parent": 577,
+        "file": "_stream_writable.js",
+        "name": "writeOrBuffer",
+        "line": 348,
+        "count": 0
+      },
+      {
+        "self": 579,
+        "parent": 578,
+        "file": "_stream_writable.js",
+        "name": "doWrite",
+        "line": 388,
+        "count": 0
+      },
+      {
+        "self": 580,
+        "parent": 579,
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "_write",
+        "line": 72,
+        "count": 0
+      },
+      {
+        "self": 581,
+        "parent": 580,
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "startLoop",
+        "line": 123,
+        "count": 0
+      },
+      {
+        "self": 582,
+        "parent": 581,
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "getData",
+        "line": 336,
+        "count": 0
+      },
+      {
+        "self": 583,
+        "parent": 582,
+        "file": "/app/node_modules/ws/lib/receiver.js",
+        "name": "dataMessage",
+        "line": 406,
+        "count": 0
+      },
+      {
+        "self": 584,
+        "parent": 583,
+        "file": "buffer.js",
+        "name": "Buffer.toString",
+        "line": 609,
+        "count": 1
+      },
+      {
+        "self": 585,
+        "parent": 534,
+        "file": "",
+        "name": "(garbage collector)",
+        "line": 0,
+        "count": 1
+      },
+      {
+        "self": 586,
+        "parent": 534,
+        "file": "fs.js",
+        "name": "",
+        "line": 151,
+        "count": 0
+      },
+      {
+        "self": 587,
+        "parent": 586,
+        "file": "/app/node_modules/async-listener/glue.js",
+        "name": "",
+        "line": 162,
+        "count": 0
+      },
+      {
+        "self": 588,
+        "parent": 587,
+        "file": "/app/node_modules/send/index.js",
+        "name": "",
+        "line": 770,
+        "count": 0
+      },
+      {
+        "self": 589,
+        "parent": 588,
+        "file": "/app/node_modules/send/index.js",
+        "name": "send",
+        "line": 606,
+        "count": 0
+      },
+      {
+        "self": 590,
+        "parent": 589,
+        "file": "/app/node_modules/send/index.js",
+        "name": "stream",
+        "line": 789,
+        "count": 0
+      },
+      {
+        "self": 591,
+        "parent": 590,
+        "file": "fs.js",
+        "name": "fs.createReadStream",
+        "line": 1930,
+        "count": 0
+      },
+      {
+        "self": 592,
+        "parent": 591,
+        "file": "fs.js",
+        "name": "ReadStream",
+        "line": 1937,
+        "count": 0
+      },
+      {
+        "self": 593,
+        "parent": 592,
+        "file": "fs.js",
+        "name": "ReadStream.open",
+        "line": 1994,
+        "count": 0
+      },
+      {
+        "self": 594,
+        "parent": 593,
+        "file": "/app/node_modules/async-listener/index.js",
+        "name": "",
+        "line": 588,
+        "count": 1
+      },
+      {
+        "self": 595,
+        "parent": 534,
+        "file": "_http_common.js",
+        "name": "parserOnHeadersComplete",
+        "line": 62,
+        "count": 0
+      },
+      {
+        "self": 596,
+        "parent": 595,
+        "file": "_http_server.js",
+        "name": "parserOnIncoming",
+        "line": 596,
+        "count": 0
+      },
+      {
+        "self": 597,
+        "parent": 596,
+        "file": "events.js",
+        "name": "emit",
+        "line": 156,
+        "count": 0
+      },
+      {
+        "self": 598,
+        "parent": 597,
+        "file": "events.js",
+        "name": "emitTwo",
+        "line": 124,
+        "count": 0
+      },
+      {
+        "self": 599,
+        "parent": 598,
+        "file": "/app/node_modules/socket.io/lib/index.js",
+        "name": "",
+        "line": 336,
+        "count": 0
+      },
+      {
+        "self": 600,
+        "parent": 599,
+        "file": "/app/node_modules/engine.io/lib/server.js",
+        "name": "",
+        "line": 463,
+        "count": 0
+      },
+      {
+        "self": 601,
+        "parent": 600,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 602,
+        "parent": 601,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 603,
+        "parent": 602,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 604,
+        "parent": 603,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 605,
+        "parent": 604,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 606,
+        "parent": 605,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 607,
+        "parent": 606,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 608,
+        "parent": 607,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 609,
+        "parent": 608,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 610,
+        "parent": 609,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 611,
+        "parent": 610,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 612,
+        "parent": 611,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 613,
+        "parent": 612,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 614,
+        "parent": 613,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 615,
+        "parent": 614,
+        "file": "/app/node_modules/express/lib/middleware/init.js",
+        "name": "expressInit",
+        "line": 29,
+        "count": 0
+      },
+      {
+        "self": 616,
+        "parent": 615,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 617,
+        "parent": 616,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 618,
+        "parent": 617,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 619,
+        "parent": 618,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 620,
+        "parent": 619,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 621,
+        "parent": 620,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "defaultMiddleware",
+        "line": 56,
+        "count": 0
+      },
+      {
+        "self": 622,
+        "parent": 621,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 623,
+        "parent": 622,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 624,
+        "parent": 623,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 625,
+        "parent": 624,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 626,
+        "parent": 625,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 627,
+        "parent": 626,
+        "file": "/app/node_modules/appmetrics-dash/lib/appmetrics-dash.js",
+        "name": "",
+        "line": 217,
+        "count": 0
+      },
+      {
+        "self": 628,
+        "parent": 627,
+        "file": "/app/node_modules/appmetrics/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 25,
+        "count": 0
+      },
+      {
+        "self": 629,
+        "parent": 628,
+        "file": "/app/node_modules/ibmapm-embed/appmetrics-zipkin/lib/aspect.js",
+        "name": "args.(anonymous function)",
+        "line": 26,
+        "count": 0
+      },
+      {
+        "self": 630,
+        "parent": 629,
+        "file": "/app/node_modules/express/lib/express.js",
+        "name": "app",
+        "line": 38,
+        "count": 0
+      },
+      {
+        "self": 631,
+        "parent": 630,
+        "file": "/app/node_modules/express/lib/application.js",
+        "name": "handle",
+        "line": 158,
+        "count": 0
+      },
+      {
+        "self": 632,
+        "parent": 631,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "handle",
+        "line": 136,
+        "count": 0
+      },
+      {
+        "self": 633,
+        "parent": 632,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 634,
+        "parent": 633,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 0
+      },
+      {
+        "self": 635,
+        "parent": 634,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "",
+        "line": 275,
+        "count": 0
+      },
+      {
+        "self": 636,
+        "parent": 635,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "trim_prefix",
+        "line": 288,
+        "count": 0
+      },
+      {
+        "self": 637,
+        "parent": 636,
+        "file": "/app/node_modules/express/lib/router/layer.js",
+        "name": "handle",
+        "line": 86,
+        "count": 0
+      },
+      {
+        "self": 638,
+        "parent": 637,
+        "file": "/app/node_modules/express/lib/middleware/query.js",
+        "name": "query",
+        "line": 39,
+        "count": 0
+      },
+      {
+        "self": 639,
+        "parent": 638,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "next",
+        "line": 176,
+        "count": 0
+      },
+      {
+        "self": 640,
+        "parent": 639,
+        "file": "/app/node_modules/express/lib/router/index.js",
+        "name": "process_params",
+        "line": 327,
+        "count": 1
+      }
+    ],
+    "time": 1589367974296
+  }
+]

--- a/test/src/unit/script/summariseNodeProfiles.test.js
+++ b/test/src/unit/script/summariseNodeProfiles.test.js
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+*******************************************************************************/
+const chai = require('chai');
+const fs = require('fs-extra');
+const path = require('path');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
+
+const { testTimeout, TEMP_TEST_DIR } = require('../../../config');
+
+const sampleInputFiles = {
+    'Node.js': {
+        input: path.join(__dirname, 'node-cw-profile.json'),
+        expected: path.join(__dirname, 'node-cw-profile-summary.json'),
+    },
+};
+const scriptPath = path.join(__dirname, '../../../../src/pfe/portal/scripts/summariseProfile.js');
+
+chai.should();
+
+describe('summariseProfile.js', () => {
+    
+    after(async function() {
+        this.timeout(testTimeout.med);
+        for (const language in sampleInputFiles) {
+            const outputFile = path.join(TEMP_TEST_DIR, `${language}-summary-output.json`);
+            await fs.remove(outputFile);
+        }
+    });
+
+    for (const language in sampleInputFiles) {
+        const sampleInputFile = sampleInputFiles[language].input;
+        const expectedOutputFile = sampleInputFiles[language].expected;
+        it(`Summarise data for a ${language} profile`, async function() { // eslint-disable-line no-loop-func
+            this.timeout(testTimeout.short);
+            const outputFile = path.join(TEMP_TEST_DIR, `${language}-summary-output.json`);
+            const mergeCommand = `${process.execPath} ${scriptPath} ${sampleInputFile} ${outputFile}`;
+            await exec(mergeCommand);
+
+            const actual = await fs.readJson(outputFile);
+            const expected = await fs.readJson(expectedOutputFile);
+
+            actual.should.deep.equal(expected);
+        });
+    }
+});


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?

 - Adds profiling rest APIs to allow the UI to run JSONPath queries against our profiling data.
 - Adds post processing scripts for node profiling data.
 - Invokes post processing after profiling is complete.
 - Adds tests and test data.

The REST API's use POST rather than GET as GET requests are not expected to have a body. Proxy's between PFE and the user may drop the body from a GET request. (And the bug would be ours to fix.) An alternative would be to pass the JSONPath query in the query field of the URL but that may be ugly as it will contain many special characters.

## Which issue(s) does this PR fix ?
This is the first part of implementing:
https://github.com/eclipse/codewind/issues/2506

The next part will be adding the ability to post process Java profiling data (in .hcd) files to the standard format we will be using so the UI can work with 

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2506

## Does this PR require a documentation change ?
No - the openapi.yml for our REST API changes but we do not expect users to interact directly with this feature.

## Any special notes for your reviewer ?
