### PR TITLE
Fix failing test due to order changes.

### DIFF
--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -274,7 +274,7 @@ describe('Templates.js', function() {
                 });
                 it(`returns ['Codewind', 'Appsody']`, async function() {
                     const output = await templateController.getAllTemplateStyles();
-                    output.should.deep.equal(['Codewind', 'Appsody']);
+                    output.should.deep.equalInAnyOrder(['Codewind', 'Appsody']);
                 });
             });
         });


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes the failing test for `getAllTemplateStyles()`
The order of the array should not be significant so this change just uses equalInAnyOrder to compare the two arrays.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2970

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/2970

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No