### PR TITLE
PFE changes to support odo-devfile extension

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,6 +274,7 @@ pipeline {
                         mkdir -p ${SRC_DIR}/pfe/extensions
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-*.zip
                         rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
+                        rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-devfile-extension-*.zip
 
                         curl -Lfo ${SRC_DIR}/pfe/extensions/codewind-appsody-extension-$VERSION.zip http://archive.eclipse.org/codewind/codewind-appsody-extension/$BRANCH/latest/codewind-appsody-extension-$VERSION.zip
                         if [ $? -ne 0 ]; then
@@ -284,6 +285,13 @@ pipeline {
                         curl -Lfo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-$VERSION.zip http://archive.eclipse.org/codewind/codewind-odo-extension/$BRANCH/latest/codewind-odo-extension-$VERSION.zip
                         if [ $? -ne 0 ]; then
                             echo "Error downloading odo extension"
+                            exit 1
+                        fi
+
+                        ODO_DEVFILE_BRANCH="master-devfile"
+                        curl -Lfo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-devfile-$VERSION.zip http://archive.eclipse.org/codewind/codewind-odo-extension/$ODO_DEVFILE_BRANCH/latest/codewind-odo-extension-devfile-$VERSION.zip
+                        if [ $? -ne 0 ]; then
+                            echo "Error downloading odo-devfile extension"
                             exit 1
                         fi
 

--- a/script/build.sh
+++ b/script/build.sh
@@ -71,6 +71,9 @@ fi
 rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-*.zip
 curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-9.9.9999.zip http://archive.eclipse.org/codewind/codewind-odo-extension/master/latest/codewind-odo-extension-9.9.9999.zip
 
+rm -f ${SRC_DIR}/pfe/extensions/codewind-odo-extension-devfile-*.zip
+curl -Lo ${SRC_DIR}/pfe/extensions/codewind-odo-extension-devfile-9.9.9999.zip http://archive.eclipse.org/codewind/codewind-odo-extension/master-devfile/latest/codewind-odo-extension-devfile-9.9.9999.zip
+
 # BUILD IMAGES
 # Uses a build file in each of the directories that we want to use
 echo -e "\n+++   BUILDING DOCKER IMAGES   +++\n";

--- a/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/OdoExtensionProject.ts
@@ -285,12 +285,13 @@ export class OdoExtensionProject implements IExtensionProject {
         const projectInfo: ProjectInfo = await projectUtil.getProjectInfo(projectID);
         const projectLocation = projectInfo.location;
         const projectName = path.basename(projectLocation);
+        const componentName: string = await projectUtil.getComponentName(projectName);
         const args: string[] = [
             projectLocation,
             "",
             "getPort",
             "",
-            "",
+            componentName,
             "",
             ""
         ];
@@ -323,12 +324,13 @@ export class OdoExtensionProject implements IExtensionProject {
         const projectInfo: ProjectInfo = await projectUtil.getProjectInfo(projectID);
         const projectLocation = projectInfo.location;
         const projectName = path.basename(projectLocation);
+        const componentName: string = await projectUtil.getComponentName(projectName);
         const args: string[] = [
             projectLocation,
             "",
             "getURL",
             "",
-            "",
+            componentName,
             "",
             ""
         ];

--- a/src/pfe/file-watcher/server/src/projects/projectUtil.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectUtil.ts
@@ -171,7 +171,7 @@ export async function containerCreate(operation: Operation, script: string, comm
             args = [projectLocation, LOCAL_WORKSPACE, operation.projectInfo.projectID, command, operation.containerName,
                 String(operation.projectInfo.autoBuildEnabled), logName, operation.projectInfo.startMode, operation.projectInfo.debugPort,
                 (operation.projectInfo.forceAction) ? String(operation.projectInfo.forceAction) : "NONE", logDir, imagePushRegistry, userMavenSettings];
-        } else if (projectType == "odo") {
+        } else if (["odo", "odo-devfile"].includes(projectType)) {
             const componentName: string = await getComponentName(projectName);
 
             args = [
@@ -278,7 +278,7 @@ export async function containerUpdate(operation: Operation, script: string, comm
         args = [projectLocation, LOCAL_WORKSPACE, operation.projectInfo.projectID, command, operation.containerName,
             String(operation.projectInfo.autoBuildEnabled), logName, operation.projectInfo.startMode, operation.projectInfo.debugPort,
             (operation.projectInfo.forceAction) ? String(operation.projectInfo.forceAction) : "NONE", logDir, imagePushRegistry, userMavenSettings];
-    } else if (projectType == "odo") {
+    } else if (["odo", "odo-devfile"].includes(projectType)) {
         const componentName: string = await getComponentName(projectName);
 
         args = [
@@ -416,7 +416,7 @@ async function executeBuildScript(operation: Operation, script: string, args: Ar
                         projectInfo.ports.internalDebugPort = operation.projectInfo.debugPort;
                     }
 
-                    if (operation.projectInfo.projectType == "odo") {
+                    if (["odo", "odo-devfile"].includes(operation.projectInfo.projectType)) {
                         const projectHandler = await projectExtensions.getProjectHandler(operation.projectInfo);
                         const odoProjectInfo: ProjectInfo = operation.projectInfo;
                         const appBaseURL: string = (await projectHandler.getAppBaseURL(projectID)).trim();
@@ -670,7 +670,7 @@ export async function containerDelete(projectInfo: ProjectInfo, script: string):
     try {
         let args: any[] = [projectInfo.location, LOCAL_WORKSPACE, projectID, "remove", containerName, undefined, undefined, undefined, undefined, undefined, undefined, imagePushRegistry];
 
-        if (projectInfo.projectType == "odo") {
+        if (["odo", "odo-devfile"].includes(projectInfo.projectType)) {
             const logDir: string = await logHelper.getLogDir(projectID, projectName);
             const componentName: string = await getComponentName(projectName);
 
@@ -1253,7 +1253,7 @@ export async function runScript(projectInfo: ProjectInfo, script: string, comman
     let args = [projectInfo.location, LOCAL_WORKSPACE, projectID, command, containerName, String(projectInfo.autoBuildEnabled), logName, projectInfo.startMode,
         projectInfo.debugPort, "NONE", logDir];
 
-    if (projectInfo.projectType == "odo") {
+    if (["odo", "odo-devfile"].includes(projectInfo.projectType)) {
         const componentName: string = await getComponentName(projectName);
 
         args = [

--- a/src/pfe/file-watcher/server/src/utils/kubeutil.ts
+++ b/src/pfe/file-watcher/server/src/utils/kubeutil.ts
@@ -90,9 +90,11 @@ export async function getApplicationContainerInfo(projectInfo: ProjectInfo, oper
         if (!projectInfo.compositeAppName) {
             return undefined;
         }
-
         const componentName = path.basename(projectInfo.location);
         releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.compositeAppName;
+    } else if (projectInfo.projectType == "odo-devfile") {
+        const componentName = path.basename(projectInfo.location);
+        releaseLabel = "component=" + "cw-" + componentName;
     }
     const projectName = path.basename(projectLocation);
 
@@ -289,9 +291,11 @@ export async function getFilesOrFoldersInContainerWithTimestamp(projectID: strin
 export async function isContainerActive(containerName: string, projectInfo?: ProjectInfo): Promise<any> {
     try {
         let releaseLabel = "release=" + containerName;
-        if (projectInfo && projectInfo.projectType == "odo") {
+        if (projectInfo && ["odo", "odo-devfile"].includes(projectInfo.projectType)) {
             const componentName = path.basename(projectInfo.location);
-            releaseLabel = "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.compositeAppName;
+            releaseLabel = projectInfo.projectType === "odo"
+                ? "deploymentconfig=" + "cw-" + componentName + "-" + projectInfo.compositeAppName
+                : "component=" + "cw-" + componentName;
         }
         let containerState = {state: ContainerStates.containerNotFound};
         // We are getting the list of pods by the release label

--- a/src/pfe/portal/modules/utils/installExtensions.js
+++ b/src/pfe/portal/modules/utils/installExtensions.js
@@ -23,6 +23,7 @@ const extensionsPattern = /^(\S+)-(\d+\.\d+\.\d+|latest)\.zip$/; // e.g. extensi
 const versionPattern = /^\d+[.]\d+[.]\d+$/; // e.g. 0.0.1
 const SUFFIX_OLD = '__old';
 const odoExtensionName = "codewind-odo-extension";
+const odoDevfileExtensionName = "codewind-odo-extension-devfile";
 
 /**
  * Install (unzip) built-in extensions that are stored in /extensions to the
@@ -56,8 +57,9 @@ async function installBuiltInExtension(file, targetDir, extensionsDir) {
   if (file.isFile() && (match = extensionsPattern.exec(file.name))) {
     const name = match[1];
     const version = match[2];
+    log.trace(`extensionPattern - name: ${name}, version ${version}`);
 
-    if ((name == odoExtensionName) && (process.env.ON_OPENSHIFT != 'true')) {
+    if (([odoExtensionName, odoDevfileExtensionName].includes(name)) && (process.env.ON_OPENSHIFT != 'true')) {
       return;
     }
 

--- a/src/pfe/portal/modules/utils/installExtensions.js
+++ b/src/pfe/portal/modules/utils/installExtensions.js
@@ -69,7 +69,7 @@ async function installBuiltInExtension(file, targetDir, extensionsDir) {
 
     try {
       if (await prepForUnzip(target, version)) {
-        const unzipCmd = `unzip ${source} -d ${targetDir}`;
+        const unzipCmd = `unzip -o ${source} -d ${targetDir}`;
         log.trace(`unzip command ${unzipCmd}`);
         await exec(unzipCmd);
 

--- a/src/pfe/pushRemote.sh
+++ b/src/pfe/pushRemote.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# To be run from the codewind/src/pfe directory
+
+# Get the PFE pod in the current namespace
+if [ -z "$1" ]; then
+  echo "Please pass in the PFE Pod name as the parameter"
+  exit 1
+fi
+
+PFE=$1
+
+# PORTAL
+
+# Refresh the docs directory
+rm -r ./portal/docs
+cp -r ../../docs ./portal
+
+kubectl cp ./portal/config $PFE:/portal
+kubectl cp ./portal/docs $PFE:/portal
+kubectl cp ./portal/middleware $PFE:/portal
+kubectl cp ./portal/modules $PFE:/portal
+kubectl cp ./portal/routes $PFE:/portal
+kubectl cp ./portal/server.js $PFE:/portal
+
+# FILE-WATCHER
+
+kubectl cp ./file-watcher/scripts $PFE:/file-watcher

--- a/test/src/unit/modules/utils/installExtensions.test.js
+++ b/test/src/unit/modules/utils/installExtensions.test.js
@@ -147,6 +147,14 @@ describe('installBuiltInExtensions.js', () => {
             await installBuiltInExtension(file, targetDir, extensionDir).should.eventually.be.fulfilled;
             assertExtensionIsNotInstalled(targetDir);
         });
+        it('Function returns as the odo-devfile file is given and process.env.ON_OPENSHIFT is not set to true', async() => {
+            const filePath = path.join(extensionDir, 'codewind-odo-extension-devfile-9.9.9.zip');
+            await fs.ensureFile(filePath);
+            const file = await fs.stat(filePath);
+            file.name = 'codewind-odo-extension-devfile-9.9.9.zip';
+            await installBuiltInExtension(file, targetDir, extensionDir).should.eventually.be.fulfilled;
+            assertExtensionIsNotInstalled(targetDir);
+        });
         describe('Valid extension', () => {
             const fileName = 'valid-extension';
             const zipFileName = 'valid-extension-1.0.0.zip';


### PR DESCRIPTION
Co-authored-by: Richard Waller <richard.lh.waller@gmail.com>
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
### Summary
Made changes to build scripts and file-watcher to support the `odo-devfile` extension.
  * `codewind-odo-extension` will work as normal.
  * `codewind-odo-extension-devfile` will be pulled down in `build.sh` and the `Jenkinsfile` to add it to the PFE images.
* Added a `-o` to the extension `unzip` command to stop it freezing sometimes during development.
* Also added `pushRemote.sh` which we can use to easily push changes to Kubernetes to speed up development time. Usage: `./pushRemote.sh pfe-pod-name`.

### Testing
* Manually tested that the `codewind-odo-extension` works alongside the new `codewind-odo-extension-devfile`.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
