### PR TITLE
Reduce Cancel Socket Messages

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -450,9 +450,7 @@ module.exports = class LoadRunner {
   * Function to cancel the loadrunner
   */
   async cancelRunLoad(loadConfig) {
-    if (this.heartbeatID !== null) {
-      clearTimeout(this.heartbeatID);
-    }
+    this.heartbeat('cancelling');
     try {
       let options = {
         host: this.hostname,

--- a/test/src/unit/modules/User.test.js
+++ b/test/src/unit/modules/User.test.js
@@ -139,6 +139,7 @@ describe('User.js', () => {
                 'secure',
                 'dockerConfigFile',
                 'codewindPFESecretName',
+                'cancelRequests',
             ]);
             user.user_id.should.equal('default');
             user.workspace.should.equal(testWorkspace);
@@ -169,6 +170,7 @@ describe('User.js', () => {
                 'dockerConfigFile',
                 'codewindPFESecretName',
                 'k8Client',
+                'cancelRequests',
             ]);
             user.user_id.should.equal('default');
             user.workspace.should.equal(testWorkspace);
@@ -210,6 +212,7 @@ describe('User.js', () => {
                 'templates',
                 'fw',
                 'loadRunner',
+                'cancelRequests',
             ]);
             user.user_id.should.equal('default');
             user.workspace.should.equal(testWorkspace);
@@ -335,6 +338,12 @@ describe('User.js', () => {
             
             await user.cancelLoad(project)
                 .should.eventually.be.rejectedWith(`Unable to cancel, no load run in progress.\nFor project ${sampleProjectID}`);
+        });
+        it('errors if a cancel request has already been made on the load run', async() => {
+            const { user, project } = await createSimpleUserWithProject();
+            user.cancelRequests[project.projectID] = true;
+
+            await user.cancelLoad(project).should.eventually.be.rejectedWith('Cancel request already in progress.');
         });
         it('gets to LoadRunner.cancelRunLoad() then errors because we are not connected to the LoadRunner container', async() => {
             const { user, project } = await createSimpleUserWithProject();


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Reduces the amount of 'Cancelling' socket messages coming out of User.js when a cancel request is made on a load run.

Adds a cancelRequests field to User.js that tracks whether a project load run is currently being cancelled. Prevents additional requests to cancel being made. Previously the user could click the cancel button multiple times on the performance dashboard, which would stack up these requests. 

## Which issue(s) does this PR fix ?
https://github.com/eclipse/codewind/issues/3029

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No