### PR TITLE
Prevent Build if Load in Progress

### DIFF
--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -337,7 +337,7 @@ function getMode(project) {
 async function syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID) {
   // If the current project is being built, we do not want to copy the files as this will
   // interfere with the current build
-  if (project.buildStatus != "inProgress") {
+  if (project.buildStatus != "inProgress" && project.loadRunner.isIdle()) {
     const globalProjectPath = project.projectPath();
     // We now need to remove any files that have been deleted from the global workspace
     await Promise.all(filesToDelete.map(oldFile => cwUtils.forceRemove(path.join(globalProjectPath, oldFile))));
@@ -388,7 +388,7 @@ async function syncToBuildContainer(project, filesToDelete, modifiedList, timeSt
     }
     user.fileChanged(projectID, timeStamp, 1, 1, IFileChangeEvent);
   } else {
-    // if a build is in progress, wait 5 seconds and try again
+    // if a build or loadrun is in progress, wait 5 seconds and try again
     await cwUtils.timeout(5000)
     await syncToBuildContainer(project, filesToDelete, modifiedList, timeStamp, IFileChangeEvent, user, projectID);
   }

--- a/src/pfe/portal/routes/projects/build.route.js
+++ b/src/pfe/portal/routes/projects/build.route.js
@@ -36,8 +36,8 @@ async function buildProject(req, res) {
       return;
     }
     
-    if (project.isClosed() || project.isClosing() || project.isDeleting()) {
-      const msg = `Cannot perform build action ${action} on ${project.name} because it is in state ${project.state}.`;
+    if (project.isClosed() || project.isClosing() || project.isDeleting() || !project.loadRunner.isIdle()) {
+      const msg = `Cannot perform build action ${action} on ${project.name} because it is in state ${project.state}. Or a load run is in progress.`;
       res.status(400).send(msg);
       log.error(msg);
       return;


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Prevents the build endpoint and the upload/end endpoint from triggering a build while there is a loadrun in progress on the target project.

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/2870

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No.

## Any special notes for your reviewer ?
No.