### PR TITLE
Multiple Load Tests

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -541,7 +541,7 @@ module.exports = class FileWatcher {
       }
 
       // remove fields which are not required by the UI
-      const { logStreams, ...projectInfoForUI } = updatedProject
+      const projectInfoForUI = updatedProject.toJSON()
       this.user.uiSocket.emit(event, { ...results, ...projectInfoForUI })
       if (fwProject.buildStatus === 'inProgress') {
         // Reset build logs.
@@ -580,7 +580,7 @@ module.exports = class FileWatcher {
     // (Storing the status in the project object is bad as it is
     // only about this close operation.)
     // remove fields which are not required by the UI
-    const { logStreams, ...projectInfoForUI } = updatedProject
+    const projectInfoForUI = updatedProject.toJSON()
     this.user.uiSocket.emit('projectClosed', {...projectInfoForUI, status: fwProject.status});
     log.debug(`project ${fwProject.projectID} successfully closed`);
   }

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -27,6 +27,7 @@ const Logger = require('./utils/Logger');
 const LogStream = require('./LogStream');
 const metricsService = require('./metricsService');
 const Links = require('./project/Links');
+const LoadRunner = require('./LoadRunner');
 
 const log = new Logger(__filename);
 
@@ -129,6 +130,8 @@ module.exports = class Project {
     this.links = new Links(this.projectPath(), args.links);
 
     this.perfDashboardPath = `/performance/charts?project=${this.projectID}`;
+    log.debug(`Creating LoadRunner for project ${this.projectID}`);
+    this.loadRunner = new LoadRunner(this);
   }
 
 
@@ -302,7 +305,7 @@ module.exports = class Project {
   toJSON() {
     // Strip out fields we don't want to attempt to turn into JSON.
     // (This is our guard against trying to write circular references.)
-    const { logStreams, loadInProgress, loadConfig, operation, ...filteredProject } = this;
+    const { logStreams, loadInProgress, loadConfig, operation, loadRunner, ...filteredProject } = this;
     return filteredProject;
   }
 

--- a/src/pfe/portal/modules/User.js
+++ b/src/pfe/portal/modules/User.js
@@ -14,7 +14,6 @@ const path = require('path');
 const crypto = require('crypto');
 const ProjectList = require('./ProjectList');
 const FileWatcher = require('./FileWatcher');
-const LoadRunner = require('./LoadRunner');
 const Project = require('./Project');
 const ExtensionList = require('./ExtensionList');
 const Templates = require('./Templates');
@@ -60,6 +59,7 @@ module.exports = class User {
     if (global.codewind.RUNNING_IN_K8S == true) {
       this.k8Client = global.codewind.k8Client;
     }
+    this.cancelRequests = {};
   }
 
   /**
@@ -134,8 +134,6 @@ module.exports = class User {
       // Create the FileWatcher and LoadRunner classes for this user
       log.debug(`Creating FileWatcher for user ${this.user_id}`);
       this.fw = new FileWatcher(this);
-      log.debug(`Creating LoadRunner for user ${this.user_id}`);
-      this.loadRunner = new LoadRunner(this);
       this.fw.setLocale(["en"]);
       log.info(`Starting existing projects for user ${this.user_id}`)
       this.startExistingProjects();
@@ -149,9 +147,6 @@ module.exports = class User {
    * Function to run load on project
    */
   async runLoad(project, description) {
-    log.info("runLoad: project " + project.projectID + " loadInProgress was =" + project.loadInProgress);
-    project.loadInProgress = true;
-    log.info("runLoad: project " + project.projectID + " loadInProgress now =" + project.loadInProgress);
     try {
       let config = await project.getLoadTestConfig();
 
@@ -169,12 +164,11 @@ module.exports = class User {
       config.url = `${projectProtocol}${projectHost}:${projectPort}${config.path}`;
       project.loadConfig = config;
       log.info(`Requesting load on project: ${project.projectID} config: ${JSON.stringify(config)}`);
-      const runLoadResp = await this.loadRunner.runLoad(config, project, description);
+      const runLoadResp = await project.loadRunner.runLoad(config, this, description);
       return runLoadResp;
     } catch (err) {
       // Reset run load flag and config in the project, and re-throw the error
       project.loadConfig = null;
-      project.loadInProgress = false;
       throw err;
     }
   }
@@ -184,31 +178,32 @@ module.exports = class User {
    */
   async cancelLoad(project) {
     log.debug("cancelLoad: project " + project.projectID + " loadInProgress=" + project.loadInProgress);
-    if (project.loadInProgress) {
+    if (this.cancelRequests[project.projectID]) {
+      throw new Error("Cancel request already in progress.");
+    }
+    if (!project.loadRunner.isIdle()) {
       log.debug("Cancelling load for config: " + JSON.stringify(project.loadConfig));
+      this.cancelRequests[project.projectID] = true;
       const res = await retry((bail, number) => {
-        log.info(`Attempting to cancel load run. Attempt ${number}/30`);
-        this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelling' });
+        log.info(`Attempting to cancel load run. Attempt ${number}/10`);
         return this.callCancelRunLoad(project)
-          .catch(function (err) {
+          .catch(err => {
             if (err.code !== "CANCEL_RUN_LOAD_ERROR") {
+              this.cancelRequests[project.projectID] = false;
               bail(err); 
             } else {
-              this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelled' });
               throw err;
             }
           });
       }, {
-        retries: 30,
-        minTimeout: 1000,
-        maxTimeout: 1000,
+        retries: 10,
+        minTimeout: 3000,
+        maxTimeout: 3000,
       });
       project.loadInProgress = false;
-      this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelled' });
+      this.cancelRequests[project.projectID] = false;
       return res;
     }
-    
-    this.uiSocket.emit('runloadStatusChanged', { projectID: project.projectID, status: 'cancelled' });
     throw new LoadRunError("NO_RUN_IN_PROGRESS", `For project ${project.projectID}`);
   }
 
@@ -218,7 +213,7 @@ module.exports = class User {
   async callCancelRunLoad(project) {
     let cancelLoadResp
     try {
-      cancelLoadResp = await this.loadRunner.cancelRunLoad(project.loadConfig); 
+      cancelLoadResp = await project.loadRunner.cancelRunLoad(project.loadConfig); 
     } catch (error) {
       throw error;
     }

--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -337,7 +337,7 @@ function getMode(project) {
 async function syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID) {
   // If the current project is being built, we do not want to copy the files as this will
   // interfere with the current build
-  if (project.buildStatus != "inProgress") {
+  if (project.buildStatus != "inProgress" && project.loadRunner.isIdle()) {
     const globalProjectPath = project.projectPath();
     // We now need to remove any files that have been deleted from the global workspace
     await Promise.all(filesToDelete.map(oldFile => cwUtils.forceRemove(path.join(globalProjectPath, oldFile))));
@@ -388,7 +388,7 @@ async function syncToBuildContainer(project, filesToDelete, modifiedList, timeSt
     }
     user.fileChanged(projectID, timeStamp, 1, 1, IFileChangeEvent);
   } else {
-    // if a build is in progress, wait 5 seconds and try again
+    // if a build or loadrun is in progress, wait 5 seconds and try again
     await cwUtils.timeout(5000)
     await syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID);
   }

--- a/src/pfe/portal/routes/projects/build.route.js
+++ b/src/pfe/portal/routes/projects/build.route.js
@@ -36,8 +36,8 @@ async function buildProject(req, res) {
       return;
     }
     
-    if (project.isClosed() || project.isClosing() || project.isDeleting()) {
-      const msg = `Cannot perform build action ${action} on ${project.name} because it is in state ${project.state}.`;
+    if (project.isClosed() || project.isClosing() || project.isDeleting() || !project.loadRunner.isIdle()) {
+      const msg = `Cannot perform build action ${action} on ${project.name} because it is in state ${project.state}. Or a load run is in progress.`;
       res.status(400).send(msg);
       log.error(msg);
       return;

--- a/src/pfe/portal/routes/projects/loadtest.route.js
+++ b/src/pfe/portal/routes/projects/loadtest.route.js
@@ -49,12 +49,14 @@ router.post('/api/v1/projects/:id/loadtest', validateReq, async function(req,res
       return;
     }
 
-    log.info(`LoadTest route: loadInProgress= ${project.loadInProgress}`);
-    if (project.loadInProgress == true) {
+    log.info(`LoadTest route: isIdle= ${!project.loadRunner.isIdle()}`);
+    if (!project.loadRunner.isIdle()) {
       const err = new LoadRunError("RUN_IN_PROGRESS", `For project ${project.projectID}`);
       res.status(409).send(err.info || err);
       return;
     }
+    
+    res.status(202).send("");
 
     try {
       await user.runLoad(project, description);
@@ -66,7 +68,6 @@ router.post('/api/v1/projects/:id/loadtest', validateReq, async function(req,res
       }
       res.status(500).send(err.info || err);
     }
-    res.status(202).send("");
   }
 });
 

--- a/test/package.json
+++ b/test/package.json
@@ -65,6 +65,7 @@
     "zlib": "^1.0.5"
   },
   "devDependencies": {
+    "chai-exclude": "^2.0.2",
     "eslint": "^5.9.0",
     "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-no-only-tests": "^2.0.1",

--- a/test/src/unit/modules/FileWatcher.test.js
+++ b/test/src/unit/modules/FileWatcher.test.js
@@ -594,12 +594,18 @@ describe('FileWatcher.js', () => {
                 type: 'mockType',
                 appStatus: 'started',
             };
+            mockFwProject.toJSON = function() {
+                // eslint-disable-next-line no-unused-vars
+                const { toJSON, name, operationId, logStreams, ...filteredProject } = this;
+                return filteredProject;
+            };
             const setMetricsState = sinon.stub().resolves();
             const expectedProjectUpdate = {
                 projectID: mockFwProject.projectID,
                 logStreams: mockFwProject.logStreams,
                 type: mockFwProject.type,
                 appStatus: 'started',
+                toJSON: mockFwProject.toJSON,
             };
             const expectedProjectInfoForUI = {
                 projectID: mockFwProject.projectID,
@@ -637,12 +643,18 @@ describe('FileWatcher.js', () => {
                 type: 'mockType',
                 appStatus: 'starting',
             };
+            mockFwProject.toJSON = function() {
+                // eslint-disable-next-line no-unused-vars
+                const { toJSON, name, operationId, logStreams, ...filteredProject } = this;
+                return filteredProject;
+            };
             const setMetricsState = sinon.stub().resolves();
             const expectedProjectUpdate = {
                 projectID: mockFwProject.projectID,
                 logStreams: mockFwProject.logStreams,
                 type: mockFwProject.type,
                 appStatus: 'starting',
+                toJSON: mockFwProject.toJSON,
             };
             const expectedProjectInfoForUI = {
                 projectID: mockFwProject.projectID,
@@ -678,6 +690,11 @@ describe('FileWatcher.js', () => {
             const mockProject = {
                 logStreams: 'should not be emitted to UI',
             };
+            mockProject.toJSON = function() {
+                // eslint-disable-next-line no-unused-vars
+                const { toJSON, logStreams, ... filteredProject } = this;
+                return filteredProject;
+            };
             const mockUser = {
                 uiSocket: { emit: sinon.mock() },
             };
@@ -708,9 +725,24 @@ describe('FileWatcher.js', () => {
                 detailedAppStatus: undefined, // eslint-disable-line no-undefined
                 containerId: '',
             };
+            const expectedProjectUpdateToJSON = {
+                projectID: mockFwProject.projectID,
+                ports: '',
+                buildStatus: 'unknown',
+                appStatus: 'unknown',
+                state: 'closed',
+                capabilitiesReady: false,
+                detailedAppStatus: undefined, // eslint-disable-line no-undefined
+                containerId: '',
+            };
+            expectedProjectUpdateToJSON.toJSON = function() {
+                // eslint-disable-next-line no-unused-vars
+                const { toJSON, ... filteredProject } = this;
+                return filteredProject;
+            };
             const mockUser = {
                 projectList: { 
-                    updateProject: sinon.stub().returns(expectedProjectUpdate),
+                    updateProject: sinon.stub().returns(expectedProjectUpdateToJSON),
                     deleteProjectKey: () => {},
                 },
                 uiSocket: { emit: sinon.mock() },

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -402,6 +402,7 @@ describe('Project.js', function() {
             infJson.should.have.property('projectID').and.equal(project.projectID);
 
             const projectFromInf = createProjectAndCheckIsAnObject(infJson, global.codewind.CODEWIND_WORKSPACE);
+            projectFromInf.loadRunner = project.loadRunner = null;
             projectFromInf.should.deep.equal(project);
         });
         it('Checks the Project cannot be written when it is locked', function() {


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
- Moves the LoadRunner object from being a single object held by User.js to being one instance of the object per Project object
- Enables multiple load runs to be run at once by reworking how the 'Load Run in progress' error is handled throughout Codewind. LoadRunner.js now has a method to state if it is idle, which is used to determine if a project can run a load test
- All LoadRunner socket messages now contain the ProjectID they are associated with. Meaning each LoadRunner object can filter out incoming messages from multiple in progress load runs.

TODO:
- Rework existing testing scripts to work with new layout of Loadrunner.js
- Extensive testing of LoadRunner scenarios to make sure that no functionality has been lost with the changes

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2825
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
Yes. Users now have the ability to run multiple load runs at the same time, which changes the functionality of the performance dashboard.

## Any special notes for your reviewer ?
None.