### PR TITLE
fix: remove projectID check from connect_timeout

### DIFF
--- a/src/pfe/portal/modules/LoadRunner.js
+++ b/src/pfe/portal/modules/LoadRunner.js
@@ -539,15 +539,13 @@ module.exports = class LoadRunner {
     * Socket event for connection timeout
     * Logs the error and starts reconnect procedure
     */
-    this.socket.on('connect_timeout', data => {
-      if (data.projectID === this.project.projectID) {
-        log.info('Loadrunner has timed out')
-        // If this.up is false we're already trying to reconnect
-        if (this.up) {
-          // socket.io-client will automatically reconnect and trigger the connect event.
-          this.up = false;
-        }
-      }  
+    this.socket.on('connect_timeout', () => {
+      log.info('Loadrunner has timed out')
+      // If this.up is false we're already trying to reconnect
+      if (this.up) {
+        // socket.io-client will automatically reconnect and trigger the connect event.
+        this.up = false;
+      }
     });
 
     /**


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Removes the projectID from the `connect_timeout` socket event in Loadrunner.js.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: #3097 

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
