### PR TITLE
Improve the logging in FileWatcher.js

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -130,7 +130,7 @@ module.exports = class FileWatcher {
         await this.user.projectList.updateProject(fwProject);
         this.user.uiSocket.emit('projectValidated', fwProject);
       } catch (err) {
-        log.error(err);
+        log.error(`Error validating project ${fwProject.projectID}: ${inspect(err)}`);
       }
       break;
     }
@@ -194,6 +194,7 @@ module.exports = class FileWatcher {
       await this.user.projectList.updateProject(projectUpdate);
       this.user.uiSocket.emit('projectChanged', projectUpdate);
     } catch (err) {
+      log.error(`Error handling capabilities update to project ${fwProject.projectID}: ${inspect(err)}`);
       log.error(err);
     }
   }
@@ -362,7 +363,7 @@ module.exports = class FileWatcher {
         throw new Error(`check project logs ${retval.statusCode} ${retval.error.msg}`);
       }
     } catch (err) {
-      log.error(err);
+      log.error(`Error checking for new log file for project ${projectID}: ${inspect(err)}`);
     }
   }
 
@@ -381,7 +382,7 @@ module.exports = class FileWatcher {
         throw new Error(`project update ${retval.statusCode} ${retval.error.msg}`);
       }
     } catch (err) {
-      log.error(err);
+      log.error(`Error updating project status ${inspect(err)}`);
     }
   }
 
@@ -391,7 +392,7 @@ module.exports = class FileWatcher {
       retval = await filewatcher.imagePushRegistryStatus(body);
       this.logFWReturnedMsg(retval);
     } catch (err) {
-      log.error(err);
+      log.error(`Error with image registry status: ${inspect(err)}`);
     }
     if (retval.statusCode != 200) {
       throw new Error(`imagePushRegistryStatus ${retval.statusCode} ${retval.error.msg}`);
@@ -408,7 +409,7 @@ module.exports = class FileWatcher {
         throw new Error(`project update ${retval.statusCode} ${retval.error.msg}`);
       }
     } catch (err) {
-      log.error(err);
+      log.error(`Error handling project file change for project ${projectID}: ${inspect(err)}`);
     }
   }
 
@@ -458,7 +459,7 @@ module.exports = class FileWatcher {
         await this.handleFWProjectEvent(event, fwProject);
       }
     } catch (err) {
-      log.error(err);
+      log.error(`Error handling project update for project ${fwProject.projectID}: ${inspect(err)}`);
     }
   }
 
@@ -503,7 +504,7 @@ module.exports = class FileWatcher {
       await this.handleFWProjectEvent(event, projectUpdate);
       WebSocket.watchListChanged(data);
     } catch (err) {
-      log.error(err);
+      log.error(`Error handling new project ${fwProject.projectID}: ${inspect(err)}`);
     }
   }
 
@@ -552,7 +553,7 @@ module.exports = class FileWatcher {
         updatedProject.resetLogStream('app');
       }
     } catch (err) {
-      log.error(err);
+      log.error(`Error handling project event for ${fwProject.projectID}: ${inspect(err)}`);
     }
   }
 
@@ -579,7 +580,7 @@ module.exports = class FileWatcher {
     // (Storing the status in the project object is bad as it is
     // only about this close operation.)
     // remove fields which are not required by the UI
-    const { logStreams, ...projectInfoForUI } = updatedProject;
+    const { logStreams, ...projectInfoForUI } = updatedProject
     this.user.uiSocket.emit('projectClosed', {...projectInfoForUI, status: fwProject.status});
     log.debug(`project ${fwProject.projectID} successfully closed`);
   }
@@ -613,7 +614,7 @@ module.exports = class FileWatcher {
       retval = await filewatcher.testImagePushRegistry(address, namespace);
       this.logFWReturnedMsg(retval);
     } catch (err) {
-      log.error(`Error in testImagePushRegistry`);
+      log.error(`Error in testImagePushRegistry: ${inspect(err)}`);
       throw err;
     }
 
@@ -626,7 +627,7 @@ module.exports = class FileWatcher {
       retval = await filewatcher.readWorkspaceSettings();
       this.logFWReturnedMsg(retval);
     } catch (err) {
-      log.error(err);
+      log.error(`Error in readWorkspaceSettings: ${inspect(err)}`);
     }
     if (retval.statusCode != 200) {
       throw new Error(`readWorkspaceSettings ${retval.statusCode} ${retval.workspaceSettings.msg}`);
@@ -639,7 +640,7 @@ module.exports = class FileWatcher {
       retval = await filewatcher.writeWorkspaceSettings(address, namespace);
       this.logFWReturnedMsg(retval);
     } catch (err) {
-      log.error(`Error in writeWorkspaceSettings`);
+      log.error(`Error in writeWorkspaceSettings: ${inspect(err)}`);
       throw err;
     }
     if (retval.statusCode != 200) {
@@ -654,7 +655,7 @@ module.exports = class FileWatcher {
       retval = await filewatcher.removeImagePushRegistry(address);
       this.logFWReturnedMsg(retval);
     } catch (err) {
-      log.error(`Error in removeImagePushRegistry`);
+      log.error(`Error in removeImagePushRegistry: ${inspect(err)}`);
       throw err;
     }
     return retval;
@@ -688,7 +689,7 @@ module.exports = class FileWatcher {
     try {
       await filewatcher.setLoggingLevel(this.level);
     } catch (err) {
-      log.error(err);
+      log.error(`Error in setLoggingLevel: ${inspect(err)}`);
     }
   }
 


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [X] Enhancement

## What does this PR do ?
Improves the logging in FileWatcher.js so that when an error is logged we can see which function actually logged it.

## Which issue(s) does this PR fix ?
N/A but was discovered while looking at an early draft for the changes in https://github.com/eclipse/codewind/pull/2977 that caused an error in FileWatcher.js that we then couldn't isolate because many functions handled exceptions by calling:
`log.error(err)` with no further details.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No