### PR TITLE
Empty Auth with personal access token

### DIFF
--- a/src/pfe/portal/modules/Templates.js
+++ b/src/pfe/portal/modules/Templates.js
@@ -324,8 +324,12 @@ async function constructRepositoryObject(url, description, name, isRepoProtected
   if (isRepoProtected !== undefined) {
     repository.protected = isRepoProtected;
   }
-  if (gitCredentials && gitCredentials.username) {
-    repository.authentication = { username: gitCredentials.username };
+  if (gitCredentials) {
+    if (gitCredentials.username) {
+      repository.authentication = { username: gitCredentials.username }; 
+    } else if (gitCredentials.personalAccessToken) {
+      repository.authentication = {};
+    }
   }
   return repository;
 }


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Returns an empty Authentication field when a repo is added with a personal access token. Allowing IDEs to pick up on repos that need them by looking for the empty field.

## Which issue(s) does this PR fix ?
#3101 
#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
None