### PR TITLE
Update the Dockerfiles used to generate the spring and liberty cache images.

### DIFF
--- a/src/pfe/file-watcher/dockerfiles/liberty/libertyDockerfile
+++ b/src/pfe/file-watcher/dockerfiles/liberty/libertyDockerfile
@@ -1,5 +1,4 @@
-FROM websphere-liberty:19.0.0.3-webProfile7
-# FROM websphere-liberty@sha256:e99527c9275af659208e8ee28c9935f2f6c88cf24cf1819558578d8ddbcad112
+FROM websphere-liberty:19.0.0.9-webProfile7
 LABEL maintainer="IBM Java Engineering at IBM Cloud"
 COPY /target/liberty/wlp/usr/servers/defaultServer /config/
 COPY /target/liberty/wlp/usr/shared/resources /config/resources/
@@ -10,54 +9,16 @@ USER root
 RUN chmod g+w /config/apps
 RUN configure.sh
 USER 1001
-ENV JAVA_VERSION_PREFIX 1.8.0
 ENV HOME /home/default
 
 USER root
 
+COPY --from=ibmjava:8-sdk /opt/ibm/java $HOME/java
+
 RUN set -eux; \
-    ARCH="$(dpkg --print-architecture)"; \
-    case "${ARCH}" in \
-       amd64|x86_64) \
-         YML_FILE='sdk/linux/x86_64/index.yml'; \
-         ;; \
-       i386) \
-         YML_FILE='sdk/linux/i386/index.yml'; \
-         ;; \
-       ppc64el|ppc64le) \
-         YML_FILE='sdk/linux/ppc64le/index.yml'; \
-         ;; \
-       s390) \
-         YML_FILE='sdk/linux/s390/index.yml'; \
-         ;; \
-       s390x) \
-         YML_FILE='sdk/linux/s390x/index.yml'; \
-         ;; \
-       *) \
-         echo "Unsupported arch: ${ARCH}"; \
-         exit 1; \
-         ;; \
-    esac; \
     apt-get update \
     && apt-get install -y --no-install-recommends wget openssl \
     && rm -rf /var/lib/apt/lists/*; \
-    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
-    wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
-    ESUM=$(cat /tmp/index.yml | sed -n '/'${JAVA_VERSION_PREFIX}'/{n;n;p}' | sed -n 's/\s*sha256sum:\s//p' | tr -d '\r' | tail -1); \
-    JAVA_URL=$(cat /tmp/index.yml | sed -n '/'${JAVA_VERSION_PREFIX}'/{n;p}' | sed -n 's/\s*uri:\s//p' | tr -d '\r' | tail -1); \
-    wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
-    echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
-    echo "INSTALLER_UI=silent" > /tmp/response.properties; \
-    echo "USER_INSTALL_DIR=$HOME/java" >> /tmp/response.properties; \
-    echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
-    mkdir -p $HOME/java; \
-    chmod +x /tmp/ibm-java.bin; \
-    /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
-    rm -f /tmp/response.properties; \
-    rm -f /tmp/index.yml; \
-    rm -f /tmp/ibm-java.bin; \
-    cd $HOME/java/jre/lib; \
-    rm -rf icc; \
     mkdir -p $HOME/mvn &&\
     MAVEN_VERSION=$(wget -qO- https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml | sed -n 's/\s*<release>\(.*\)<.*>/\1/p') &&\
     wget -q -U UA_IBM_JAVA_Docker -O $HOME/mvn/apache-maven-${MAVEN_VERSION}-bin.tar.gz https://search.maven.org/remotecontent?filepath=org/apache/maven/apache-maven/${MAVEN_VERSION}/apache-maven-${MAVEN_VERSION}-bin.tar.gz &&\

--- a/src/pfe/file-watcher/dockerfiles/spring/springDockerfile
+++ b/src/pfe/file-watcher/dockerfiles/spring/springDockerfile
@@ -1,51 +1,11 @@
 FROM ibmjava:8-sfj
-LABEL maintainer="IBM Java Engineering at IBM Cloud"
+LABEL maintainer="Eclipse Codewind"
 
 ENV JAVA_OPTS=""
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]
+EXPOSE 8080
 
-ENV JAVA_VERSION_PREFIX 1.8.0
-
-RUN set -eux; \
-    ARCH="$(dpkg --print-architecture)"; \
-    case "${ARCH}" in \
-       amd64|x86_64) \
-         YML_FILE='sdk/linux/x86_64/index.yml'; \
-         ;; \
-       i386) \
-         YML_FILE='sdk/linux/i386/index.yml'; \
-         ;; \
-       ppc64el|ppc64le) \
-         YML_FILE='sdk/linux/ppc64le/index.yml'; \
-         ;; \
-       s390) \
-         YML_FILE='sdk/linux/s390/index.yml'; \
-         ;; \
-       s390x) \
-         YML_FILE='sdk/linux/s390x/index.yml'; \
-         ;; \
-       *) \
-         echo "Unsupported arch: ${ARCH}"; \
-         exit 1; \
-         ;; \
-    esac; \
-    BASE_URL="https://public.dhe.ibm.com/ibmdl/export/pub/systems/cloud/runtimes/java/meta/"; \
-    wget -q -U UA_IBM_JAVA_Docker -O /tmp/index.yml ${BASE_URL}/${YML_FILE}; \
-    ESUM=$(cat /tmp/index.yml | sed -n '/'${JAVA_VERSION_PREFIX}'/{n;n;p}' | sed -n 's/\s*sha256sum:\s//p' | tr -d '\r' | tail -1); \
-    JAVA_URL=$(cat /tmp/index.yml | sed -n '/'${JAVA_VERSION_PREFIX}'/{n;p}' | sed -n 's/\s*uri:\s//p' | tr -d '\r' | tail -1); \
-    wget -q -U UA_IBM_JAVA_Docker -O /tmp/ibm-java.bin ${JAVA_URL}; \
-    echo "${ESUM}  /tmp/ibm-java.bin" | sha256sum -c -; \
-    echo "INSTALLER_UI=silent" > /tmp/response.properties; \
-    echo "USER_INSTALL_DIR=/root/java" >> /tmp/response.properties; \
-    echo "LICENSE_ACCEPTED=TRUE" >> /tmp/response.properties; \
-    mkdir -p /root/java; \
-    chmod +x /tmp/ibm-java.bin; \
-    /tmp/ibm-java.bin -i silent -f /tmp/response.properties; \
-    rm -f /tmp/response.properties; \
-    rm -f /tmp/index.yml; \
-    rm -f /tmp/ibm-java.bin; \
-    cd /root/java/jre/lib; \
-    rm -rf icc;
+COPY --from=ibmjava:8-sdk /opt/ibm/java /root/java
 
 RUN mkdir -p /opt/mvn &&\
     MAVEN_VERSION=$(wget -qO- https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml | sed -n 's/\s*<release>\(.*\)<.*>/\1/p') &&\


### PR DESCRIPTION
##What type of PR is this ? 

- [X] Bug fix
- [ ] Enhancement

## What does this PR do ?
Updates the Dockerfiles for building the spring and liberty caches to match the latest templates for those project
types.
See recent changes:
https://github.com/codewind-resources/springJavaTemplate/pull/4
https://github.com/codewind-resources/javaMicroProfileTemplate/pull/7

## Which issue(s) does this PR fix ?
This is for https://github.com/eclipse/codewind/issues/171
(Although it only resolves the issue until the next time the templates change.)

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references:
https://github.com/eclipse/codewind/issues/171

## Does this PR require a documentation change ?
No

## Any special notes for your reviewer ?
