### PR TITLE
fix: Handle when a template.json file does not exist versus is invalid json

### DIFF
--- a/src/pfe/portal/modules/utils/errors/TemplateError.js
+++ b/src/pfe/portal/modules/utils/errors/TemplateError.js
@@ -42,6 +42,9 @@ function constructMessage(code, identifier, message) {
   case 'URL_DOES_NOT_POINT_TO_INDEX_JSON':
     output = `URL '${identifier}' does not point to a JSON file of the correct form`;
     break;
+  case 'REPO_FILE_DOES_NOT_EXIST':
+    output = `repo file '${identifier}' does not exist`;
+    break;
   case 'REPO_FILE_DOES_NOT_POINT_TO_INDEX_JSON':
     output = `repo file '${identifier}' does not point to a JSON file of the correct form`;
     break;

--- a/test/src/unit/template.test.js
+++ b/test/src/unit/template.test.js
@@ -1345,8 +1345,20 @@ describe('Templates.js', function() {
                 return func().should.be.rejectedWith(`URL 'https://www.google.com/' does not point to a JSON file of the correct form`);
             });
             it('should be rejected as filepath does not exist', function() {
-                const func = () => getTemplateSummaries('file://something.json');
-                return func().should.be.rejectedWith(`repo file 'file://something.json/' does not point to a JSON file of the correct form`);
+                const func = () => getTemplateSummaries('file:///something.json/');
+                return func().should.be.rejectedWith(`repo file 'file:///something.json/' does not exist`);
+            });
+            it('should be rejected as filepath is not valid json', function() {
+                // setup
+                const testFile = path.join(__dirname, 'doesURLPointToIndexJSON.json');
+
+                // test
+                fs.writeFileSync(testFile, 'string');
+                const func = () => getTemplateSummaries(`file://${testFile}`);
+                func().should.eventually.be.rejectedWith(`repo file 'file://${testFile}' does not point to a JSON file of the correct form`);
+
+                // teardown
+                fs.removeSync(testFile);
             });
         });
         describe('filterTemplatesByStyle(templates, projectStyle)', function() {


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Refactors the error handling when a `template.json` file does not exist versus cannot be read.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: #3133 

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
