### PR TITLE
Remove null from Template error message

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -521,17 +521,17 @@ async function getTemplateSummaries(givenURL, gitCredentials) {
         templateSummaries = await fs.readJSON(parsedURL.pathname);
       }
     } catch (err) {
-      throw new TemplateError('URL_DOES_NOT_POINT_TO_INDEX_JSON', null, `repo file '${parsedURL}' did not return JSON`);
+      throw new TemplateError('REPO_FILE_DOES_NOT_POINT_TO_INDEX_JSON', parsedURL);
     }
   } else {
     const res = await makeGetRequest(parsedURL, gitCredentials);
     if (res.statusCode !== 200) {
-      throw new TemplateError('URL_DOES_NOT_POINT_TO_INDEX_JSON', null, `Unexpected HTTP status for ${givenURL}: ${res.statusCode}`);
+      throw new TemplateError('GET_TEMPLATE_SUMMARIES_FAILED', null, `Unexpected HTTP status for ${givenURL}: ${res.statusCode}`);
     }
     try {
       templateSummaries = JSON.parse(res.body);
     } catch (error) {
-      throw new TemplateError('URL_DOES_NOT_POINT_TO_INDEX_JSON', null, `URL '${parsedURL}' did not return JSON`);
+      throw new TemplateError('URL_DOES_NOT_POINT_TO_INDEX_JSON', parsedURL);
     }
   }
   return templateSummaries;

--- a/src/pfe/portal/modules/utils/errors/TemplateError.js
+++ b/src/pfe/portal/modules/utils/errors/TemplateError.js
@@ -37,13 +37,19 @@ function constructMessage(code, identifier, message) {
     output = `Invalid URL: ${identifier}`;
     break;
   case 'DUPLICATE_URL':
-    output = `${identifier} is already a template repository`;
+    output = `URL ${identifier} is already a template repository`;
     break;
   case 'URL_DOES_NOT_POINT_TO_INDEX_JSON':
-    output = `${identifier} does not point to a JSON file of the correct form`;
+    output = `URL '${identifier}' does not point to a JSON file of the correct form`;
+    break;
+  case 'REPO_FILE_DOES_NOT_POINT_TO_INDEX_JSON':
+    output = `repo file '${identifier}' does not point to a JSON file of the correct form`;
     break;
   case 'ADD_TO_PROVIDER_FAILURE':
     output = `A template provider failed to add the ${identifier} repository`;
+    break;
+  case 'GET_TEMPLATE_SUMMARIES_FAILED':
+    output = `Get template summaries failed.`
     break;
   case 'REPOSITORY_DOES_NOT_EXIST':
     output = `${identifier} does not exist`;

--- a/src/pfe/portal/routes/templates.route.js
+++ b/src/pfe/portal/routes/templates.route.js
@@ -80,7 +80,13 @@ async function postRepositories(req, res, next) {
     await sendRepositories(req, res, next);
   } catch (error) {
     log.error(error);
-    const knownErrorCodes = ['INVALID_URL', 'DUPLICATE_URL', 'URL_DOES_NOT_POINT_TO_INDEX_JSON', 'ADD_TO_PROVIDER_FAILURE'];
+    const knownErrorCodes = ['INVALID_URL',
+      'DUPLICATE_URL',
+      'URL_DOES_NOT_POINT_TO_INDEX_JSON',
+      'REPO_FILE_DOES_NOT_POINT_TO_INDEX_JSON',
+      'GET_TEMPLATE_SUMMARIES_FAILED',
+      'ADD_TO_PROVIDER_FAILURE'
+    ];
     if (error instanceof TemplateError) {
       if (knownErrorCodes.includes(error.code)) {
         res.status(400).send(error.message);

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -614,7 +614,7 @@ describe('Templates.js', function() {
                             url,
                             description: 'description',
                         });
-                        return func().should.be.rejectedWith(`${url} is already a template repository`);
+                        return func().should.be.rejectedWith(`URL ${url} is already a template repository`);
                     });
                 });
                 describe('(<validUrlNotPointingToIndexJson>, <validDesc>)', function() {
@@ -624,7 +624,7 @@ describe('Templates.js', function() {
                             url,
                             description: 'description',
                         });
-                        return func().should.be.rejectedWith(`${url} does not point to a JSON file of the correct form`);
+                        return func().should.be.rejectedWith(`URL '${url}' does not point to a JSON file of the correct form`);
                     });
                 });
                 describe('(<validUrlPointingToIndexJson>, <validDesc>, <validName>)', function() {
@@ -1278,11 +1278,11 @@ describe('Templates.js', function() {
             });
             it('throws a useful error when a valid URL is given but it does not point to JSON', function() {
                 const func = () => getTemplatesFromRepo({ url: 'https://www.google.com/' });
-                return func().should.be.rejectedWith(`URL 'https://www.google.com/' did not return JSON`);
+                return func().should.be.rejectedWith(`URL 'https://www.google.com/' does not point to a JSON file of the correct form`);
             });
             it('throws a useful error when an invalid file path is given', function() {
                 const func = () => getTemplatesFromRepo({ url: 'file://something.json' });
-                return func().should.be.rejectedWith(`repo file 'file://something.json/' did not return JSON`);
+                return func().should.be.rejectedWith(`repo file 'file://something.json/' does not point to a JSON file of the correct form`);
             });
         });
         describe('getTemplateSummaries(givenURL)', () => {
@@ -1342,11 +1342,11 @@ describe('Templates.js', function() {
             });
             it('should be rejected as URL does not point to JSON', () => {
                 const func = () => getTemplateSummaries('https://www.google.com/');
-                return func().should.be.rejectedWith(`URL 'https://www.google.com/' did not return JSON`);
+                return func().should.be.rejectedWith(`URL 'https://www.google.com/' does not point to a JSON file of the correct form`);
             });
             it('should be rejected as filepath does not exist', function() {
                 const func = () => getTemplateSummaries('file://something.json');
-                return func().should.be.rejectedWith(`repo file 'file://something.json/' did not return JSON`);
+                return func().should.be.rejectedWith(`repo file 'file://something.json/' does not point to a JSON file of the correct form`);
             });
         });
         describe('filterTemplatesByStyle(templates, projectStyle)', function() {


### PR DESCRIPTION
Signed-off-by: James Cockbain <james.cockbain@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Fix for https://github.com/eclipse/codewind/issues/2837, which whilst partially fixed already (cwctl now parsing the PFE error correctly), still displays a null in the error message.

### Before

![](https://user-images.githubusercontent.com/31372187/82441241-8e835e00-9a95-11ea-9e28-20bece90f5c8.png)

### After

<img width="1680" alt="Screenshot 2020-05-21 at 13 55 45" src="https://user-images.githubusercontent.com/31372187/82561164-cb6d5480-9b6a-11ea-9a0e-6a73eaa4015f.png">

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/2837


