### PR TITLE
Typo in expect a follow-up notification

### DIFF
--- a/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
+++ b/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
@@ -84,7 +84,7 @@ class ProjectStatus extends Component {
                 kind: KIND_INFO,
                 title: 'Project status: starting',
                 subtitle: 'Please wait whilst the project launches',
-                caption: 'Expect a followup notification once the project has started',
+                caption: 'Expect a follow-up notification once the project has started',
                 timeout: NOTIFICATION_TIMEOUT_MEDIUM,
               }
             ));


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Fixes typo in the notification message : 

From: `Expect a followup notification once the project has started`

To:  `Expect a follow-up notification once the project has started`

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
NO