### PR TITLE
[0.13.0] Fix incorrect status of metrics in the performance dashboard

### DIFF
--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -77,12 +77,12 @@ class ActionRunLoad extends React.Component {
                         break;
                     }
                     case 'collecting': {
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Collecting...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Collecting...' });
                         break;
                     }
                     case 'completed': {
                         // after receiving a loadrun completion message,  wait a bit,  then reset the button back to ready
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Completed...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Completed...' });
                         setTimeout(() => {
                             this.setState({ loadRunStatus: { status: 'idle' } });
                             this.props.dispatch(addNotification({kind: KIND_SUCCESS, title:'Load runner finished', subtitle:'The test has completed successfully',  timeout: 6,}));
@@ -90,11 +90,11 @@ class ActionRunLoad extends React.Component {
                         break;
                     }
                     case 'cancelling': {
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelling...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelling...' });
                         break;
                     }
                     case 'cancelled': {
-                        this.setState({ showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelled...' });
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Cancelled...' });
                         setTimeout(() => {
                             this.setState({ loadRunStatus: { status: 'idle' } })
                         }, 2000);
@@ -220,9 +220,13 @@ class ActionRunLoad extends React.Component {
                                 <div style={{ display: 'inline-block', verticalAlign: "middle" }}>
                                     <InlineLoading style={{ marginLeft: '1rem' }} description={inlineTextLabelFormatted} success={loadRunCompleted} />
                                 </div>
-                                <div style={{ display: 'inline-block', verticalAlign: "middle", float: 'right' }}>
-                                    <Button onClick={() => this.handleCancelLoad()} style={{ verticalAlign: "middle", padding: 0, margin: 0 }} renderIcon={IconStop} kind="ghost" small iconDescription="Stop the load run"></Button>
-                                </div>
+                                {
+                                    loadRunStatus.status === "running" ? (
+                                    <div style={{ display: 'inline-block', verticalAlign: "middle", float: 'right' }}>
+                                        <Button onClick={() => this.handleCancelLoad()} style={{ verticalAlign: "middle", padding: 0, margin: 0 }} renderIcon={IconStop} kind="ghost" small iconDescription="Stop the load run"></Button>
+                                    </div>
+                                    ) : <Fragment/>
+                                }
                             </Fragment>
                         ) : (
                                 <Fragment>

--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -21,6 +21,7 @@ import SocketContext from '../../utils/sockets/SocketContext';
 import { addNotification, KIND_ERROR,  KIND_SUCCESS} from '../../store/actions/notificationsActions';
 import ModalRunTest from '../modals/ModalRunTest';
 import * as AppConstants from '../../AppConstants';
+import { fetchProjectCapabilities } from '../../store/actions/projectCapabilitiesActions';
 
 import './ActionRunLoad.scss';
 
@@ -87,6 +88,7 @@ class ActionRunLoad extends React.Component {
                             this.setState({ loadRunStatus: { status: 'idle' } });
                             this.props.dispatch(addNotification({kind: KIND_SUCCESS, title:'Load runner finished', subtitle:'The test has completed successfully',  timeout: 6,}));
                         }, 3000);
+                        this.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), this.props.projectID));
                         break;
                     }
                     case 'cancelling': {

--- a/src/performance/dashboard/src/components/modals/ModalModifyLoadTests.jsx
+++ b/src/performance/dashboard/src/components/modals/ModalModifyLoadTests.jsx
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import ProjectIDChecker from '../../utils/projectUtils';
 import { reloadMetricsData } from '../../store/actions/projectMetricsActions';
 import { connect } from 'react-redux';
-import { Modal, TextInput, TextInputSkeleton, TextArea, Dropdown } from 'carbon-components-react';
+import { Modal, TextInput, TextInputSkeleton, TextAreaSkeleton, TextArea, Dropdown } from 'carbon-components-react';
 import { fetchProjectLoadConfig, saveProjectLoadConfig } from '../../store/actions/loadRunnerConfigActions';
 import { TESTRUN_MAX_REQUEST_PER_SEC, TESTRUN_MAX_CONCURRENT, TESTRUN_MAX_DURATION } from '../../AppConstants';
 import * as AppConstants from '../../AppConstants';
@@ -148,7 +148,7 @@ class ModalModifyLoadTests extends React.Component {
     }
 
     render() {
-        let { formFields, dialogStateOpen, saveInProgress, modalErrorText } = this.state;
+        let { formFields, dialogStateOpen, saveInProgress, modalErrorText, loadingData } = this.state;
 
         if (!formFields) {
             return <Fragment />
@@ -186,8 +186,8 @@ class ModalModifyLoadTests extends React.Component {
                                     <tr>
                                         <td className='fieldLabel'><label>Method</label></td>
                                         <td>
-                                            {this.state.loadingData ?
-                                                <TextInputSkeleton hideLabel /> :
+                                            {loadingData ?
+                                                <TextInputSkeleton hideLabel className="sizeSmall"/> :
                                                 <Dropdown
                                                     id="method"
                                                     light
@@ -207,8 +207,8 @@ class ModalModifyLoadTests extends React.Component {
                                     <tr>
                                         <td className='fieldLabel'><label>Path</label></td>
                                         <td>
-                                            {this.state.loadingData ?
-                                                <TextInputSkeleton hideLabel /> :
+                                            {loadingData ?
+                                                <div className="sizeSmall"><TextInputSkeleton hideLabel/></div> :
                                                 <TextInput
                                                     className="inputField"
                                                     id='path'
@@ -228,8 +228,8 @@ class ModalModifyLoadTests extends React.Component {
                                     <tr>
                                         <td className='fieldLabel'><label>Requests/second</label></td>
                                         <td>
-                                            {this.state.loadingData ?
-                                                <TextInputSkeleton hideLabel /> :
+                                            {loadingData ?
+                                                <div className="sizeSmall"><TextInputSkeleton hideLabel/></div> :
                                                 <TextInput
                                                     className="inputField"
                                                     id='requestsPerSecond'
@@ -249,12 +249,12 @@ class ModalModifyLoadTests extends React.Component {
                                     <tr>
                                         <td className='fieldLabel'><label>Concurrent</label></td>
                                         <td>
-                                            {this.state.loadingData ?
-                                                <TextInputSkeleton hideLabel /> :
+                                            {loadingData ?
+                                                <div className="sizeSmall"><TextInputSkeleton hideLabel/></div> :
                                                 <TextInput
                                                     className="inputField"
                                                     id='concurrency'
-                                                    disabled={saveInProgress}
+                                                    disabled={this.state.loadingData || saveInProgress}
                                                     autoComplete="off"
                                                     invalid={!isConcurrentValid.valid}
                                                     invalidText={`${isConcurrentValid.message}`}
@@ -270,12 +270,12 @@ class ModalModifyLoadTests extends React.Component {
                                     <tr>
                                         <td className='fieldLabel'><label>Duration</label></td>
                                         <td>
-                                            {this.state.loadingData ?
-                                                <TextInputSkeleton hideLabel /> :
+                                        {loadingData ?
+                                                <div className="sizeSmall"><TextInputSkeleton hideLabel/></div> :
                                                 <TextInput
                                                     className="inputField"
                                                     id='maxSeconds'
-                                                    disabled={saveInProgress}
+                                                    disabled={this.state.loadingData || saveInProgress}
                                                     autoComplete="off"
                                                     invalid={!isDurationValid.valid}
                                                     invalidText={`${isDurationValid.message}`}
@@ -285,20 +285,20 @@ class ModalModifyLoadTests extends React.Component {
                                                     value={formFields['maxSeconds']}
                                                     onChange={e => this.fieldValueChanged(e)}
                                                     placeholder='Test run duration' />
-                                            }
+                                        }
                                         </td>
                                     </tr>
-                                    <tr>
+                                    <tr className="rowMultiLine">
                                         <td className='fieldLabel'><label>JSON Body</label></td>
                                         <td>
-                                            {this.state.loadingData ?
-                                                <TextInputSkeleton hideLabel /> :
+                                            {loadingData ?
+                                                <TextAreaSkeleton hideLabel /> :
                                                 <TextArea
                                                     className="inputField"
                                                     style={{ "resize": "none" }}
                                                     id='body'
                                                     light={true}
-                                                    disabled={saveInProgress}
+                                                    disabled={loadingData || saveInProgress}
                                                     autoComplete="off"
                                                     invalid={!isBodyValid.valid}
                                                     invalidText={`${isBodyValid.message}`}

--- a/src/performance/dashboard/src/components/modals/ModalModifyLoadTests.scss
+++ b/src/performance/dashboard/src/components/modals/ModalModifyLoadTests.scss
@@ -16,6 +16,18 @@
   vertical-align: middle;
 }
 
+.ModalModifyLoadTest tr.rowMultiLine {
+  height: 110px;
+}
+
+.ModalModifyLoadTest td.fieldLabel {
+  width:140px;
+}
+
+.ModalModifyLoadTest .sizeSmall {
+  width: 180px;
+}
+
 .ModalModifyLoadTest .errorMessage {
   color: red;
   text-align: left;

--- a/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
+++ b/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
@@ -17,7 +17,7 @@ import queryString from 'query-string';
 import { SocketEvents } from '../../utils/sockets/SocketEvents';
 import SocketContext from '../../utils/sockets/SocketContext';
 import { fetchProjectConfig } from '../../store/actions/projectInfoActions';
-import { fetchProjectCapabilities } from '../../store/actions/projectCapabilitiesActions';
+
 import { addNotification, KIND_INFO, KIND_SUCCESS, NOTIFICATION_TIMEOUT_MEDIUM } from '../../store/actions/notificationsActions';
 
 class ProjectStatus extends Component {
@@ -92,7 +92,7 @@ class ProjectStatus extends Component {
           }
           case 'started': {
             thisComponent.props.dispatch(fetchProjectConfig(localStorage.getItem('cw-access-token'), projectID));
-            thisComponent.props.dispatch(fetchProjectCapabilities(localStorage.getItem('cw-access-token'), projectID));
+ 
             thisComponent.props.dispatch(addNotification(
               {
                 kind: KIND_SUCCESS,

--- a/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
+++ b/src/performance/dashboard/src/components/socketWatchers/ProjectStatus.jsx
@@ -84,7 +84,7 @@ class ProjectStatus extends Component {
                 kind: KIND_INFO,
                 title: 'Project status: starting',
                 subtitle: 'Please wait whilst the project launches',
-                caption: 'Expect a followup notification once the project has started',
+                caption: 'Expect a follow-up notification once the project has started',
                 timeout: NOTIFICATION_TIMEOUT_MEDIUM,
               }
             ));

--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -720,15 +720,6 @@ module.exports = class LoadRunner {
     }
     if (this.timerID !== null) {
       clearTimeout(this.timerID);
-      log.info(`cancelProfiling: Stopping liberty server`);
-      const stopCommand = ['bash', '-c', `source $HOME/artifacts/envvars.sh; $HOME/artifacts/server_setup.sh; cd $WLP_USER_DIR;  /opt/ibm/wlp/bin/server stop; `];
-      await cwUtils.spawnContainerProcess(this.project, stopCommand);
-      await this.waitForHealth(false);
-      log.info(`cancelProfiling: Starting liberty server`); 
-      const startCommand = ['bash', '-c', `source $HOME/artifacts/envvars.sh; $HOME/artifacts/server_setup.sh; cd $WLP_USER_DIR;  /opt/ibm/wlp/bin/server start; `];
-      await cwUtils.spawnContainerProcess(this.project, startCommand);
-      await cwUtils.deleteFile(this.project, cwUtils.getProjectSourceRoot(this.project), `load-test/${this.metricsFolder}`);
-      await this.waitForHealth(true);
       await this.project.removeProfilingData(this.metricsFolder);
       this.timerID = null;
     }

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -67,12 +67,7 @@ router.get('/api/v1/projects/:id/metrics/status', checkProjectExists, async func
   try {
     const project = getProjectFromReq(req);
     const { canMetricsBeInjected, appStatus } = project;
-    let capabilities = project.getMetricsCapabilities();
-    //if (!capabilities || Object.keys(capabilities).length === 0) {
-    // If projectMetrics is an empty object, fetch them first
-    const { capabilities: updatedCapabilities } = await project.setMetricsState();
-    capabilities = updatedCapabilities;
-    //}
+    let capabilities = await project.setMetricsState();
     const projectRunning = (appStatus === 'started');
     res.status(200).send({ ...capabilities, canMetricsBeInjected, projectRunning });
   } catch (err) {

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -67,7 +67,8 @@ router.get('/api/v1/projects/:id/metrics/status', checkProjectExists, async func
   try {
     const project = getProjectFromReq(req);
     const { canMetricsBeInjected, appStatus } = project;
-    let capabilities = await project.setMetricsState();
+    const { capabilities: updatedCapabilities } = await project.setMetricsState();
+    let capabilities = updatedCapabilities;
     const projectRunning = (appStatus === 'started');
     res.status(200).send({ ...capabilities, canMetricsBeInjected, projectRunning });
   } catch (err) {

--- a/src/pfe/portal/routes/projects/metrics.route.js
+++ b/src/pfe/portal/routes/projects/metrics.route.js
@@ -68,11 +68,11 @@ router.get('/api/v1/projects/:id/metrics/status', checkProjectExists, async func
     const project = getProjectFromReq(req);
     const { canMetricsBeInjected, appStatus } = project;
     let capabilities = project.getMetricsCapabilities();
-    if (!capabilities || Object.keys(capabilities).length === 0) {
-      // If projectMetrics is an empty object, fetch them first
-      const { capabilities: updatedCapabilities } = await project.setMetricsState();
-      capabilities = updatedCapabilities;
-    }
+    //if (!capabilities || Object.keys(capabilities).length === 0) {
+    // If projectMetrics is an empty object, fetch them first
+    const { capabilities: updatedCapabilities } = await project.setMetricsState();
+    capabilities = updatedCapabilities;
+    //}
     const projectRunning = (appStatus === 'started');
     res.status(200).send({ ...capabilities, canMetricsBeInjected, projectRunning });
   } catch (err) {


### PR DESCRIPTION
## What type of PR is this ? 

- [ x ] Bug fix
- [ ] Enhancement

## What does this PR do ?
This PR resolves the issues seen with the metrics capabilities panel and incorrectly giving status.  The change does the following
* Only refreshes the panel when load collection completes, not on a project restart
* Changes the metrics/status api to return a live value rather than a cached value
* When cancelling load, we no longer stop and restart the project (This was to stop profiling collection but actually causes more harm than good)

## Which issue(s) does this PR fix ?
#3036



## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
This also pulls in fixes from  master 
https://github.com/eclipse/codewind/pull/3052
https://github.com/eclipse/codewind/pull/3041