### PR TITLE
Help dashboard recover from a variety of network and connectivity scenarios 

### DIFF
--- a/src/performance/dashboard/src/App.js
+++ b/src/performance/dashboard/src/App.js
@@ -43,6 +43,38 @@ socket.on('connect', function(){
   }
 });
 
+socket.on('connect_error', function(error) {
+  console.error("Dashboard Socket connect_error: ", error);
+});
+
+socket.on('connect_timeout', function(timeout) {
+  console.warn("Dashboard Socket connect_timeout: ", timeout);
+});
+
+socket.on('error', function(error) {
+  console.error("Dashboard Socket error: ", error);
+});
+
+socket.on('disconnect', function(reason) {
+  console.warn("Dashboard Socket disconnect: ", reason);
+});
+
+socket.on('reconnect', function(attemptNumber) {
+  console.warn("Dashboard Socket reconnect.  Attempt # ", attemptNumber);
+});
+
+socket.on('reconnecting', function(attemptNumber) {
+  console.warn("Dashboard Socket reconnecting. Attempt #", attemptNumber);
+});
+
+socket.on('reconnect_error', function(error) {
+  console.error("Dashboard Socket reconnect_error : ", error);
+});
+
+socket.on('reconnect_failed', function() {
+  console.error("Dashboard Socket reconnect_failed");
+});
+
 function App() {
 
   const projectID = ProjectIDChecker.projectID();

--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -150,10 +150,11 @@ class ActionRunLoad extends React.Component {
     // eslint-disable-next-line class-methods-use-this
     async requestRunLoad(desc) {
         let descriptionPayload = JSON.stringify({ description: desc });
+        const accessToken = localStorage.getItem("cw-access-token");
         const response = await fetch(`${AppConstants.API_SERVER}/api/v1/projects/${this.props.projectID}/loadtest`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
                 body: descriptionPayload
             });
         const reply = await response;
@@ -162,10 +163,11 @@ class ActionRunLoad extends React.Component {
 
     async handleCancelLoad() {
         try {
+            const accessToken = localStorage.getItem("cw-access-token");
             const response = await fetch(`${AppConstants.API_SERVER}/api/v1/projects/${this.props.projectID}/loadtest/cancel`,
                 {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" }
+                    headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` }
                 });
             const reply = await response;
             console.error("Cancel accepted")

--- a/src/performance/dashboard/src/components/modals/ModalModifyLoadTests.jsx
+++ b/src/performance/dashboard/src/components/modals/ModalModifyLoadTests.jsx
@@ -45,15 +45,15 @@ class ModalModifyLoadTests extends React.Component {
     }
 
     /**
-     * New props provided, 
+     * New props provided,
      * Re-load configuration from the server if dialogbox is opening
-     * @param {*} nextProps 
+     * @param {*} nextProps
      */
     async componentWillReceiveProps(nextProps) {
         if (nextProps.open !== this.state.dialogStateOpen) {
             this.setState({ dialogStateOpen: nextProps.open, modalErrorText: '', saveInProgress: false, loadingData: true });
             if (nextProps.open) {
-                await this.props.dispatch(fetchProjectLoadConfig(ProjectIDChecker.projectID()));
+                await this.props.dispatch(fetchProjectLoadConfig(localStorage.getItem("cw-access-token"), ProjectIDChecker.projectID()));
                 if (this.props.loadRunnerConfig.fetched) {
                     const formFields = { ...this.props.loadRunnerConfig.config }
                     if (formFields['body']) {
@@ -137,11 +137,10 @@ class ModalModifyLoadTests extends React.Component {
             "concurrency": this.state.formFields.concurrency,
             "maxSeconds": this.state.formFields.maxSeconds
         };
-
-        await this.props.dispatch(saveProjectLoadConfig(projectID, newConfigPayload));
+        await this.props.dispatch(saveProjectLoadConfig(localStorage.getItem('cw-access-token'), projectID, newConfigPayload));
 
         if (!this.props.loadRunnerConfig.error && this.props.loadRunnerConfig.fetched) {
-            await this.props.dispatch(reloadMetricsData(projectID, this.props.projectMetricTypes.types));
+            await this.props.dispatch(reloadMetricsData(localStorage.getItem('cw-access-token'), projectID, this.props.projectMetricTypes.types));
             this.props.closeModalWindow();
         } else {
             this.setState({ modalErrorText: this.props.loadRunnerConfig.error.message, saveInProgress: false });

--- a/src/performance/dashboard/src/components/navBar/NavBar.jsx
+++ b/src/performance/dashboard/src/components/navBar/NavBar.jsx
@@ -32,7 +32,7 @@ class NavBar extends React.Component {
 
     async componentDidMount() {
         try {
-            await this.props.dispatch(fetchProjectConfig(this.props.projectID));
+            await this.props.dispatch(fetchProjectConfig(localStorage.getItem('cw-access-token'), this.props.projectID));
         } catch (err) {
             this.setState({ projectName: '' });
         }

--- a/src/performance/dashboard/src/components/resultsCard/DescriptionEditor.jsx
+++ b/src/performance/dashboard/src/components/resultsCard/DescriptionEditor.jsx
@@ -98,6 +98,7 @@ class DescriptionEditor extends React.Component {
       * 
       */
     async handleDescSave() {
+        const accessToken = localStorage.getItem("cw-access-token");
         const projectid = this.props.projectID;
         this.setState({ isBeingSaved: true, editMode: false });
         try {
@@ -105,14 +106,15 @@ class DescriptionEditor extends React.Component {
                 method: 'put',
                 headers: {
                     'Accept': 'application/json',
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${accessToken}`
                 },
                 body: JSON.stringify({ description: this.state.descFieldValue })
             });
 
             await result.json();
             if (result.status === 200) {
-                this.props.dispatch(reloadMetricsData(projectid, this.props.projectMetricTypes.types));
+                this.props.dispatch(reloadMetricsData(localStorage.getItem('cw-access-token'), projectid, this.props.projectMetricTypes.types));
                 this.setState({ isBeingSaved: false, text: this.state.descFieldValue });
             } else {
                 this.setState({ isBeingSaved: false, errorText: result.statusText });

--- a/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
+++ b/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
@@ -85,7 +85,7 @@ class RunTestHistory extends Component {
         this.setState({ deleteInProgress: true });
         const result = await postDeleteTests(this.props.projectID, rowID);
         if (result.status && result.status === 200) {
-            await this.props.dispatch(reloadMetricsData(this.props.projectID, this.props.projectMetricTypes.types));
+            await this.props.dispatch(reloadMetricsData(localStorage.getItem('cw-access-token'), this.props.projectID, this.props.projectMetricTypes.types));
         } else {
             this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Delete failed', subtitle:'Unable to delete test', caption:`${result.message}` }));
         }
@@ -109,7 +109,7 @@ class RunTestHistory extends Component {
 
         await this.setState({ deleteInProgress: false });
         this.refs.tableTestHistory.handleOnCancel(); // deselect all rows & hide batch action bar
-        this.props.dispatch(reloadMetricsData(this.props.projectID, this.props.projectMetricTypes.types));
+        this.props.dispatch(reloadMetricsData(localStorage.getItem('cw-access-token'), this.props.projectID, this.props.projectMetricTypes.types));
     }
 
     componentWillReceiveProps(nextprops) {

--- a/src/performance/dashboard/src/components/socketWatchers/ProjectClosed.jsx
+++ b/src/performance/dashboard/src/components/socketWatchers/ProjectClosed.jsx
@@ -29,8 +29,8 @@ class ProjectClosed extends Component {
   }
 
   refreshModels(thisComponent) {
-    thisComponent.props.dispatch(fetchProjectConfig(thisComponent.props.projectID));
-    thisComponent.props.dispatch(fetchProjectCapabilities(thisComponent.props.projectID));
+    thisComponent.props.dispatch(fetchProjectConfig(localStorage.getItem('cw-access-token'), thisComponent.props.projectID));
+    thisComponent.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), thisComponent.props.projectID));
   }
 
   bindSocketHandlers() {

--- a/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
+++ b/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
@@ -43,8 +43,8 @@ class ProjectStatus extends Component {
   }
 
   refreshModels(thisComponent) {
-    thisComponent.props.dispatch(fetchProjectConfig(thisComponent.props.projectID));
-    thisComponent.props.dispatch(fetchProjectCapabilities(thisComponent.props.projectID));
+    thisComponent.props.dispatch(fetchProjectConfig(localStorage.getItem('cw-access-token'), thisComponent.props.projectID));
+    thisComponent.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), thisComponent.props.projectID));
   }
 
   bindSocketHandlers() {

--- a/src/performance/dashboard/src/components/status/CapabilitiesPanel.jsx
+++ b/src/performance/dashboard/src/components/status/CapabilitiesPanel.jsx
@@ -43,7 +43,7 @@ class CapabilitiesPanel extends React.Component {
     async componentDidMount() {
         if (!this.props.projectID) return;
         try {
-            await this.props.dispatch(fetchProjectCapabilities(this.props.projectID))
+            await this.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), this.props.projectID))
         } catch (err) {
             console.log("Error loading capabilities: ", err)
         }
@@ -229,9 +229,6 @@ class CapabilitiesPanel extends React.Component {
     render() {
         const dataModel = this.buildDisplayModel();
         const fetching = this.props.projectCapabilities.fetching;
-
-        console.log('this.props.projectInfo.config.appStatus', this.props.projectInfo.config.appStatus);
-
         return (
             <Fragment>
                 <div className="Capabilities">
@@ -245,7 +242,7 @@ class CapabilitiesPanel extends React.Component {
                                     <div key={row.id} className="row " role="gridcell">
                                         <Fragment>
                                             <div className="headline">
-                                                <div className="icon"> 
+                                                <div className="icon">
                                                     { (fetching) ? <InlineLoading description="" iconDescription="Active loading indicator" status="active"/> : this.getIconMarkup(row.status) }
                                                 </div>
                                                 <div className="capability">

--- a/src/performance/dashboard/src/components/status/CapabilitiesPanel.jsx
+++ b/src/performance/dashboard/src/components/status/CapabilitiesPanel.jsx
@@ -115,20 +115,18 @@ class CapabilitiesPanel extends React.Component {
             return
         }
 
-        if (capabilityData.liveMetricsAvailable) {
-            feature.status = Constants.STATUS_OK
-            feature.statusMessage = Constants.MESSAGE_LIVEMETRICS_AVAILABLE;
-            return
-        }
-
         // Show the re-enable auth button
-        if (capabilityData.microprofilePackageAuthenticationDisabled &&
-            !capabilityData.metricsEndpoint &&
-            capabilityData.microprofilePackageFoundInBuildFile)
-            {
+        if (capabilityData.microprofilePackageAuthenticationDisabled) {
             feature.status = Constants.STATUS_OK
             feature.statusMessage = Constants.MESSAGE_LIVEMETRICS_MICROPROFILE_ISDISABLED;
             feature.detailSubComponent = Constants.MESSAGE_COMPONENT_LIVEMETRICS_MICROPROFILE_ENABLE_AUTH;
+            return
+        }
+
+        // If live metrics is enabled - everything is good
+        if (capabilityData.liveMetricsAvailable) {
+            feature.status = Constants.STATUS_OK
+            feature.statusMessage = Constants.MESSAGE_LIVEMETRICS_AVAILABLE;
             return
         }
 

--- a/src/performance/dashboard/src/components/status/DetailPanel.jsx
+++ b/src/performance/dashboard/src/components/status/DetailPanel.jsx
@@ -33,7 +33,7 @@ class DetailPanel extends Component {
         detailSubComponent = <MPDisableAuth projectID={this.props.projectID} />
         break;
       case  Constants.MESSAGE_COMPONENT_LIVEMETRICS_MICROPROFILE_ENABLE_AUTH:
-        detailSubComponent = <MPEnableAuth></MPEnableAuth>
+        detailSubComponent = <MPEnableAuth projectID={this.props.projectID} />
         break;
       default:
         detailSubComponent = <Fragment></Fragment>

--- a/src/performance/dashboard/src/components/status/messages/actions/ActionDisableMicroProfileAuth.jsx
+++ b/src/performance/dashboard/src/components/status/messages/actions/ActionDisableMicroProfileAuth.jsx
@@ -60,10 +60,11 @@ class ActionDisableMicroProfileAuth extends Component {
    * @param {string} projectID
    */
   async dispatchRequest() {
+    const accessToken = localStorage.getItem('cw-access-token');
     const response = fetch(`${AppConstants.API_SERVER}/api/v1/projects/${this.props.projectID}/metrics/auth`,
         {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}`},
             body: JSON.stringify({disable:true})
         });
      const reply = await response;

--- a/src/performance/dashboard/src/components/status/messages/actions/ActionEnableMicroProfileAuth.jsx
+++ b/src/performance/dashboard/src/components/status/messages/actions/ActionEnableMicroProfileAuth.jsx
@@ -60,10 +60,11 @@ class ActionEnableMicroProfileAuth extends Component {
    * @param {string} projectID
    */
   async dispatchRequest() {
+    const accessToken = localStorage.getItem('cw-access-token');
     const response = fetch(`${AppConstants.API_SERVER}/api/v1/projects/${this.props.projectID}/metrics/auth`,
         {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${accessToken}` },
             body: JSON.stringify({disable:false})
         });
      const reply = await response;

--- a/src/performance/dashboard/src/index.js
+++ b/src/performance/dashboard/src/index.js
@@ -61,14 +61,15 @@ async function init() {
             } else {
                 console.info(`Dashboard - authenticated`);
             }
+
+            localStorage.setItem("cw-access-token", keycloak.token);
+            localStorage.setItem("cw-refresh-token", keycloak.refreshToken);
+
             ReactDOM.render(
                 <Provider store={configureStore}>
                     <App />
                 </Provider>
                 , document.getElementById('root'));
-
-            localStorage.setItem("cw-access-token", keycloak.token);
-            localStorage.setItem("cw-refresh-token", keycloak.refreshToken);
 
             // Access token refresh
             setTimeout(() => {

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -61,20 +61,27 @@ class PagePerformance extends React.Component {
     }
 
     async componentDidMount() {
-        
+
         // Check if page was called with a projectID.  If note, the render() will display further instructions.
         if (!this.props.projectID) { return; }
         this.bindSocketHandlers();
 
         // read the project configuration
         await this.props.dispatch(fetchProjectConfig(localStorage.getItem("cw-access-token"), this.props.projectID));
+        if (this.props.projectConfig && this.props.projectConfig.error) {
+            this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Error loading project details', subtitle:this.props.projectConfig.error.message , caption:`${this.props.projectConfig.error.err}` }));
+            return;
+        }
 
         // read the load runner configuration
         await this.props.dispatch(fetchProjectLoadConfig(localStorage.getItem("cw-access-token"), this.props.projectID));
+        if (this.props.loadRunnerConfig && this.props.loadRunnerConfig.error) {
+            this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Error loading test parameters', subtitle:this.props.loadRunnerConfig.error.message , caption:`${this.props.loadRunnerConfig.error.err}` }));
+            return;
+        }
 
         // Determine which metrics are available for this project
         await this.props.dispatch(fetchProjectMetricTypes(localStorage.getItem("cw-access-token"), this.props.projectMetricTypes, this.props.projectID));
-
         const projectMetricTypes = this.props.projectMetricTypes;
         if (projectMetricTypes && projectMetricTypes.error) {
             this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Error loading metric types', subtitle:projectMetricTypes.error.message , caption:`${projectMetricTypes.error.err}` }));
@@ -84,7 +91,6 @@ class PagePerformance extends React.Component {
         // Get the metrics for the project
         await this.props.dispatch(fetchProjectMetrics(localStorage.getItem("cw-access-token"), this.props.projectMetrics, this.props.projectID, projectMetricTypes.types));
         const projectMetrics = this.props.projectMetrics;
-
         if (projectMetrics && projectMetrics.error) {
             this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Error loading project metrics', subtitle:projectMetrics.error.message  , caption:`${projectMetrics.error.err}` }));
         }

--- a/src/performance/dashboard/src/pages/PagePerformance.jsx
+++ b/src/performance/dashboard/src/pages/PagePerformance.jsx
@@ -61,18 +61,19 @@ class PagePerformance extends React.Component {
     }
 
     async componentDidMount() {
+        
         // Check if page was called with a projectID.  If note, the render() will display further instructions.
         if (!this.props.projectID) { return; }
         this.bindSocketHandlers();
 
         // read the project configuration
-        await this.props.dispatch(fetchProjectConfig(this.props.projectID));
+        await this.props.dispatch(fetchProjectConfig(localStorage.getItem("cw-access-token"), this.props.projectID));
 
         // read the load runner configuration
-        await this.props.dispatch(fetchProjectLoadConfig(this.props.projectID));
+        await this.props.dispatch(fetchProjectLoadConfig(localStorage.getItem("cw-access-token"), this.props.projectID));
 
         // Determine which metrics are available for this project
-        await this.props.dispatch(fetchProjectMetricTypes(this.props.projectMetricTypes, this.props.projectID));
+        await this.props.dispatch(fetchProjectMetricTypes(localStorage.getItem("cw-access-token"), this.props.projectMetricTypes, this.props.projectID));
 
         const projectMetricTypes = this.props.projectMetricTypes;
         if (projectMetricTypes && projectMetricTypes.error) {
@@ -81,11 +82,11 @@ class PagePerformance extends React.Component {
         }
 
         // Get the metrics for the project
-        await this.props.dispatch(fetchProjectMetrics(this.props.projectMetrics, this.props.projectID, projectMetricTypes.types));
+        await this.props.dispatch(fetchProjectMetrics(localStorage.getItem("cw-access-token"), this.props.projectMetrics, this.props.projectID, projectMetricTypes.types));
         const projectMetrics = this.props.projectMetrics;
 
         if (projectMetrics && projectMetrics.error) {
-            this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Error loading project metrics', subtitle:rojectMetrics.error.message  , caption:`${projectMetrics.error.err}` }));
+            this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Error loading project metrics', subtitle:projectMetrics.error.message  , caption:`${projectMetrics.error.err}` }));
         }
     }
 
@@ -145,7 +146,7 @@ class PagePerformance extends React.Component {
     }
 
     reloadMetrics(projectID) {
-        this.props.dispatch(reloadMetricsData(projectID, this.props.projectMetricTypes.types));
+        this.props.dispatch(reloadMetricsData(localStorage.getItem('cw-access-token'), projectID, this.props.projectMetricTypes.types));
     }
 
     render() {

--- a/src/performance/dashboard/src/store/actions/loadRunnerConfigActions.js
+++ b/src/performance/dashboard/src/store/actions/loadRunnerConfigActions.js
@@ -56,13 +56,13 @@ function fetchWriteRejected(json) {
 }
 
 
-function fetchConfig(projectID) {
+function fetchConfig(access_token, projectID) {
     return dispatch => {
         dispatch(requestConfig());
         return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/loadtest/config`,
             {
                 method: "GET",
-                headers: { "Content-Type": "application/json" }
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${access_token}` },
             }
         ).then(function (response) {
             let data = response.json();
@@ -104,7 +104,7 @@ function fetchConfig(projectID) {
 * }
 * 
 */
-function saveConfig(projectID, config) {
+function saveConfig(access_token, projectID, config) {
 
     // Clone the config then update it with path and query in the form requwired by the loadtest/config API
     let formattedContents = Object.assign({}, config);
@@ -117,8 +117,8 @@ function saveConfig(projectID, config) {
         return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/loadtest/config`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(formattedContents)
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${access_token}` },
+                body: JSON.stringify(formattedContents),
             }
         ).then(function (response) {
             if (response.status !== 200) {
@@ -148,9 +148,9 @@ function saveConfig(projectID, config) {
 /**
 Consumers should call this function to retrieve the config
 */
-function fetchProjectLoadConfig(projectID) {
+function fetchProjectLoadConfig(accessToken, projectID) {
     return (dispatch) => {
-        return dispatch(fetchConfig(projectID));
+        return dispatch(fetchConfig(accessToken, projectID));
     };
 }
 
@@ -158,9 +158,9 @@ function fetchProjectLoadConfig(projectID) {
 * @param {*} projectID           Project to update
 * @param {*} newConfigFileContents  JSONObject contents of the config.json file
 */
-function saveProjectLoadConfig(projectID, newConfigFileContents) {
+function saveProjectLoadConfig(access_token, projectID, newConfigFileContents) {
     return (dispatch) => {
-        return dispatch(saveConfig(projectID, newConfigFileContents));
+        return dispatch(saveConfig(access_token, projectID, newConfigFileContents));
     };
 }
 

--- a/src/performance/dashboard/src/store/actions/projectCapabilitiesActions.js
+++ b/src/performance/dashboard/src/store/actions/projectCapabilitiesActions.js
@@ -33,13 +33,13 @@ function fetchRejected(json) {
   };
 }
 
-function fetchCapabilities(projectID) {
+function fetchCapabilities(access_token, projectID) {
   return dispatch => {
     dispatch(requestCapabilities());
     return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/metrics/status`,
       {
         method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json',  Authorization: `Bearer ${access_token}` },
       },
     ).then(function(response) {
       const data = response.json();
@@ -69,9 +69,9 @@ function fetchCapabilities(projectID) {
 /**
 Consumers should call this function to retrieve the project capabilities
 */
-function fetchProjectCapabilities(projectID) {
+function fetchProjectCapabilities(access_token, projectID) {
   return (dispatch) => {
-    return dispatch(fetchCapabilities(projectID));
+    return dispatch(fetchCapabilities(access_token, projectID));
   };
 }
 

--- a/src/performance/dashboard/src/store/actions/projectInfoActions.js
+++ b/src/performance/dashboard/src/store/actions/projectInfoActions.js
@@ -33,13 +33,13 @@ function fetchRejected(json) {
     };
 }
 
-function fetchConfig(projectID) {
+function fetchConfig(access_token, projectID) {
     return dispatch => {
         dispatch(requestConfig());
         return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}`,
             {
                 method: "GET",
-                headers: { "Content-Type": "application/json" }
+                headers: { "Content-Type": "application/json",  Authorization: `Bearer ${access_token}` }
             }
         ).then(function (response) {
             let data = response.json();
@@ -70,9 +70,9 @@ function fetchConfig(projectID) {
 /**
 Consumers should call this function to retrieve the config
 */
-function fetchProjectConfig(projectID) {
+function fetchProjectConfig(access_token, projectID) {
     return (dispatch) => {
-        return dispatch(fetchConfig(projectID));
+        return dispatch(fetchConfig(access_token, projectID));
     };
 }
 

--- a/src/performance/dashboard/src/store/actions/projectMetricTypesActions.js
+++ b/src/performance/dashboard/src/store/actions/projectMetricTypesActions.js
@@ -33,10 +33,14 @@ function fetchRejected(json) {
     };
 }
 
-function fetchMetricTypes(projectID) {
+function fetchMetricTypes(access_token, projectID) {
     return dispatch => {
         dispatch(requestMetricTypes());
-        return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/metrics`)
+        return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/metrics`,
+        {
+            method: "GET",
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${access_token}` },
+        })
             .then(function (response) {
                 let data = response.json();
 
@@ -78,10 +82,10 @@ function shouldFetchMetricTypes(data) {
 /**
 Consumers should call this function to retrieve a list of which metrics are available
 */
-function fetchProjectMetricTypes(data, projectID) {
+function fetchProjectMetricTypes(access_token, data, projectID) {
     return (dispatch) => {
         if (shouldFetchMetricTypes(data)) {
-            return dispatch(fetchMetricTypes(projectID));
+            return dispatch(fetchMetricTypes(access_token, projectID));
         }
         return Promise.resolve();
     };

--- a/src/performance/dashboard/src/store/actions/projectMetricsActions.js
+++ b/src/performance/dashboard/src/store/actions/projectMetricsActions.js
@@ -9,7 +9,7 @@
 *     IBM Corporation - initial API and implementation
 *******************************************************************************/
 
-var AppConstants = require('../../AppConstants');
+const AppConstants = require('../../AppConstants');
 const ActionTypes = require('./types');
 
 function requestMetrics() {
@@ -33,10 +33,10 @@ function fetchRejected(json) {
     };
 }
 
-function fetchMetrics(projectID, availableTypes) {
+function fetchMetrics(access_token, projectID, availableTypes) {
 
-    let validTypes = {};
-    // extract the availble types eg :   ["cpu", "memory", 'http'];
+    const validTypes = {};
+    // extract the available types eg :   ["cpu", "memory", 'http'];
     validTypes.types = availableTypes.map(t => t.type);
 
     return dispatch => {
@@ -44,12 +44,12 @@ function fetchMetrics(projectID, availableTypes) {
         return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/metrics/types`,
             {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: { "Content-Type": "application/json", Authorization: `Bearer ${access_token}` },
                 body: JSON.stringify(validTypes),
             }
         )
             .then(function (response) {
-                let data = response.json();
+                const data = response.json();
 
                 // 422 is expected for a project with empty load-test history
                 if (response.status === 422) { return []; }
@@ -90,20 +90,20 @@ function shouldFetchMetrics(data) {
 /**
 Consumers should call this function to retrieve metrics data
 */
-function fetchProjectMetrics(data, projectID, availableTypes) {
+function fetchProjectMetrics(access_token, data, projectID, availableTypes) {
     return (dispatch) => {
         if (shouldFetchMetrics(data)) {
-            return dispatch(fetchMetrics(projectID, availableTypes));
+            return dispatch(fetchMetrics(access_token, projectID, availableTypes));
         }
         return Promise.resolve();
     };
 }
 
-function postDeleteTests(projectID, idToDelete) {
+function postDeleteTests(access_token, projectID, idToDelete) {
     return fetch(`${AppConstants.API_SERVER}/api/v1/projects/${projectID}/metrics/${idToDelete}`,
         {
             method: "DELETE",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", Authorization: `Bearer ${access_token}` },
         })
         .then(response => {
             if (response.status === 200) {
@@ -119,9 +119,9 @@ function postDeleteTests(projectID, idToDelete) {
         });
 }
 
-function reloadMetricsData(projectID, availableTypes) {
+function reloadMetricsData(access_token, projectID, availableTypes) {
     return (dispatch) => {
-        return dispatch(fetchMetrics(projectID, availableTypes));
+        return dispatch(fetchMetrics(access_token, projectID, availableTypes));
     };
 }
 


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

If the dashboard has loaded but then at some point later there is a network burb or the gatekeeper pod were to be restarted,  the dashboard may stay disconnected and miss future socket notifications or fail sending followup REST requests to Codewind.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

Issue:  https://github.com/eclipse/codewind/issues/2901

also requires PFE PR:  https://github.com/eclipse/codewind/pull/2980

## Does this PR require a documentation change ?

NO

## Any special notes for your reviewer ?

This PR does a few things : 

1.  Temporarily adds additional socket event debug to assist SVT
2.  Sends bearer access tokens when calling Codewind APIs rather than the old cookie method. which get rejected when the session table gets reset in Gatekeeper.
3.  Uses the latest updated token retrieved direct from Keycloak.
4.  Displays errors to the user when fetch requests fail
5.  Updates the order certain things happen (like making sure the tokes are updated before using them)
6.  Changes the criteria around when Auth can be re-enabled to match recent changes in the `/metrics/status` API.

Ran existing dashboard tests : 

```
Test Suites: 10 passed, 10 total
Tests:       64 passed, 64 total
Snapshots:   0 total
Time:        10.302s, estimated 11s
Ran all test suites.
```


