### PR TITLE
Fix incorrect status of metrics in the performance dashboard

### DIFF
--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -21,6 +21,7 @@ import SocketContext from '../../utils/sockets/SocketContext';
 import { addNotification, KIND_ERROR,  KIND_SUCCESS} from '../../store/actions/notificationsActions';
 import ModalRunTest from '../modals/ModalRunTest';
 import * as AppConstants from '../../AppConstants';
+import { fetchProjectCapabilities } from '../../store/actions/projectCapabilitiesActions';
 
 import './ActionRunLoad.scss';
 
@@ -87,6 +88,7 @@ class ActionRunLoad extends React.Component {
                             this.setState({ loadRunStatus: { status: 'idle' } });
                             this.props.dispatch(addNotification({kind: KIND_SUCCESS, title:'Load runner finished', subtitle:'The test has completed successfully',  timeout: 6,}));
                         }, 3000);
+                        this.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), this.props.projectID));
                         break;
                     }
                     case 'cancelling': {

--- a/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
+++ b/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
@@ -17,7 +17,7 @@ import queryString from 'query-string';
 import { SocketEvents } from '../../utils/sockets/SocketEvents';
 import SocketContext from '../../utils/sockets/SocketContext';
 import { fetchProjectConfig } from '../../store/actions/projectInfoActions';
-import { fetchProjectCapabilities } from '../../store/actions/projectCapabilitiesActions';
+
 import { addNotification, KIND_INFO, KIND_SUCCESS, NOTIFICATION_TIMEOUT_MEDIUM } from '../../store/actions/notificationsActions';
 
 class ProjectStatus extends Component {
@@ -92,7 +92,7 @@ class ProjectStatus extends Component {
           }
           case 'started': {
             thisComponent.props.dispatch(fetchProjectConfig(localStorage.getItem('cw-access-token'), projectID));
-            thisComponent.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), projectID));
+ 
             thisComponent.props.dispatch(addNotification(
               {
                 kind: KIND_SUCCESS,

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -720,15 +720,6 @@ module.exports = class LoadRunner {
     }
     if (this.timerID !== null) {
       clearTimeout(this.timerID);
-      log.info(`cancelProfiling: Stopping liberty server`);
-      const stopCommand = ['bash', '-c', `source $HOME/artifacts/envvars.sh; $HOME/artifacts/server_setup.sh; cd $WLP_USER_DIR;  /opt/ibm/wlp/bin/server stop; `];
-      await cwUtils.spawnContainerProcess(this.project, stopCommand);
-      await this.waitForHealth(false);
-      log.info(`cancelProfiling: Starting liberty server`); 
-      const startCommand = ['bash', '-c', `source $HOME/artifacts/envvars.sh; $HOME/artifacts/server_setup.sh; cd $WLP_USER_DIR;  /opt/ibm/wlp/bin/server start; `];
-      await cwUtils.spawnContainerProcess(this.project, startCommand);
-      await cwUtils.deleteFile(this.project, cwUtils.getProjectSourceRoot(this.project), `load-test/${this.metricsFolder}`);
-      await this.waitForHealth(true);
       await this.project.removeProfilingData(this.metricsFolder);
       this.timerID = null;
     }

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -67,12 +67,7 @@ router.get('/api/v1/projects/:id/metrics/status', checkProjectExists, async func
   try {
     const project = getProjectFromReq(req);
     const { canMetricsBeInjected, appStatus } = project;
-    let capabilities = project.getMetricsCapabilities();
-    //if (!capabilities || Object.keys(capabilities).length === 0) {
-    // If projectMetrics is an empty object, fetch them first
-    const { capabilities: updatedCapabilities } = await project.setMetricsState();
-    capabilities = updatedCapabilities;
-    //}
+    let capabilities = await project.setMetricsState();
     const projectRunning = (appStatus === 'started');
     res.status(200).send({ ...capabilities, canMetricsBeInjected, projectRunning });
   } catch (err) {

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -67,7 +67,8 @@ router.get('/api/v1/projects/:id/metrics/status', checkProjectExists, async func
   try {
     const project = getProjectFromReq(req);
     const { canMetricsBeInjected, appStatus } = project;
-    let capabilities = await project.setMetricsState();
+    const { capabilities: updatedCapabilities } = await project.setMetricsState();
+    let capabilities = updatedCapabilities;
     const projectRunning = (appStatus === 'started');
     res.status(200).send({ ...capabilities, canMetricsBeInjected, projectRunning });
   } catch (err) {

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -68,11 +68,11 @@ router.get('/api/v1/projects/:id/metrics/status', checkProjectExists, async func
     const project = getProjectFromReq(req);
     const { canMetricsBeInjected, appStatus } = project;
     let capabilities = project.getMetricsCapabilities();
-    if (!capabilities || Object.keys(capabilities).length === 0) {
-      // If projectMetrics is an empty object, fetch them first
-      const { capabilities: updatedCapabilities } = await project.setMetricsState();
-      capabilities = updatedCapabilities;
-    }
+    //if (!capabilities || Object.keys(capabilities).length === 0) {
+    // If projectMetrics is an empty object, fetch them first
+    const { capabilities: updatedCapabilities } = await project.setMetricsState();
+    capabilities = updatedCapabilities;
+    //}
     const projectRunning = (appStatus === 'started');
     res.status(200).send({ ...capabilities, canMetricsBeInjected, projectRunning });
   } catch (err) {


### PR DESCRIPTION
## What type of PR is this ? 

- [ x ] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR resolves the issues seen with the metrics capabilities panel and incorrectly giving status.  The change does the following
* Only refreshes the panel when load collection completes, not on a project restart
* Changes the metrics/status api to return a live value rather than a cached value
* When cancelling load, we no longer stop and restart the project (This was to stop profiling collection but actually causes more harm than good)

## Which issue(s) does this PR fix ?
#3036


## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
