### PR TITLE
Add extra null checking projectLogsListChanged message.

### DIFF
--- a/src/pfe/portal/modules/FileWatcher.js
+++ b/src/pfe/portal/modules/FileWatcher.js
@@ -146,24 +146,19 @@ module.exports = class FileWatcher {
     }
 
     case "projectLogsListChanged" : {
-      let logType;
-      if (fwProject.build) {
-        logType = 'build'
-      } else if (fwProject.app) {
-        logType = 'app'
-      } else {
-        log.error('projectLogsListChanged: Unknown log type.');
-        break;
+      // fwProject is of type ILogFilesResult, use its type field as the logType.
+      let logType = fwProject.type;
+      if (fwProject[logType][0] && fwProject[logType][0].files && fwProject[logType][0].files[0]) {
+        let file = fwProject[logType][0].files[0];
+        let logName = path.basename(file);
+        let logObject = { logName: logName }
+        if (fwProject[logType][0].origin == 'workspace') {
+          logObject.workspaceLogPath = path.dirname(file);
+        }
+        let message = { projectID: fwProject.projectID };
+        message[logType] = [logObject];
+        this.user.uiSocket.emit('projectLogsListChanged', message);
       }
-      let file = fwProject[logType][0].files[0];
-      let logName = path.basename(file);
-      let logObject = { logName: logName }
-      if (fwProject[logType][0].origin == 'workspace') {
-        logObject.workspaceLogPath = path.dirname(file);
-      }
-      let message = { projectID: fwProject.projectID };
-      message[logType] = [logObject];
-      this.user.uiSocket.emit('projectLogsListChanged', message);
       break;
     }
 

--- a/test/src/unit/modules/FileWatcher.test.js
+++ b/test/src/unit/modules/FileWatcher.test.js
@@ -273,6 +273,7 @@ describe('FileWatcher.js', () => {
         it('handles `projectLogsListChanged` event with build, origin', async() => {
             const mockFwProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                type: 'build',
                 build: [
                     {
                         origin: 'workspace',
@@ -302,6 +303,7 @@ describe('FileWatcher.js', () => {
         it('handles `projectLogsListChanged` event with app, no origin', async() => {
             const mockFwProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                type: 'app',
                 app: [
                     {
                         origin: 'application',
@@ -330,6 +332,7 @@ describe('FileWatcher.js', () => {
         it('handles `projectLogsListChanged` event with unknown log type', async() => {
             const mockFwProject = {
                 projectID: 'be4ea4e0-5239-11ea-abf6-f10edc5370f9',
+                type: 'container',
                 container: [
                     {
                         origin: 'docker',


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Ensures we check the object we receive on a `projectLogsListChanged` has all the fields we attempt to access. 
It also simplifies the logic slightly by using it's own type field to decide which type of logs changed.

## Which issue(s) does this PR fix ?
This may stop the 500 error seen in https://github.com/eclipse/codewind/issues/3062 (although I haven't been able to reproduce) however there may not be any logs available after doing this as that may have been the cause of the original error and why the field we read was null.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3062

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
No