### PR TITLE
Remove slashes from cw-settings

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/DockerProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/DockerProject.ts
@@ -75,8 +75,8 @@ export class DockerProject implements ProjectExtension {
      * .swp, swx, 4913 files are all temporary files created by vim & vi, need to ignore thoses files
      *
      */
-    defaultIgnoredPath: string[] = ["/.project", "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "/load-test*",
-        "*/.dockerignore", "*/.gitignore", "*/*~", "/.settings"];
+    defaultIgnoredPath: string[] = [".project", "*node_modules*", "*.git/*", "*.DS_Store", "*.swp", "*.swx", "*4913", "load-test*",
+        "*.dockerignore", "*.gitignore", "*~", ".settings"];
 
     /**
      * @function

--- a/src/pfe/file-watcher/server/src/projects/libertyProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/libertyProject.ts
@@ -86,12 +86,12 @@ const logsOrigin: logHelper.ILogTypes = {
  * .swp, swx, 4913 files are all temporary files created by vim & vi, need to ignore thoses files
  *
  */
-export const defaultIgnoredPath: string[] = ["/.project", "/Dockerfile-tools", "/target",
-                                             "/mc-target", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", "/load-test*",
-                                             "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore",
-                                             "*/.gitignore", "*/*~", "/.settings", "/localm2cache.zip", "/libertyrepocache.zip"];
+export const defaultIgnoredPath: string[] = [".project", "Dockerfile-tools", "target",
+                                             "mc-target", "cli-config.yml", "README.md", "Jenkinsfile", ".cfignore", "load-test*",
+                                             "*node_modules*", "*.git/*", "*.DS_Store", "*.swp", "*.swx", "*4913", "*.dockerignore",
+                                             ".gitignore", "*~", ".settings", "localm2cache.zip", "libertyrepocache.zip"];
 if (!process.env.IN_K8) {
-    defaultIgnoredPath.push("/chart");
+    defaultIgnoredPath.push("chart");
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/nodejsProject.ts
@@ -59,12 +59,12 @@ const logsOrigin: logHelper.ILogTypes = {
  * .swp, swx, 4913 files are all temporary files created by vim & vi, need to ignore thoses files
  *
  */
-export const defaultIgnoredPath: string[] = ["/.project", "/run-dev", "/run-debug", "/package-lock.json*", "/nodejs_restclient.log", "/nodejs_dc.log",
-                                             "/manifest.yml", "/idt.js", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", "/load-test*",
-                                             "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore", "*/.gitignore",
-                                             "*/*~", "/.settings"];
+export const defaultIgnoredPath: string[] = [".project", "run-dev", "run-debug", "package-lock.json*", "nodejs_restclient.log", "nodejs_dc.log",
+                                             "manifest.yml", "idt.js", "cli-config.yml", "README.md", "Jenkinsfile", ".cfignore", "load-test*",
+                                             "*node_modules*", "*.git/*", "*.DS_Store", "*.swp", "*.swx", "*4913", "*.dockerignore", "*.gitignore",
+                                             "*~", ".settings"];
 if (!process.env.IN_K8) {
-    defaultIgnoredPath.push("/chart");
+    defaultIgnoredPath.push("chart");
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/springProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/springProject.ts
@@ -67,12 +67,12 @@ const logsOrigin: logHelper.ILogTypes = {
  * .swp, swx, 4913 files are all temporary files created by vim & vi, need to ignore thoses files
  *
  */
-export const defaultIgnoredPath: string[] = ["/.project", "/target", "/Dockerfile-tools",
-                                             "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.m2", "/load-test*",
-                                             "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx",
-                                             "*/4913", "*/.dockerignore", "*/.gitignore", "*/*~", "/.settings", "/localm2cache.zip"];
+export const defaultIgnoredPath: string[] = [".project", "target", "Dockerfile-tools",
+                                             "cli-config.yml", "README.md", "Jenkinsfile", ".m2", "load-test*",
+                                             "*node_modules*", "*.git/*", "*.DS_Store", "*.swp", "*.swx",
+                                             "*4913", "*.dockerignore", "*.gitignore", "*~", ".settings", "localm2cache.zip"];
 if (!process.env.IN_K8) {
-    defaultIgnoredPath.push("/chart");
+    defaultIgnoredPath.push("chart");
 }
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/swiftProject.ts
+++ b/src/pfe/file-watcher/server/src/projects/swiftProject.ts
@@ -57,13 +57,13 @@ const logsOrigin: logHelper.ILogTypes = {
  * only want to watch ["/Sources", "/Tests", "/Package.swift", "/Dockerfile", "/Dockerfile-tools", "/.cw-settings"], and "/chart" if on cloud
  * .swp, swx, 4913 files are all temporary files created by vim & vi, need to ignore thoses files
  */
-export const defaultIgnoredPath: string[] = ["/.project", "/LICENSE", "/Package.resolved", "README.rtf", "/debian", "/manifest.yml", "/load-test*",
-                                             "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.bluemix", "/iterative-dev.sh", "/terraform",
-                                            ".swift-version", "/.build-ubuntu", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json",
-                                            "*/node_modules*", "*/.git/*", "*/.DS_Store", "*/*.swp", "*/*.swx", "*/4913", "*/.dockerignore",
-                                            "*/.gitignore", "*/*~", "/.settings"];
+export const defaultIgnoredPath: string[] = [".project", "LICENSE", "Package.resolved", "README.rtf", "debian", "manifest.yml", "load-test*",
+                                             "cli-config.yml", "README.md", "Jenkinsfile", ".bluemix", "iterative-dev.sh", "terraform",
+                                            ".swift-version", ".build-ubuntu", ".cfignore", ".swiftservergenerator-project", ".yo-rc.json",
+                                            "*node_modules*", "*.git/*", "*.DS_Store", "*.swp", "*.swx", "*4913", "*.dockerignore",
+                                            "*.gitignore", "*~", ".settings"];
 if (!process.env.IN_K8) {
-    defaultIgnoredPath.push("/chart");
+    defaultIgnoredPath.push("chart");
 }
 
 

--- a/src/pfe/portal/modules/utils/ignoredPaths.js
+++ b/src/pfe/portal/modules/utils/ignoredPaths.js
@@ -8,24 +8,24 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
-const defaultIgnoredPaths = ["*/.idea/*", "*.iml", "/.project", "/load-test*", "*/*.swp", "*/*.swx", 
-  "*/.gitignore", "*/node_modules*", "*/4913", "*/.git/*", "*/.DS_Store", 
-  "*/.dockerignore", "*/*~", "/.settings", "/.classpath", "/.options", "/.vscode/*"];
+const defaultIgnoredPaths = ["*.idea/*", "*.iml", ".project", "load-test*", "*.swp", "*.swx", 
+  "*.gitignore", "*node_modules*", "*4913", ".git/*", ".DS_Store", 
+  ".dockerignore", "*~", ".settings", ".classpath", ".options", ".vscode/*"];
 
 const dockerIgnoredPaths = [...defaultIgnoredPaths];
 
-const swiftIgnoredPaths = [...defaultIgnoredPaths, "/LICENSE", "/Package.resolved", "README.rtf", "/debian", "/manifest.yml", 
-  "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.bluemix", "/iterative-dev.sh", "/terraform",
-  ".swift-version", "/.build-ubuntu", "/.cfignore", "/.swiftservergenerator-project", "/.yo-rc.json"];
+const swiftIgnoredPaths = [...defaultIgnoredPaths, "LICENSE", "Package.resolved", "README.rtf", "debian", "manifest.yml", 
+  "cli-config.yml", "README.md", "Jenkinsfile", ".bluemix", "iterative-dev.sh", "terraform",
+  ".swift-version", ".build-ubuntu", ".cfignore", ".swiftservergenerator-project", ".yo-rc.json"];
 
-const nodeIgnoredPaths =  [...defaultIgnoredPaths, "/run-dev", "/run-debug", "/package-lock.json*", "/nodejs_restclient.log", "/nodejs_dc.log",
-  "/manifest.yml", "/idt.js", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore"];
+const nodeIgnoredPaths =  [...defaultIgnoredPaths, "run-dev", "run-debug", "package-lock.json*", "nodejs_restclient.log", "nodejs_dc.log",
+  "manifest.yml", "idt.js", "cli-config.yml", "README.md", "Jenkinsfile", ".cfignore"];
 
-const springIgnoredPaths = [...defaultIgnoredPaths, "/target", "/Dockerfile-tools",
-  "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.m2", "/localm2cache.zip"];
+const springIgnoredPaths = [...defaultIgnoredPaths, "target", "Dockerfile-tools",
+  "cli-config.yml", "README.md", "Jenkinsfile", ".m2", "localm2cache.zip"];
 
-const libertyIgnoredPaths = [...defaultIgnoredPaths, "/Dockerfile-tools", "/target",
-  "/mc-target", "/cli-config.yml", "/README.md", "/Jenkinsfile", "/.cfignore", "/localm2cache.zip", "/libertyrepocache.zip"];
+const libertyIgnoredPaths = [...defaultIgnoredPaths, "Dockerfile-tools", "target",
+  "mc-target", "cli-config.yml", "README.md", "Jenkinsfile", ".cfignore", "localm2cache.zip", "libertyrepocache.zip"];
 
 const projectTypeToIgnoredPaths = {
   'swift': swiftIgnoredPaths,


### PR DESCRIPTION
Signed-off-by: Edward Buckle <edward.buckle0@gmail.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Removing the preceding slashes from cw-settings ignored file paths. Files checked in cwctl do not include a preceding slash, so these ignored files are not being picked up during sync.

## Which issue(s) does this PR fix ?
Required for https://github.com/eclipse/codewind-installer/pull/499

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?
Yes. Users no longer need a preceding slash on files added to cw-settings ignore list.

## Any special notes for your reviewer ?
None