### PR TITLE
[0.12.0] Only update metric status when project starts or stops

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -527,11 +527,16 @@ module.exports = class FileWatcher {
         results.error = error;
       }
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
-      try {
-        // If updating the metrics fails, don't stop the status being emitted to the UI
-        await updatedProject.setMetricsState();
-      } catch(setMetricsStateErr) {
-        log.warn(`error updating the metrics state for ${updatedProject.name}, Error: ${setMetricsStateErr}`);
+
+      const { appStatus } = updatedProject;
+      // Only update metrics state when the project is running or stopped
+      if (appStatus === 'started' || appStatus === 'stopped') {
+        try {
+          // If updating the metrics fails, don't stop the status being emitted to the UI
+          await updatedProject.setMetricsState();
+        } catch(setMetricsStateErr) {
+          log.warn(`error updating the metrics state for ${updatedProject.name}, Error: ${setMetricsStateErr}`);
+        }
       }
 
       // remove fields which are not required by the UI


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Ports https://github.com/eclipse/codewind/pull/2912 to 0.12.0

**Original PR summary**
* When we receive a project status change from the file-watcher, only check if metrics availability if the project is either started or stopped (not starting or stopping).
  * This means we're making less requests to the projects - when doing a load test described in the issue we receive lots of starting messages.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2937
Related (Master): https://github.com/eclipse/codewind/issues/2900

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
