### PR TITLE
Guard against internalDebugPort being set as an empty string

### DIFF
--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -19,6 +19,7 @@ import * as projectUtil from "./projectUtil";
 import { Operation } from "./operation";
 import * as io from "../utils/socket";
 import * as constants from "./constants";
+import { debug } from "console";
 const xss = require("xss"); // tslint:disable-line:no-require-imports
 
 export const specificationSettingMap = new Map<string, (args: any, operation: Operation) => any>();
@@ -42,21 +43,32 @@ const changeInternalDebugPort = async function (debugPort: string, operation: Op
 
     debugPort = debugPort.toString();
 
-    if ( !capabilities || ( !capabilities.hasStartMode("debug") && !capabilities.hasStartMode("debugNoInit") )) {
-            const errorMsg = "BAD_REQUEST: The project does not support debug mode.";
-            logger.logProjectError("Changing the debug port failed: " + errorMsg, projectID);
+    if (projectInfo.debugPort === debugPort) {
+        logger.logProjectInfo("The debug port is already set to: " + debugPort, projectID);
+        return;
+    }
 
-            const data: ProjectSettingsEvent = {
-                operationId: operation.operationId,
-                projectID: projectID,
-                ports: {
-                    internalDebugPort: debugPort
-                },
-                status: "failed",
-                error: errorMsg
-            };
-            io.emitOnListener("projectSettingsChanged", data);
+    if ( !capabilities || ( !capabilities.hasStartMode("debug") && !capabilities.hasStartMode("debugNoInit") )) {
+        // If the debugPort is an empty String don't show an error and don't update
+        // Guards against .cw-settings files being initialised with a debugPort when its not supported
+        if (debugPort.trim().length == 0) {
+            logger.logProjectInfo("The project does not support debug mode - but as debugPort was an empty string it has been skipped.", projectID);
             return;
+        }
+        const errorMsg = "BAD_REQUEST: The project does not support debug mode.";
+        logger.logProjectError("Changing the debug port failed: " + errorMsg, projectID);
+
+        const data: ProjectSettingsEvent = {
+            operationId: operation.operationId,
+            projectID: projectID,
+            ports: {
+                internalDebugPort: debugPort
+            },
+            status: "failed",
+            error: errorMsg
+        };
+        io.emitOnListener("projectSettingsChanged", data);
+        return;
     }
 
     if (debugPort.trim().length == 0) {
@@ -69,42 +81,37 @@ const changeInternalDebugPort = async function (debugPort: string, operation: Op
         logger.logProjectInfo("The debug port is empty, setting to the default debug port: " + debugPort, projectID);
     }
 
-    if (projectInfo.debugPort !== debugPort) {
-        const keyValuePair: UpdateProjectInfoPair = {
-                key: "debugPort",
-                value: debugPort,
-                saveIntoJsonFile: true
-        };
-        operation.projectInfo = await projectsController.updateProjectInfo(projectID, keyValuePair);
-        if (projectInfo.startMode === StartModes.debug || projectInfo.startMode === StartModes.debugNoInit) {
-            // call project restart to change the debug port
-            projectUtil.restartProject(operation, projectInfo.startMode, "projectSettingsChanged");
-        } else {
-            // Get the container info with the new ports
-            const containerInfo: any = await projectUtil.getContainerInfo(operation.projectInfo, true);
-            logger.logProjectInfo("changeDebugPort API: The containerInfo: " + JSON.stringify(containerInfo), projectInfo.projectID);
-
-            // return success status since no restart required
-            const data: ProjectSettingsEvent = {
-                operationId: operation.operationId,
-                projectID: projectID,
-                ports: {
-                    internalDebugPort: debugPort
-                },
-                status: "success"
-            };
-
-            if (containerInfo.internalPort && containerInfo.exposedPort) {
-                data.ports.exposedPort = containerInfo.exposedPort;
-                data.ports.internalPort = containerInfo.internalPort;
-            }
-
-            io.emitOnListener("projectSettingsChanged", data);
-        }
+    const keyValuePair: UpdateProjectInfoPair = {
+            key: "debugPort",
+            value: debugPort,
+            saveIntoJsonFile: true
+    };
+    operation.projectInfo = await projectsController.updateProjectInfo(projectID, keyValuePair);
+    if (projectInfo.startMode === StartModes.debug || projectInfo.startMode === StartModes.debugNoInit) {
+        // call project restart to change the debug port
+        projectUtil.restartProject(operation, projectInfo.startMode, "projectSettingsChanged");
     } else {
-        logger.logProjectInfo("The debug port is already set to: " + debugPort, projectID);
-    }
+        // Get the container info with the new ports
+        const containerInfo: any = await projectUtil.getContainerInfo(operation.projectInfo, true);
+        logger.logProjectInfo("changeDebugPort API: The containerInfo: " + JSON.stringify(containerInfo), projectInfo.projectID);
 
+        // return success status since no restart required
+        const data: ProjectSettingsEvent = {
+            operationId: operation.operationId,
+            projectID: projectID,
+            ports: {
+                internalDebugPort: debugPort
+            },
+            status: "success"
+        };
+
+        if (containerInfo.internalPort && containerInfo.exposedPort) {
+            data.ports.exposedPort = containerInfo.exposedPort;
+            data.ports.internalPort = containerInfo.internalPort;
+        }
+
+        io.emitOnListener("projectSettingsChanged", data);
+    }
 };
 
 /**

--- a/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
+++ b/src/pfe/file-watcher/server/src/projects/projectSpecifications.ts
@@ -19,7 +19,6 @@ import * as projectUtil from "./projectUtil";
 import { Operation } from "./operation";
 import * as io from "../utils/socket";
 import * as constants from "./constants";
-import { debug } from "console";
 const xss = require("xss"); // tslint:disable-line:no-require-imports
 
 export const specificationSettingMap = new Map<string, (args: any, operation: Operation) => any>();


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Adds a guard so that project types that do not support an `internalDebugPort` will not error when a default `.cw-settings` is updated as described in #3121. 
* We initialise `.cw-settings` to have an `internalDebugPort` of `""` and when changing an unrelated setting such as `ignoredPaths` in `.cw-settings` Turbine throws an error as we can't update `internalDebugPort` for an unsupported project. - If the user does try to set `internalDebugPort` to something other than a blank string, the usual error will occur.
* Key change is https://github.com/eclipse/codewind/compare/master...james-wallis:3139-ignoredpaths?expand=1#diff-2a30a2a4dccd9b8e1dccf2220b27057fR55

I've tested that I can change `ignoredPaths` in a generic Docker project without having the `internalDebugPort` error.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/3139

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
