### PR TITLE
Update UI tests with changes to the disable auth button label

### DIFF
--- a/src/performance/dashboard/src/components/status/messages/actions/__tests__/ActionDisableMicroProfileAuth.test.js
+++ b/src/performance/dashboard/src/components/status/messages/actions/__tests__/ActionDisableMicroProfileAuth.test.js
@@ -45,7 +45,7 @@ describe('<ActionDisableMicroProfileAuth />', () => {
 
   test('ActionButton sends a valid request to API and displays accepted', async () => {
     const { getByLabelText, container, getByText } = render(wrapper);
-    const button = getByLabelText('Disable Authentication');
+    const button = getByLabelText('Allow anonymous connections');
     global.fetch = jest.fn().mockImplementationOnce(() => {
       return new Promise((resolve, reject) => {
         resolve({
@@ -60,7 +60,7 @@ describe('<ActionDisableMicroProfileAuth />', () => {
 
   test('ActionButton sends an invalid request to API and displays a warning', async () => {
     const { getByLabelText, getByText } = render(wrapper);
-    const button = getByLabelText('Disable Authentication');
+    const button = getByLabelText('Allow anonymous connections');
     global.fetch = jest.fn().mockImplementationOnce(() => {
       return new Promise((resolve, reject) => {
         resolve({


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Updates the UI tests to use the new button label : `Allow anonymous connections` where previously the button was labelled as. : `Disable Authentication`

![image](https://user-images.githubusercontent.com/28102564/83143326-aee09780-a0e9-11ea-88f3-a29f845eb05c.png)
## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?

Ran component test with change : 
```
  <ActionDisableMicroProfileAuth />
    ✓ component renders without crashing (78ms)
    ✓ ActionButton sends a valid request to API and displays accepted (1963ms)
    ✓ ActionButton sends an invalid request to API and displays a warning (1414ms)
```

All UI tests : 

```
Test Suites: 10 passed, 10 total
Tests:       64 passed, 64 total
Snapshots:   0 total
Time:        13.869s
Ran all test suites.
```