### PR TITLE
[0.14] Project Link - specific error for when target project does not exist

### DIFF
--- a/src/pfe/portal/modules/utils/errors/ProjectLinkError.js
+++ b/src/pfe/portal/modules/utils/errors/ProjectLinkError.js
@@ -22,6 +22,7 @@ ProjectLinkError.CODES = {
   NOT_FOUND: 'NOT_FOUND',
   INVALID_PARAMETERS: 'INVALID_PARAMETERS',
   EXISTS: 'EXISTS',
+  TARGET_PROJECT_NOT_FOUND: 'TARGET_PROJECT_NOT_FOUND',
   CONTAINER_NOT_FOUND: 'CONTAINER_NOT_FOUND',
   SERVICE_NOT_FOUND: 'SERVICE_NOT_FOUND',
   CONFIG_MAP_NOT_FOUND: 'CONFIG_MAP_NOT_FOUND',
@@ -45,6 +46,9 @@ function constructMessage(code, identifier, message) {
     break;
   case ProjectLinkError.CODES.EXISTS:
     output = `The envName '${identifier}' already exists as a link`;
+    break;
+  case ProjectLinkError.CODES.TARGET_PROJECT_NOT_FOUND:
+    output = `The target project '${identifier}' cannot be found on the Codewind server`;
     break;
   case ProjectLinkError.CODES.CONTAINER_NOT_FOUND:
     output = `The container for project '${identifier}' cannot be found`;

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -63,7 +63,6 @@ router.post('/api/v1/projects/:id/links', validateReq, checkProjectExists, async
 router.put('/api/v1/projects/:id/links', validateReq, checkProjectExists, async(req, res) => {
   const currentEnvName = req.sanitizeBody('envName');
   const newEnvName = req.sanitizeBody('updatedEnvName');
-
   const { cw_user: user } = req;
   const project = getProjectFromReq(req);
   const { links } = project;

--- a/src/pfe/portal/routes/projects/links.route.js
+++ b/src/pfe/portal/routes/projects/links.route.js
@@ -106,17 +106,18 @@ function handleHttpError(err, res) {
   log.error(err);
   switch(err.code) {
   case ProjectLinkError.CODES.INVALID_PARAMETERS:
-    res.status(400).send(err);
+    res.status(400).send(err.info || err);
     break;
   case ProjectLinkError.CODES.NOT_FOUND:
+  case ProjectLinkError.CODES.TARGET_PROJECT_NOT_FOUND:
   case ProjectLinkError.CODES.CONTAINER_NOT_FOUND:
   case ProjectLinkError.CODES.SERVICE_NOT_FOUND:
   case ProjectLinkError.CODES.CONFIG_MAP_NOT_FOUND:
   case ProjectLinkError.CODES.DEPLOYMENT_NOT_FOUND:
-    res.status(404).send(err);
+    res.status(404).send(err.info || err);
     break;
   case ProjectLinkError.CODES.EXISTS:
-    res.status(409).send(err);
+    res.status(409).send(err.info || err);
     break;
   default:
     res.status(500).send(err);

--- a/src/pfe/portal/services/links.service.js
+++ b/src/pfe/portal/services/links.service.js
@@ -45,7 +45,7 @@ async function handleProjectRestartAndSocketEmit(user, project, link, forceRebui
 function verifyTargetProjectExists(user, projectID) {
   const project = user.projectList.retrieveProject(projectID);
   if (!project) {
-    throw new ProjectLinkError('NOT_FOUND', projectID);
+    throw new ProjectLinkError('TARGET_PROJECT_NOT_FOUND', projectID);
   }
   return project;
 }

--- a/test/src/API/projects/links.test.js
+++ b/test/src/API/projects/links.test.js
@@ -62,7 +62,7 @@ describe('Link tests (/api/v1/project/:id/links)', () => {
             const res = await projectService.addProjectLink(projectID, '00000000-0000-11ea-aaba-d5e958b858e9', 'ENVNAME');
             res.should.have.status(404);
             const { body: { code } } = res;
-            code.should.equal(ProjectLinkError.CODES.NOT_FOUND);
+            code.should.equal(ProjectLinkError.CODES.TARGET_PROJECT_NOT_FOUND);
         });
         it('fails to add a link as the request does not contain the required fields', async function() {
             const res = await projectService.addProjectLink(projectID, targetProjectID, null);

--- a/test/src/unit/routes/projects/links.route.test.js
+++ b/test/src/unit/routes/projects/links.route.test.js
@@ -28,6 +28,7 @@ describe('links.route.js', () => {
             { errCode: ProjectLinkError.CODES.INVALID_PARAMETERS, httpCode: 400 },
             { errCode: ProjectLinkError.CODES.NOT_FOUND, httpCode: 404 },
             { errCode: ProjectLinkError.CODES.EXISTS, httpCode: 409 },
+            { errCode: ProjectLinkError.CODES.TARGET_PROJECT_NOT_FOUND, httpCode: 404 },
             { errCode: ProjectLinkError.CODES.CONFIG_MAP_NOT_FOUND, httpCode: 404 },
             { errCode: ProjectLinkError.CODES.SERVICE_NOT_FOUND, httpCode: 404 },
             { errCode: ProjectLinkError.CODES.DEPLOYMENT_NOT_FOUND, httpCode: 404 },

--- a/test/src/unit/services/links.service.test.js
+++ b/test/src/unit/services/links.service.test.js
@@ -134,7 +134,7 @@ describe('links.service.js', () => {
                 },
             };
             (() => verifyTargetProjectExists(user, 'dummyid')).should.throw(ProjectLinkError)
-                .and.have.property('code', 'NOT_FOUND');
+                .and.have.property('code', 'TARGET_PROJECT_NOT_FOUND');
         });
         it('returns the project as it can be retrieved', () => {
             const user = {


### PR DESCRIPTION
I realise that the original PR missed DCUT due to the failing tests, but the other ‘cwctl’ side of this has been accepted - for that to take effect this needs to be added in. 

Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [x] Enhancement

## What does this PR do ?
Needed for the recent link PR ‘cwctl’ to take effect. 
Adds a new project link error for when the target project does not exist so its more clear when a link does not exist vs the target project does not exist (both previously `NOT_FOUND` errors).
Also sends `err.info` when available or defaults to `err`.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
