### PR TITLE
Stop emitting our own 'error' event via socket.io to avoid clash with socket.io's own 'error' event.

### DIFF
--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -216,7 +216,7 @@ class ActionRunLoad extends React.Component {
         const { loadRunStatus, inlineTextLabel, timeRemaining } = this.state;
 
         let loadRunCompleted = loadRunStatus.status === 'completed';
-        const options = ['preparing', 'connecting', 'starting', 'started', 'running',  'collecting', 'completed', 'requesting', 'requested', 'cancelling', 'cancelled']
+        const options = ['preparing', 'connecting', 'starting', 'started', 'running',  'collecting', 'completed', 'requesting', 'requested', 'cancelling', 'cancelled', 'failed']
         const showBusy = options.includes(loadRunStatus.status)
 
         let inlineTextLabelFormatted = (timeRemaining !== 0) ? `${inlineTextLabel}${timeRemaining}` : `${inlineTextLabel}`

--- a/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
+++ b/src/performance/dashboard/src/components/actions/ActionRunLoad.jsx
@@ -102,6 +102,14 @@ class ActionRunLoad extends React.Component {
                         }, 2000);
                         break;
                     }
+                    case 'failed': {
+                        this.setState({ timeRemaining:0, showModalRunTest: false, loadRunStatus: data, inlineTextLabel: 'Failed...' });
+                        setTimeout(() => {
+                            this.setState({ loadRunStatus: { status: 'idle' } })
+                            this.props.dispatch(addNotification({kind: KIND_ERROR, title:'Load run failed', subtitle:'An unexpected error occurred' }));
+                        }, 2000);
+                        break;
+                    }
                     default: {
                         if (queryString.parse(location.search).debugsocket) {
                             console.log("Ignoring UISocket RX: ",data);

--- a/src/performance/server.js
+++ b/src/performance/server.js
@@ -124,14 +124,14 @@ function runLoad(options) {
             io.emit('cancelled', {projectID: options.projectID});
         } else if (code != 0) { // error
             log.error(`error ${errOutput}`);
-            io.emit('error', {error: errOutput, projectID: options.projectID});
+            io.emit('loadrunError', {output: output, error: errOutput, projectID: options.projectID});
         } else { // success
             log.info(`completed - loadrun summary : ${output}`);
             io.emit('completed', {output: output, projectID: options.projectID});
         }
     }).on('error', (err) => {
         loadProcess[options.projectID] = null;
-        io.emit('error', {error: errOutput, projectID: options.projectID});
+        io.emit('loadrunError', {output: output, error: errOutput, projectID: options.projectID});
         log.error(err);
     });
     log.debug(`loadProcess = ${inspect(loadProcess[options.projectID])}`);


### PR DESCRIPTION
## What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?

- Rename 'error' to `loadrunError` to avoid a clash between our event and a reserved `error` event in socket.io. https://socket.io/docs/emit-cheatsheet/
- Handle both `error` and `loadrunError` in PFE.
Handle `loadrunError` in the UI.
The 'error' event is a socket error and won't relate to specific project so it is not handled by the UI.

## Which issue(s) does this PR fix ?
We were emitting an `error` event when a load run failed. This clashed with the `error` event that socket.io will emit when an internal error occurs. Our version of the event also specified different parameters and the listening code assumed there would be a projectID sent in the `data` object for the error. This would not be true if an error occurred in socket.io itself and it emitted it's own `error` event.

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/3095

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
