### PR TITLE
Only show disable metrics auth after project has started, don't scan metrics when project is stopped

### DIFF
--- a/src/performance/dashboard/src/components/status/CapabilitiesPanel.jsx
+++ b/src/performance/dashboard/src/components/status/CapabilitiesPanel.jsx
@@ -108,6 +108,12 @@ class CapabilitiesPanel extends React.Component {
 
     getCapabilityLiveMetrics(capabilityData, feature) {
 
+        // When the project is not running we can not determine if it supports live metrics
+        if (this.props.projectInfo.config.appStatus !=='running' && !this.props.projectInfo.config.host) {
+            feature.status = Constants.STATUS_WARNING
+            feature.statusMessage = Constants.MESSAGE_LIVEMETRICS_PROJECT_NOT_RUNNING;
+            return
+        }
 
         // Show the re-enable auth button
         if (capabilityData.microprofilePackageAuthenticationDisabled) {

--- a/src/performance/dashboard/src/components/status/Constants.js
+++ b/src/performance/dashboard/src/components/status/Constants.js
@@ -24,6 +24,7 @@ export const MESSAGE_LOADRUNNER_NOT_AVAILABLE = 'Your project is not running. Lo
 export const MESSAGE_LIVEMETRICS_AVAILABLE = 'Lives monitoring is available for your project';
 export const MESSAGE_LIVEMETRICS_MICROPROFILE = 'Your project has all the prerequisite modules. However this feature it is not currently available because the metrics capability has been secured.';
 export const MESSAGE_LIVEMETRICS_MICROPROFILE_ISDISABLED = 'Metrics endpoint allows anonymous access';
+export const MESSAGE_LIVEMETRICS_PROJECT_NOT_RUNNING = "Unable to detect capability because the project is not running"
 export const MESSAGE_COMPONENT_LIVEMETRICS_MICROPROFILE_DISABLE_AUTH = 'MPDisableAuth';
 export const MESSAGE_COMPONENT_LIVEMETRICS_MICROPROFILE_ENABLE_AUTH = 'MPEnableAuth';
 export const MESSAGE_LIVEMETRICS_INJECT_REQUIRED = 'Action required: Inject AppMetrics into your project using your IDE.';

--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -530,8 +530,8 @@ module.exports = class FileWatcher {
       let updatedProject = await this.user.projectList.updateProject(projectUpdate);
 
       const { appStatus } = updatedProject;
-      // Update the metrics state if its just been added, or is running or stopped
-      if (event === 'newProjectAdded' || (appStatus === 'started' || appStatus === 'stopped')) {
+      // Update the metrics state if its just been added or is running
+      if (event === 'newProjectAdded' || appStatus === 'started') {
         try {
           // If updating the metrics fails, don't stop the status being emitted to the UI
           await updatedProject.setMetricsState();


### PR DESCRIPTION
## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
### Summary
1. Makes the `setMetricsState` only run when the project is added to Codewind and when it's state changes to `started` (application is running) because we do not benefit from show the user that `javametrics-dash` is unavailable when their project is not running. This also reduces flicker on the performance dashboard as the state changes less.

2. Changes the performance dashboard to only show the "allow anonymous-access" button when the project has started once i.e. we've actually been able to scan the metrics. This ensure the user that we don't ask them if they want to disable metrics authentication before we check whether they need to. -> Thanks @markcor11 for this enhancement.

Before the first build the project will no longer show:
![image](https://user-images.githubusercontent.com/17385115/83277049-6b5d5a80-a1c9-11ea-8a58-cbb37547db53.png)

and will show:
![image](https://user-images.githubusercontent.com/17385115/83276840-1de0ed80-a1c9-11ea-8ca9-2cb7405a1235.png)

Once the project has started once (has a `project.host` property, if the live monitoring is false it will show the "allow anonymous-access" button as before.

### Testing
Ran unit and API tests.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
