### PR TITLE
Remove cancel load button and timer when load is cancelling

### DIFF
--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -77,12 +77,12 @@ class ActionRunLoad extends React.Component {
                         break;
                     }
                     case 'collecting': {
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Collecting...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Collecting...' });
                         break;
                     }
                     case 'completed': {
                         // after receiving a loadrun completion message,  wait a bit,  then reset the button back to ready
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Completed...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Completed...' });
                         setTimeout(() => {
                             this.setState({ loadRunStatus: { status: 'idle' } });
                             this.props.dispatch(addNotification({kind: KIND_SUCCESS, title:'Load runner finished', subtitle:'The test has completed successfully',  timeout: 6,}));
@@ -90,11 +90,11 @@ class ActionRunLoad extends React.Component {
                         break;
                     }
                     case 'cancelling': {
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelling...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelling...' });
                         break;
                     }
                     case 'cancelled': {
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelled...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelled...' });
                         setTimeout(() => {
                             this.setState({ loadRunStatus: { status: 'idle' } })
                         }, 2000);
@@ -220,9 +220,13 @@ class ActionRunLoad extends React.Component {
                                 <div style={{ display: 'inline-block', verticalAlign: "middle" }}>
                                     <InlineLoading style={{ marginLeft: '1rem' }} description={inlineTextLabelFormatted} success={loadRunCompleted} />
                                 </div>
-                                <div style={{ display: 'inline-block', verticalAlign: "middle", float: 'right' }}>
-                                    <Button onClick={() => this.handleCancelLoad()} style={{ verticalAlign: "middle", padding: 0, margin: 0 }} renderIcon={IconStop} kind="ghost" small iconDescription="Stop the load run"></Button>
-                                </div>
+                                {
+                                    loadRunStatus.status === "running" ? (
+                                    <div style={{ display: 'inline-block', verticalAlign: "middle", float: 'right' }}>
+                                        <Button onClick={() => this.handleCancelLoad()} style={{ verticalAlign: "middle", padding: 0, margin: 0 }} renderIcon={IconStop} kind="ghost" small iconDescription="Stop the load run"></Button>
+                                    </div>
+                                    ) : <Fragment/>
+                                }
                             </Fragment>
                         ) : (
                                 <Fragment>


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Removes the cancel button and the timer that remains in view after the user requests the running load to be cancelled. This PR changes behaviour so that the action and counter only appear during the running phase. 

## Which issue(s) does this PR fix ?
3049

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

https://github.com/eclipse/codewind/issues/3049

## Does this PR require a documentation change ?

## Any special notes for your reviewer ?

To try this out,  run a load test,  cancel it,  confirm that the cancel X button is removed along with the countdown timer. 
