### PR TITLE
Enhance /metrics/auth API to return better errors + add microprofilePackageAuthenticationDisabled to /metrics/status

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -530,8 +530,8 @@ module.exports = class FileWatcher {
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
 
       const { appStatus } = updatedProject;
-      // Only update metrics state when the project is running or stopped
-      if (appStatus === 'started' || appStatus === 'stopped') {
+      // Update the metrics state if its just been added, or is running or stopped
+      if (event === 'newProjectAdded' || (appStatus === 'started' || appStatus === 'stopped')) {
         try {
           // If updating the metrics fails, don't stop the status being emitted to the UI
           await updatedProject.setMetricsState();

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -124,7 +124,16 @@ module.exports = class Project {
 
     this.metricsAvailable = false; // Default to false as metrics won't be available until the project has started
     this.metricsDashboard = { hosting: null, path: null };
-    this.metricsCapabilities = (args.metricsCapabilities) ? args.metricsCapabilities : {};
+    // Default all values to false as they will be updated once the project is started
+    this.metricsCapabilities = {
+      liveMetricsAvailable: false,
+      metricsEndpoint: false,
+      appmetricsEndpoint: false,
+      microprofilePackageFoundInBuildFile: false,
+      appmetricsPackageFoundInBuildFile: false,
+      hasTimedMetrics: false,
+      microprofilePackageAuthenticationDisabled: false,
+    };
 
     this.links = new Links(this.projectPath(), args.links);
 
@@ -166,11 +175,11 @@ module.exports = class Project {
 
   async setMetricsState() {
     const { capabilities, metricsDashHost: { hosting, path } } = await metricsStatusChecker.getMetricStatusForProject(this);
-    this.metricsCapabilities = capabilities;
+    this.metricsCapabilities = { ...this.metricsCapabilities, ...capabilities };
     this.metricsAvailable = (hosting !== null && path !== null);
     this.metricsDashboard = { hosting, path };
     await this.writeInformationFile();
-    return { capabilities };
+    return { capabilities: this.metricsCapabilities };
   }
 
   getMetricsCapabilities() {

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -133,6 +133,8 @@ module.exports = class Project {
       appmetricsPackageFoundInBuildFile: false,
       hasTimedMetrics: false,
       microprofilePackageAuthenticationDisabled: false,
+      // Overwrite with previous values
+      ...args.metricsCapabilities,
     };
 
     this.links = new Links(this.projectPath(), args.links);

--- a/src/pfe/portal/modules/metricsService/index.js
+++ b/src/pfe/portal/modules/metricsService/index.js
@@ -19,6 +19,7 @@ const promiseAny = require('promise.any');
 const Logger = require('../utils/Logger');
 const nodeMetricsService = require('./node');
 const { findFile } = require('../utils/sharedFunctions');
+const ProjectMetricsError = require('../utils/errors/ProjectMetricsError');
 
 const log = new Logger(__filename);
 const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
@@ -573,13 +574,13 @@ function getNewPomXmlBuildPlugins(originalBuildPlugins) {
 
 async function disableMicroprofileMetricsAuth(projectLanguage, projectDir) {
   if (projectLanguage !== 'java') {
-    throw new Error(`Disabling of Microprofile metrics authentication is not supported for projects of language '${projectLanguage}'`);
+    throw new ProjectMetricsError('DISABLE_METRICS_AUTH_UNSUPPORTED', projectLanguage);
   }
   const contents = '<server>\n\t<mpMetrics authentication="false"/>\n</server>\n';
   const fileName = 'codewind-override-disable-mpmetrics-auth.xml';
   const pathToServerXml = await findFile('server.xml', projectDir);
   if (!pathToServerXml) {
-    throw new Error(`Unable to determine 'server.xml' directory, cannot create Microprofile metrics authentication override file`);
+    throw new ProjectMetricsError('SERVER_XML_NOT_FOUND', projectDir, 'Cannot remove Microprofile metrics authentication override file');
   }
   const serverXmlDirectory = path.dirname(pathToServerXml);
   // Use overrides as it has a higher priority than /configDropins/defaults
@@ -592,12 +593,12 @@ async function disableMicroprofileMetricsAuth(projectLanguage, projectDir) {
 
 async function enableMicroprofileMetricsAuth(projectLanguage, projectDir) {
   if (projectLanguage !== 'java') {
-    throw new Error(`Disabling of Microprofile metrics authentication is not supported for projects of language '${projectLanguage}'`);
+    throw new ProjectMetricsError('DISABLE_METRICS_AUTH_UNSUPPORTED', projectLanguage);
   }
   const fileName = 'codewind-override-disable-mpmetrics-auth.xml';
   const pathToServerXml = await findFile('server.xml', projectDir);
   if (!pathToServerXml) {
-    throw new Error(`Unable to determine 'server.xml' directory, cannot remove Microprofile metrics authentication override file`);
+    throw new ProjectMetricsError('SERVER_XML_NOT_FOUND', projectDir, 'Cannot remove Microprofile metrics authentication override file');
   }
   const serverXmlDirectory = path.dirname(pathToServerXml);
   // Use overrides as it has a higher priority than /configDropins/defaults

--- a/src/pfe/portal/modules/utils/errors/ProjectMetricsError.js
+++ b/src/pfe/portal/modules/utils/errors/ProjectMetricsError.js
@@ -19,7 +19,18 @@ module.exports = class ProjectMetricsError extends BaseError {
 }
 
 // Error codes
-module.exports.NOT_FOUND = 'NOT_FOUND';
+const CODES = {
+  NOT_FOUND: 'NOT_FOUND',
+  DOCKER_CP: 'DOCKER_CP',
+  HCD_NOT_FOUND: 'HCD_NOT_FOUND',
+  PROFILING_NOT_FOUND: 'PROFILING_NOT_FOUND',
+  STREAM_FAILED: 'STREAM_FAILED',
+  DISABLE_METRICS_AUTH_UNSUPPORTED: 'DISABLE_METRICS_AUTH_UNSUPPORTED',
+  SERVER_XML_NOT_FOUND: 'SERVER_XML_NOT_FOUND',
+}
+
+module.exports.CODES = CODES;
+module.exports.NOT_FOUND = CODES.NOT_FOUND;
 
 /**
  * Function to construct an error message based on the given error code
@@ -30,20 +41,26 @@ module.exports.NOT_FOUND = 'NOT_FOUND';
 function constructMessage(code, identifier, message) {
   let output = '';
   switch(code) {
-  case 'NOT_FOUND':
+  case CODES.NOT_FOUND:
     output = `Unable to find metrics for project ${identifier}`;
     break;
-  case 'DOCKER_CP':
+  case CODES.DOCKER_CP:
     output = `Unable to perform docker cp for project ${identifier}`;
     break;
-  case 'HCD_NOT_FOUND':
+  case CODES.HCD_NOT_FOUND:
     output = `Unable to find .hcd saved in project ${identifier}`
     break;
-  case 'PROFILING_NOT_FOUND':
+  case CODES.PROFILING_NOT_FOUND:
     output = `Unable to find profiling.json saved in project ${identifier}`;
     break;
-  case 'STREAM_FAILED':
+  case CODES.STREAM_FAILED:
     output = `Unable to create read stream for file ${identifier}`;
+    break;
+  case CODES.DISABLE_METRICS_AUTH_UNSUPPORTED:
+    output = `Disabling of Microprofile metrics authentication is not supported for projects of language '${identifier}'`;
+    break;
+  case CODES.SERVER_XML_NOT_FOUND:
+    output = `Unable to determine 'server.xml' in ${identifier}`;
     break;
   default:
     output = `Unknown project metrics error`;

--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -429,6 +429,13 @@ async function bindEnd(req, res) {
       log.warn(error);
     }
 
+    try {
+      // Set the initial metrics state for the project (updates the file system)
+      await project.setMetricsState();
+    } catch(setMetricsStateErr) {
+      log.warn(`error updating the metrics state for ${updatedProject.name}, Error: ${setMetricsStateErr}`);
+    }
+
     // debug logic to identify bind time
     timerbindend = Date.now();
     let totalbindtime = (timerbindend - timerbindstart) / 1000;

--- a/test/modules/project.service.js
+++ b/test/modules/project.service.js
@@ -509,6 +509,11 @@ async function deleteProjectLink(projectID, envName) {
     return res;
 }
 
+function getMetricsStatus(projectID) {
+    return reqService.chai
+        .get(`/api/v1/projects/${projectID}/metrics/status`)
+        .set('cookie', ADMIN_COOKIE);
+}
 
 module.exports = {
     generateUniqueName,
@@ -550,4 +555,5 @@ module.exports = {
     addProjectLink,
     updateProjectLink,
     deleteProjectLink,
+    getMetricsStatus,
 };

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -33,6 +33,9 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
         // Use GO applications as these tests require two running applications
         projectID = await projectService.createProjectFromTemplate(nodeProjectName, 'nodejs', pathToNodeProject);
         targetProjectID = await projectService.createProjectFromTemplate(goProjectName, 'go', pathToGoProject, true);
+        // Close first project so it isn't built
+        await projectService.closeProject(projectID, 202, true);
+        // Ensure the target project is started
         await projectService.awaitProjectStartedHTTP(targetProjectID);
     });
 

--- a/test/src/API/projects/metricsAuth.test.js
+++ b/test/src/API/projects/metricsAuth.test.js
@@ -10,6 +10,7 @@
  *******************************************************************************/
 const chai = require('chai');
 const path = require('path');
+const fs = require('fs-extra');
 const chaiSubset = require('chai-subset');
 const chaiResValidator = require('chai-openapi-response-validator');
 
@@ -20,7 +21,9 @@ const {
     TEMP_TEST_DIR,
     testTimeout,
     pathToApiSpec,
+    templateOptions,
 } = require('../../../config');
+const { findFile } = require('../../../../src/pfe/portal/modules/utils/sharedFunctions');
 
 chai.use(chaiSubset);
 chai.use(chaiResValidator(pathToApiSpec));
@@ -41,14 +44,17 @@ describe('Metrics Auth tests (/api/v1/projects/{id}/metrics/auth)', function() {
         res.text.should.equal(`Project with ID \'${projectID}\' does not exist on the Codewind server`);
     });
 
-    describe('Disables and enables the metrics authentication of an open-liberty application', function() {
+    describe('Disables and enables the metrics authentication of an open-liberty application (These tests require the previous ones to pass)', function() {
         const projectName = `test-open-liberty-metrics-auth-${Date.now()}`;
         const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
         let projectID;
 
-        before('create a sample project and bind to Codewind, without building', async function() {
+        before('create a sample project, bind to Codewind (without building) and update its metrics status', async function() {
             this.timeout(testTimeout.med);
-            projectID = await projectService.createProjectFromTemplate(projectName, 'openliberty', pathToLocalProject); 
+            projectID = await projectService.createProjectFromTemplate(projectName, 'openliberty', pathToLocalProject);
+            const { body: { microprofilePackageFoundInBuildFile, microprofilePackageAuthenticationDisabled } } = await projectService.getMetricsStatus(projectID);
+            microprofilePackageFoundInBuildFile.should.be.true;
+            microprofilePackageAuthenticationDisabled.should.be.false;
         });
 
         after(async function() {
@@ -62,10 +68,32 @@ describe('Metrics Auth tests (/api/v1/projects/{id}/metrics/auth)', function() {
             res.status.should.equal(202, res.text); // print res.text if assertion fails
         });
 
+        it('returns 400 to /metrics/auth as the metrics authentication is already disabled', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsAuth(projectID, { disable: true });
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
+        });
+
+        it('reports the microprofilePackageAuthenticationDisabled as true as the metrics auth has been disabled', async function() {
+            const { body: { microprofilePackageAuthenticationDisabled } } = await projectService.getMetricsStatus(projectID);
+            microprofilePackageAuthenticationDisabled.should.be.true;
+        });
+
         it('returns 202 to /metrics/auth and removes the disable metrics authentication file into the user\'s project', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsAuth(projectID, { disable: false });
             res.status.should.equal(202, res.text); // print res.text if assertion fails
+        });
+
+        it('returns 400 to /metrics/auth and as metrics auth is not disabled', async function() {
+            this.timeout(testTimeout.short);
+            const res = await postMetricsAuth(projectID, { disable: false });
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
+        });
+
+        it('reports the microprofilePackageAuthenticationDisabled as false as the metrics auth has been enabled', async function() {
+            const { body: { microprofilePackageAuthenticationDisabled } } = await projectService.getMetricsStatus(projectID);
+            microprofilePackageAuthenticationDisabled.should.be.false;
         });
     });
     describe('Returns 500 as the project does not contain a server.xml (but is a Java project)', function() {
@@ -75,7 +103,26 @@ describe('Metrics Auth tests (/api/v1/projects/{id}/metrics/auth)', function() {
 
         before('create a sample project and bind to Codewind, without building', async function() {
             this.timeout(testTimeout.med);
-            projectID = await projectService.createProjectFromTemplate(projectName, 'lagom', pathToLocalProject); 
+            // projectID = await projectService.createProjectFromTemplate(projectName, 'lagom', pathToLocalProject);
+            const { url, language } = templateOptions['openliberty'];
+            await projectService.cloneProject(url, pathToLocalProject);
+
+            // Remove server.xml for this test
+            const serverXMLLocation = await findFile('server.xml', pathToLocalProject);
+            await fs.remove(serverXMLLocation);
+
+            const { body } = await projectService.bindProject({
+                name: projectName,
+                path: pathToLocalProject,
+                language,
+                projectType: 'docker',
+                autoBuild: false,
+                creationTime: Date.now(),
+            });
+            projectID = body.projectID;
+
+            const { body: { microprofilePackageFoundInBuildFile } } = await projectService.getMetricsStatus(projectID);
+            microprofilePackageFoundInBuildFile.should.be.true;
         });
 
         after(async function() {
@@ -88,21 +135,17 @@ describe('Metrics Auth tests (/api/v1/projects/{id}/metrics/auth)', function() {
             const res = await postMetricsAuth(projectID, { disable: true });
             res.status.should.equal(500, res.text); // print res.text if assertion fails
         });
-
-        it('returns 202 to /metrics/auth as the project does not contain a server.xml', async function() {
-            this.timeout(testTimeout.short);
-            const res = await postMetricsAuth(projectID, { disable: false });
-            res.status.should.equal(500, res.text); // print res.text if assertion fails
-        });
     });
-    describe('Returns 500 as the project language is nodejs which is not supported', function() {
+    describe('Returns 400 as the project language is nodejs which does not have microprofile metrics (and is not supported)', function() {
         const projectName = `test-nodejs-metrics-auth-${Date.now()}`;
         const pathToLocalProject = path.join(TEMP_TEST_DIR, projectName);
         let projectID;
 
         before('create a sample project and bind to Codewind, without building', async function() {
             this.timeout(testTimeout.med);
-            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject); 
+            projectID = await projectService.createProjectFromTemplate(projectName, 'nodejs', pathToLocalProject);
+            const { body: { microprofilePackageFoundInBuildFile } } = await projectService.getMetricsStatus(projectID);
+            microprofilePackageFoundInBuildFile.should.be.false;
         });
 
         after(async function() {
@@ -110,16 +153,18 @@ describe('Metrics Auth tests (/api/v1/projects/{id}/metrics/auth)', function() {
             if (projectID) await projectService.removeProject(pathToLocalProject, projectID);
         });
 
-        it('returns 500 to /metrics/auth as the project language is nodejs', async function() {
+        it('returns 400 to /metrics/auth as the project does not have microprofile metrics', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsAuth(projectID, { disable: true });
-            res.status.should.equal(500, res.text); // print res.text if assertion fails
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
+            res.text.should.equal(`Disabling of Microprofile metrics authentication is not supported for projects of language \'${projectID}\'\nProject does not have microprofile metrics`);
         });
 
-        it('returns 202 to /metrics/auth as the project language is nodejs', async function() {
+        it('returns 400 to /metrics/auth as the project does not have microprofile metrics', async function() {
             this.timeout(testTimeout.short);
             const res = await postMetricsAuth(projectID, { disable: false });
-            res.status.should.equal(500, res.text); // print res.text if assertion fails
+            res.status.should.equal(400, res.text); // print res.text if assertion fails
+            res.text.should.equal(`Disabling of Microprofile metrics authentication is not supported for projects of language \'${projectID}\'\nProject does not have microprofile metrics`);
         });
     });
 });

--- a/test/src/unit/modules/Project.test.js
+++ b/test/src/unit/modules/Project.test.js
@@ -84,6 +84,10 @@ describe('Project.js', function() {
                 buildLogPath: '/codewind-workspace/.logs/my-java-project-9318ab10-fef9-11e9-8761-9bf62d92b58b-9318ab10-fef9-11e9-8761-9bf62d92b58b/docker.build.log',
                 state: 'open',
                 autoBuild: false,
+                metricsCapabilities: {
+                    liveMetricsAvailable: true,
+                    microprofilePackageAuthenticationDisabled: true,
+                },
             };
             const project = createProjectAndCheckIsAnObject(args, global.codewind.CODEWIND_WORKSPACE);
             project.should.containSubset(args);


### PR DESCRIPTION
Note: the button on the dashboard won't show yet, but the changes are coming in @markcor11's next PR. Edit: This line: https://github.com/eclipse/codewind/pull/2994/files#diff-fafbd9cba5399ce927af26e85cb12eedR36

What type of PR is this ? 
- [x] Bug fix
- [x] Enhancement

## What does this PR do ?
### Summary
* Adds the field `microprofilePackageAuthenticationDisabled` into the metrics status so that the performance dashboard knows whether it should show the `disable metrics authentication or not`
* Enhances the error handling for the metrics auth disable API to send back `400` errors when the request is not wrong. Spoken to Mark and the performance dashboard shouldn't hit these conditions based on the dashboard logic, but they should be included in the API anyway.
* Improve the way the metrics state is checked by having the `setMetricsCapabilities` function run when the project is first bound to Codewind and also when the FileWatcher sends a `projectCreated` Socket message.

### Testing
* Added tests for new functionality.
* Corrected tests with incorrect comments.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/2712

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
