### PR TITLE
test: fix false positive when time increases by 1s

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
+    "chai-datetime": "^1.7.0",
     "chai-files": "^1.4.0",
     "chai-http": "^4.0.0",
     "chai-openapi-response-validator": "^0.7.2",

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -36,12 +36,16 @@ const should = chai.should();
 
 const pathToLoadRunnerJs = '../../../../src/pfe/portal/modules/LoadRunner';
 
-const reverseDateFormat = (formattedDateString) => {
-    const dateTimeString = formattedDateString.replace(
+const parseFormattedDate = (formattedDate) => {
+    const dateTimeString = formattedDate.replace(
         /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/,
         '$1-$2-$3T$4:$5:$6',
     );
-    return new Date(dateTimeString);
+    const date = new Date(dateTimeString);
+    if (date.toString() === 'Invalid Date') {
+        throw new Error(date);
+    }
+    return date;
 };
 
 describe('LoadRunner.js', () => {
@@ -751,7 +755,7 @@ describe('LoadRunner.js', () => {
 
             // assert
             const createdMetricsDir = path.basename(loadRunner.workingDir);
-            const dateOfCreatedMetricsDir = reverseDateFormat(createdMetricsDir);
+            const dateOfCreatedMetricsDir = parseFormattedDate(createdMetricsDir);
             dateOfCreatedMetricsDir.should.be.afterOrEqualDate(originalDate);
             dateOfCreatedMetricsDir.should.be.closeToTime(originalDate, 1);
 

--- a/test/src/unit/modules/LoadRunner.test.js
+++ b/test/src/unit/modules/LoadRunner.test.js
@@ -726,10 +726,8 @@ describe('LoadRunner.js', () => {
     describe('createResultsDirectory()', () => {
         it('creates the results directory', async() => {
             // arrange
-            const expectedMetricsFolder = dateFormat(new Date(), 'yyyymmddHHMMss');
             const workingDir = path.join('.', 'crd_test');
             await fs.mkdirp(workingDir);
-            const expectedPath = path.join(workingDir, expectedMetricsFolder);
             const LoadRunner = proxyquire(pathToLoadRunnerJs, {});
             const loadRunner = new LoadRunner('mockUser');
             const mockProject = {
@@ -738,13 +736,19 @@ describe('LoadRunner.js', () => {
             loadRunner.project = mockProject;
 
             // act
+            const originalDate = new Date();
             await loadRunner.createResultsDirectory();
-            const lRWorkingDir = loadRunner.workingDir;
-            loadRunner.workingDir = null;
-            await fs.remove(expectedPath);
 
             // assert
-            lRWorkingDir.should.be.equal(expectedPath);
+            const actualMetricsFolder = path.basename(loadRunner.workingDir);
+            const expectedMetricsFolder = dateFormat(originalDate, 'yyyymmddHHMMss');
+            const actualTime = parseInt(actualMetricsFolder, 10);
+            const originalTime = parseInt(expectedMetricsFolder, 10);
+            (actualTime - originalTime).should.be.at.most(1, 'Expected time2 to equal time1, or be at most 1s after time1');
+
+            // cleanup
+            const pathToActualMetricsFolder = path.join(workingDir, actualMetricsFolder);
+            await fs.remove(pathToActualMetricsFolder);
         });
     });
     describe('writeGitHash() ', () => {


### PR DESCRIPTION
Signed-off-by: Richard Waller <Richard.Waller@ibm.com>

## What type of PR is this ? 

- [x] test bug fix
- [ ] Enhancement

## What does this PR do ?
fixes https://github.com/eclipse/codewind/issues/3198 by allowing for cases where the test starts in 1 second and ends in the next second.

## Does this PR require a documentation change ?
no

## Any special notes for your reviewer ?
There may be more instances of this in the rest of the file, but I'm PRing this to see if this test pattern is one we like.