### PR TITLE
add port discovery using Openshift Routes

### DIFF
--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -152,18 +152,19 @@ module.exports = class Project {
       try {
         const namespace = process.env.KUBE_NAMESPACE
         const { projectID } = this;
-        
+
         const client = new Client({ backend: new Request( config.getInCluster() ), version: '1.13' })
-    
+
         const services = await client.api.v1.namespaces(namespace).services.get({ qs: { labelSelector: 'projectID='+projectID } })
-        const ingressPort = await cwUtils.getServicePortFromProjectIngress(projectID);
+        const discoveredPort = await cwUtils.getServicePortFromProjectIngressOrRoute(projectID);
+
         if (services && services.body && services.body.items && services.body.items[0]) {
           const ipAddress = services.body.items[0].spec.clusterIP
           const targetPort = services.body.items[0].spec.ports[0].targetPort
           const serviceName = services.body.items[0].metadata.name
 
-          // prefer the ingress port if available
-          const port = ingressPort ? ingressPort : targetPort;
+          // prefer the discovered port if available
+          const port = discoveredPort ? discoveredPort : targetPort;
 
           // update service host
           this.kubeServiceHost = ipAddress

--- a/src/pfe/portal/modules/Project.js
+++ b/src/pfe/portal/modules/Project.js
@@ -156,7 +156,7 @@ module.exports = class Project {
         const client = new Client({ backend: new Request( config.getInCluster() ), version: '1.13' })
 
         const services = await client.api.v1.namespaces(namespace).services.get({ qs: { labelSelector: 'projectID='+projectID } })
-        const discoveredPort = await cwUtils.getServicePortFromProjectIngressOrRoute(projectID);
+        const discoveredPort = await cwUtils.getPortFromProjectIngressOrRoute(projectID);
 
         if (services && services.body && services.body.items && services.body.items[0]) {
           const ipAddress = services.body.items[0].spec.clusterIP

--- a/src/pfe/portal/modules/utils/kubernetesFunctions.js
+++ b/src/pfe/portal/modules/utils/kubernetesFunctions.js
@@ -125,7 +125,7 @@ async function getProjectIngress(projectID) {
   return ingress;
 }
 
-async function getServicePortFromProjectIngress(projectID) {
+async function getPortFromProjectIngress(projectID) {
   try {
     const ingress = await getProjectIngress(projectID);
     // sanitise the response ingress
@@ -161,7 +161,7 @@ async function getProjectRoute(projectID) {
   return route;
 }
 
-async function getServicePortFromProjectRoute(projectID) {
+async function getPortFromProjectRoute(projectID) {
   try {
     const route = await getProjectRoute(projectID);
     // sanitise the response route
@@ -178,14 +178,14 @@ async function getServicePortFromProjectRoute(projectID) {
   }
 }
 
-async function getServicePortFromProjectIngressOrRoute(projectID) {
-  const servicePorts = await Promise.all([
-    getServicePortFromProjectIngress(projectID),
-    getServicePortFromProjectRoute(projectID),
+async function getPortFromProjectIngressOrRoute(projectID) {
+  const ports = await Promise.all([
+    getPortFromProjectIngress(projectID),
+    getPortFromProjectRoute(projectID),
   ]);
   // return the first non null value (or null if all are null)
-  const servicePort = servicePorts.find(port => !!port);
-  return servicePort || null;
+  const port = ports.find(port => !!port);
+  return port || null;
 }
 
 module.exports = {
@@ -198,5 +198,5 @@ module.exports = {
   updateConfigMap,
   getProjectDeployments,
   patchProjectDeployments,
-  getServicePortFromProjectIngressOrRoute,
+  getPortFromProjectIngressOrRoute,
 }

--- a/src/pfe/portal/modules/utils/kubernetesFunctions.js
+++ b/src/pfe/portal/modules/utils/kubernetesFunctions.js
@@ -198,9 +198,5 @@ module.exports = {
   updateConfigMap,
   getProjectDeployments,
   patchProjectDeployments,
-  getProjectIngress,
-  getServicePortFromProjectIngress,
-  getProjectRoute,
-  getServicePortFromProjectRoute,
   getServicePortFromProjectIngressOrRoute,
 }

--- a/test/src/unit/modules/utils/kubernetesFunctions.test.js
+++ b/test/src/unit/modules/utils/kubernetesFunctions.test.js
@@ -40,49 +40,49 @@ const MOCKED_CONFIG = {
 
 describe('kubernetesFunctions.js', function() {
     this.timeout(testTimeout.short);
-    describe('getServicePortFromProjectIngressOrRoute(projectID)', function() {
+    describe('getPortFromProjectIngressOrRoute(projectID)', function() {
         const sandbox = sinon.createSandbox();
         afterEach(() => {
             sandbox.restore();
         });
         describe('when both the ingress and route return one item in their response body (exactly 1 ingress or route found)', function() {
             it('returns the ingress port as it takes priority when both the ingress and route ports are returned', async function() {
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireServicePortFromIngressAndRoute('ingress', 'route');
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquirePortFromIngressAndRoute('ingress', 'route');
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 port.should.equal('ingress');
             });
             it('returns the ingress port as route is null', async function() {
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireServicePortFromIngressAndRoute('ingress', null);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquirePortFromIngressAndRoute('ingress', null);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 port.should.equal('ingress');
             });
             it('returns the route port as ingress is null', async function() {
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireServicePortFromIngressAndRoute(null, 'route');
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquirePortFromIngressAndRoute(null, 'route');
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 port.should.equal('route');
             });
             it('returns null as both the ingress and route ports are false', async function() {
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireServicePortFromIngressAndRoute(false, false);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquirePortFromIngressAndRoute(false, false);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 chai.expect(port).to.equal(null);
             });
         });
         describe('when the ingress or route return an invalid response body (ingress or route not found)', function() {
             it('returns null as both the ingress and route request returns 0 items in the response body', async function() {
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute([], []);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute([], []);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 chai.expect(port).to.equal(null);
             });
             it('returns null as both the ingress and route request return an invalid response', async function() {
                 const invalidResponse = { invalidResponse: true };
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute(invalidResponse, invalidResponse);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute(invalidResponse, invalidResponse);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 chai.expect(port).to.equal(null);
             });
             it('returns null as both the ingress and route request throw an error when performing the get request', async function() {
                 const throwErr = () => { throw new Error(); };
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireGetIngressAndRoute(throwErr, throwErr);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquireGetIngressAndRoute(throwErr, throwErr);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 chai.expect(port).to.equal(null);
             });
         });
@@ -92,8 +92,8 @@ describe('kubernetesFunctions.js', function() {
                     createIngressItem(1000),
                     createIngressItem(2000),
                 ];
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute(ingressItems, []);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute(ingressItems, []);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 port.should.equal(1000);
             });
             it('returns the first item\'s port when only routes returns valid items', async function() {
@@ -101,8 +101,8 @@ describe('kubernetesFunctions.js', function() {
                     createRouteItem(1000),
                     createRouteItem(2000),
                 ];
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute([], routeItems);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute([], routeItems);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 port.should.equal(1000);
             });
             it('returns the first item\'s port from the ingress when both ingress and routes returns valid items (ingress takes precedence)', async function() {
@@ -114,8 +114,8 @@ describe('kubernetesFunctions.js', function() {
                     createRouteItem(3000),
                     createRouteItem(4000),
                 ];
-                const { getServicePortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute(ingressItems, routeItems);
-                const port = await getServicePortFromProjectIngressOrRoute('projectID');
+                const { getPortFromProjectIngressOrRoute } = proxyquireBodyItemsFromIngressAndRoute(ingressItems, routeItems);
+                const port = await getPortFromProjectIngressOrRoute('projectID');
                 port.should.equal(1000);
             });
         });
@@ -133,11 +133,11 @@ describe('kubernetesFunctions.js', function() {
                     },
                 };
             });
-            const { getServicePortFromProjectIngressOrRoute } = proxyquireKubernetesFunctions({
+            const { getPortFromProjectIngressOrRoute } = proxyquireKubernetesFunctions({
                 apis,
                 loadSpec: spiedLoadSpec,
             });
-            await getServicePortFromProjectIngressOrRoute('projectID');
+            await getPortFromProjectIngressOrRoute('projectID');
             spiedLoadSpec.should.be.calledOnce;
         });
     });
@@ -200,7 +200,7 @@ function proxyquireBodyItemsFromIngressAndRoute(ingressItems, routesItems) {
     }));
 }
 
-function proxyquireServicePortFromIngressAndRoute(ingressPort, routePort) {
+function proxyquirePortFromIngressAndRoute(ingressPort, routePort) {
     const ingressItem = createIngressItem(ingressPort);
     const routeItem = createRouteItem(routePort);
     return proxyquireBodyItemsFromIngressAndRoute([ingressItem], [routeItem]);


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
### Summary
Enhance the method we use to determine the application port to use for load testing and linking - when a project has multiple ports we can use the ingress/route port to work out which one is supposed to be the application port.
Support for using the Ingress port was added in [PR 2748](https://github.com/eclipse/codewind/pull/2748/files#diff-77019e368b4024f7f954f2008537bb8aR138). This PR enhances this for the `odo` extension which doesn't create an ingress for its projects by using the `Openshift Route` when an ingress is not available for a project.

### Testing
Manually tested this works.
Added unit tests for new functions.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
