### PR TITLE
test fix: standardise to UTC timezone

### DIFF
--- a/test/scripts/mocha.sh
+++ b/test/scripts/mocha.sh
@@ -10,7 +10,7 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
-# $1 is the path given to npm test. This will run all tests from this directory recursively. 
+# $1 is the path given to npm test. This will run all tests from this directory recursively.
 # This is being passed in from test.sh via the package.json (e.g. npm run test /release)
 # If not set it defaults to all tests in 'src'
 
@@ -29,7 +29,7 @@ if [ $? != 0 ]; then
     exit 1;
 fi
 
-$NYC_CMD node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
+TZ=UTC $NYC_CMD node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
 rc=$?
 end=$(date +%F_%T)
 echo "\nTests finished at ${end}"

--- a/test/scripts/mocha.sh
+++ b/test/scripts/mocha.sh
@@ -29,7 +29,7 @@ if [ $? != 0 ]; then
     exit 1;
 fi
 
-TZ=UTC $NYC_CMD node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
+$NYC_CMD node_modules/.bin/mocha ${@:-src} --recursive --reporter mocha-multi-reporters --reporter-options configFile=scripts/config.json --exit
 rc=$?
 end=$(date +%F_%T)
 echo "\nTests finished at ${end}"

--- a/test/src/API/projects/metrics.test.js
+++ b/test/src/API/projects/metrics.test.js
@@ -11,7 +11,6 @@
 const chai = require('chai');
 const path = require('path');
 const fs = require('fs-extra');
-const dateFormat = require('dateformat');
 const chaiResValidator = require('chai-openapi-response-validator');
 
 const containerService = require('../../../modules/container.service');
@@ -91,9 +90,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
             const metricsResultsGroupedByType = await getProjectMetricsData(projectID);
             originalLoadTest.metricsResultsGroupedByType = metricsResultsGroupedByType;
 
-            //metrics time is in unix format, but dirnames are yyyymmddHHMMss
-            const unixTimeOfFirstTestRun = metricsResultsGroupedByType[0].metrics[0].time;
-            const timeOfFirstTestRun = dateFormat(unixTimeOfFirstTestRun, 'yyyymmddHHMMss'); 
+            const timeOfFirstTestRun = metricsResultsGroupedByType[0].metrics[0].container;
             originalLoadTest.testRunTime = timeOfFirstTestRun;
         });
 
@@ -190,7 +187,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
             const metricsFromTestRun = [];
             for (const metricsResults of metricsResultsGroupedByType) {
                 for (const result of metricsResults.metrics) {
-                    if (dateFormat(result.time, 'yyyymmddHHMMss') === testRunTime) {
+                    if (result.container === testRunTime) {
                         metricsFromTestRun.push(result);
                     }
                 }
@@ -214,9 +211,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
             const metricsResultsGroupedByType = await getProjectMetricsData(projectID);
             originalLoadTest.metricsResultsGroupedByType = metricsResultsGroupedByType;
 
-            //metrics time is in unix format, but dirnames are yyyymmddHHMMss
-            const unixTimeOfFirstTestRun = metricsResultsGroupedByType[0].metrics[0].time;
-            const timeOfFirstTestRun = dateFormat(unixTimeOfFirstTestRun, 'yyyymmddHHMMss'); 
+            const timeOfFirstTestRun = metricsResultsGroupedByType[0].metrics[0].container;
             originalLoadTest.testRunTime = timeOfFirstTestRun;
         });
 
@@ -269,7 +264,7 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                     const listOfMetricsResults = metricsResults.metrics;
                     for (const indexOfResult in listOfMetricsResults) {
                         const result = listOfMetricsResults[indexOfResult];
-                        if (dateFormat(result.time, 'yyyymmddHHMMss') === testRunTime) {
+                        if (result.container === testRunTime) {
                             listOfMetricsResults.splice(indexOfResult, 1);
                         }
                     }
@@ -324,12 +319,9 @@ describe('Project Metrics tests (/projects/{id}/metrics)', function() {
                 res.body.length.should.equal(metricsDirs.length);
 
                 res.body.forEach((metric, i) => {
-                    // metrics time is in unix format, but dirnames are yyyymmddHHMMss
-                    const testRunTimestamp = dateFormat(metric.time, 'yyyymmddHHMMss');
-                    
-                    // Timestamped data should have a corresponding directory
-                    metricsDirs.should.include(testRunTimestamp); 
-                    
+                    const testRunTimestamp = metric.container;
+                    metricsDirs.should.include(testRunTimestamp);
+
                     const pathToMetricsJson = path.join(localLoadTestPath, testRunTimestamp, 'metrics.json');
                     const metricsJson = fs.readJSONSync(pathToMetricsJson);
                     const expectedMetricData = {


### PR DESCRIPTION
## What type of PR is this ? 

- [x] Test

## What does this PR do ?
_fixes https://github.com/eclipse/codewind/issues/3126 by using the name of the metrics dir in PFE directly, rather than inferring the dirname by converting unix time to `yyyymmddHHMMss` format, which leaves the tests vulnerable to timezone issues such as the one in #3126

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
