### PR TITLE
0.13.0: Pass in port when re-exposing over ingress

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/ShellExtensionProject.ts
@@ -204,8 +204,20 @@ export class ShellExtensionProject implements IExtensionProject {
      * @param projectInfo <Required | ProjectInfo> - The metadata information for the project.
      */
     start = async (projectInfo: ProjectInfo): Promise<void> => {
+
         await projectUtil.runScript(projectInfo, path.join(this.fullPath, "entrypoint.sh"), "start");
-        await projectUtil.exposeOverIngress(projectInfo);
+
+        if (process.env.IN_K8) {
+            let port = undefined;
+            const ports = this.getDefaultAppPort();
+            if (Array.isArray(ports)) {
+                port = parseInt(ports[0]);
+            }
+            else if (ports) {
+                port = parseInt(ports);
+            }
+            await projectUtil.exposeOverIngress(projectInfo, port);
+        }
     }
 
     /**


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?

Pass in port when re-exposing an appsody app over ingress

Port of #3078 to 0.13.0

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

#3077

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
