### PR TITLE
[0.13.0] Fix:  Unable to delete load test

### DIFF
--- a/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
+++ b/src/performance/dashboard/src/components/runTestHistory/RunTestHistory.jsx
@@ -83,7 +83,7 @@ class RunTestHistory extends Component {
      */
     async handleDeleteRow(rowID) {
         this.setState({ deleteInProgress: true });
-        const result = await postDeleteTests(this.props.projectID, rowID);
+        const result = await postDeleteTests(localStorage.getItem('cw-access-token'),this.props.projectID, rowID);
         if (result.status && result.status === 200) {
             await this.props.dispatch(reloadMetricsData(localStorage.getItem('cw-access-token'), this.props.projectID, this.props.projectMetricTypes.types));
         } else {


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

cherry-pick of PR 3089 required for 0.13.0

Allows results from a previous load-test to be deleted through the performance dashboard

## Which issue(s) does this PR fix ?

https://github.com/eclipse/codewind/issues/3088

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?
NO
