### PR TITLE
Upgrade Python modules from baseOS

### DIFF
--- a/src/pfe/Dockerfile_x86_64
+++ b/src/pfe/Dockerfile_x86_64
@@ -10,6 +10,7 @@
 #*******************************************************************************
 FROM centos:8.1.1911 AS codewind-pfe-base
 RUN yum -y install nodejs \
+    && yum -y update platform-python-pip-9.0.3-16.el8.noarch python3-libs-3.6.8-23.el8.x86_64 python3-dnf-4.2.17-6.el8.noarch python3-libcomps-0.1.11-4.el8.x86_64 python3-pip-wheel-9.0.3-16.el8.noarch \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Signed-off-by: Mark Cornaia <mark.cornaia@uk.ibm.com>

## What type of PR is this ? 

- [x] Bug fix

## What does this PR do ?

Upgrades patch levels of some Python modules that were installed as part of the base OS image. 

Specifically : 

platform-python-pip-9.0.3-16.el8.noarch 
python3-libs-3.6.8-23.el8.x86_64 
python3-dnf-4.2.17-6.el8.noarch 
python3-libcomps-0.1.11-4.el8.x86_64 
python3-pip-wheel-9.0.3-16.el8.noarch 

Whilst PFE does not use Python (and whilst Python itself is not installed),  Appscan has located these dormant bundles so patching them anyway using the current latest available on the Redhat yum repo.

## Does this PR require a documentation change ?
NO

## Any special notes for your reviewer ?

Similar fixes to this have been merged into the Performance container see PR : https://github.com/eclipse/codewind/pull/3195