### PR TITLE
Add username field to secure repos

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2193,6 +2193,14 @@ components:
           type: boolean
         protected:
           type: boolean
+        authentication:
+          type: object
+          properties:
+            username:
+              description: user's github username
+              type: string
+              example: 'user'
+
     TemplateRepoSetting:
       type: object
       required:

--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -324,6 +324,9 @@ async function constructRepositoryObject(url, description, name, isRepoProtected
   if (isRepoProtected !== undefined) {
     repository.protected = isRepoProtected;
   }
+  if (gitCredentials && gitCredentials.username) {
+    repository.authentication = { username: gitCredentials.username };
+  }
   return repository;
 }
 


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
For secure template repos, the template object will now contain a field for the user's github username, if available. If not available, the authorization object will be empty:
<img width="694" alt="Screen Shot 2020-06-10 at 14 52 48" src="https://user-images.githubusercontent.com/33088613/84276327-22db6080-ab2a-11ea-8e09-fcffe8a98677.png">
<img width="207" alt="Screen Shot 2020-06-10 at 14 53 57" src="https://user-images.githubusercontent.com/33088613/84276428-3dadd500-ab2a-11ea-8442-817d4bba2230.png">


## Which issue(s) does this PR fix ?
#3101 
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
Yes.

## Any special notes for your reviewer ?
None.