### PR TITLE
[0.13.0] Prevent stack overflow on bindEnd call. 

### DIFF
--- a/src/pfe/portal/routes/projects/bind.route.js
+++ b/src/pfe/portal/routes/projects/bind.route.js
@@ -452,7 +452,8 @@ async function bindEnd(req, res) {
     await user.buildAndRunProject(project);
 
     res.status(200).send(project);
-    user.uiSocket.emit('projectBind', { status: 'success', ...project });
+    const projectInfoForUI = project.toJSON()
+    user.uiSocket.emit('projectBind', { status: 'success', ...projectInfoForUI });
     log.info(`Successfully created project - name: ${project.name}, ID: ${project.projectID}`);
 
   } catch (err) {


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?

This PR fixes a stack overflow on bindEnd. (And backports the fix to 0.13.0.)
Because we have added the LoadRunner to each project and that introduces a circular reference we need to call `toJSON()` before emitting the project object at the end of `/api/v1/projects/:id/bind/end`.
We do this elsewhere already for other references we should always have done it here really. We have not hit this issue before as the other fields that introduce circular refs are added later in the project life cycle. The load runner field is added when the project is created.

## Which issue(s) does this PR fix ?
There is not a specific issue however the stack trace was noticed in a comment on an issue about project logs here: https://github.com/eclipse/codewind/issues/3062#issuecomment-635592861

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
This is how we emit project objects via the socket in src/pfe/portal/modules/FileWatcher.js if you want an example of how we handle this elsewhere.